### PR TITLE
fix(install): clarify redirect download log and note versioned URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -293,9 +293,9 @@ download_dmg() {
 
     # Try primary URL first
     if curl -fSL --progress-bar -o "$dmg_path" "$DMG_URL_PRIMARY" 2>/dev/null; then
-        log_success "Downloaded from primary CDN"
+        log_success "Downloaded latest release (followed redirect)"
     elif curl -fSL --progress-bar -o "$dmg_path" "$DMG_URL_FALLBACK" 2>/dev/null; then
-        log_success "Downloaded from fallback URL"
+        log_success "Downloaded from fallback CDN"
     else
         log_error "Failed to download Claude DMG"
         log_info ""


### PR DESCRIPTION
## Summary

The primary download URL (`https://claude.ai/api/desktop/darwin/universal/dmg/latest/redirect`) redirects to a versioned, content-addressed DMG (e.g. `downloads.claude.ai/releases/darwin/universal/1.1.3963/Claude-<hash>.dmg`).

`curl -L` already follows the redirect correctly. This PR updates the success log message to say "followed redirect" rather than "primary CDN" so users understand what happened.