### PR TITLE
fix(install): root cause of app.asar not found — stdout corruption

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,7 +354,8 @@ extract_app() {
     local dmg_path="$1"
     local extract_dir="$2"
 
-    log_info "Extracting DMG..."
+    # Log to stderr — stdout is captured by the caller via $()
+    log_info "Extracting DMG..." >&2
     7z x -y -o"$extract_dir" "$dmg_path" >/dev/null 2>&1 || die "Failed to extract DMG"
 
     # Find Claude.app
@@ -364,7 +365,7 @@ extract_app() {
         die "Claude.app not found in DMG"
     fi
 
-    log_success "Extracted Claude.app"
+    log_success "Extracted Claude.app" >&2
     echo "$claude_app"
 }
 


### PR DESCRIPTION
## Summary

**Root cause found**: `extract_app()` returns its result via `echo` (stdout), but `log_info` and `log_success` inside the function also write to stdout. When called via `claude_app=$(extract_app ...)`, ALL stdout is captured:

```
$claude_app = "[INFO] Extracting DMG...\n[OK] Extracted Claude.app\n/tmp/.../Claude.app"
```

Then `$claude_app/Contents/Resources/app.asar` is a garbage path.

**Fix**: redirect log calls inside `extract_app` to stderr (`>&2`) so the captured variable contains only the path.