### PR TITLE
fix(install): DMG detection, i18n locale path, and vm.spawn command resolution

### DIFF
--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -808,7 +808,7 @@ class SwiftAddonStub extends EventEmitter {
 
         // SECURITY: Validate command is the expected Claude binary
         let hostCommand = command;
-        if (command === '/usr/local/bin/claude') {
+        if (command === '/usr/local/bin/claude' || command === 'claude') {
           hostCommand = resolveClaudeBinaryPath();
           trace('Translated command: ' + command + ' -> ' + hostCommand);
         } else {


### PR DESCRIPTION
## Summary

Three fixes discovered during a fresh install on Fedora 43 (Linux 6.18, Intel Ultra 7 155H):

- **DMG file detection broken**: `install.sh` hardcoded the glob pattern `Claude-2-*.dmg` and ignored the `$1` argument entirely. A file named `Claude.dmg` was not found. Now accepts a DMG path as first argument (`./install.sh Claude.dmg`) with fallback to a broader `Claude*.dmg` search.

- **App crash on startup (ENOENT i18n)**: The app expects locale files at `app/resources/i18n/en-US.json` but the DMG extraction places them in `Resources/`. Added a copy step during install to bridge the two locations.

- **vm.spawn() blocks bare `claude` command**: The swift stub security check only accepted `/usr/local/bin/claude` as a valid command, but the app sends bare `claude` for `plugin list --json --available --cowork` operations. Added `claude` to the allowlist so it resolves through `resolveClaudeBinaryPath()`.

- **Symlink renamed to `cowork`** (default) to avoid conflict with the `claude` CLI (Claude Code). Configurable via `SYMLINK_NAME=claude ./install.sh` for users who prefer the old name.

## How it was tested

Full end-to-end install and launch on Fedora 43:
1. `./install.sh Claude.dmg` — all 9 steps pass
2. `cowork` — app starts, login works, features load, VM rootfs downloads successfully
3. Verified `claude plugin list` resolves correctly via stub (`Translated command: claude -> ~/.local/bin/claude`)

## Additional note (TMPDIR)

The VM rootfs download (2.2 GB) may fail with `EDQUOT` (errno 122) on systems where `/tmp` is a small tmpfs. Workaround: `export TMPDIR=/home/$USER/tmp`. This is not part of the PR but could be documented or handled in the launcher script.

## Test plan

- [ ] Run `./install.sh Claude.dmg` on a clean system
- [ ] Run `./install.sh` with no args (should find `Claude*.dmg` automatically)
- [ ] Verify `cowork` launches the app
- [ ] Verify `SYMLINK_NAME=claude ./install.sh` creates a `claude` symlink instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)