### PR TITLE
docs(oauth): correct compliance doc inaccuracies and address Feb 2026 policy

### DIFF
--- a/OAUTH-COMPLIANCE.md
+++ b/OAUTH-COMPLIANCE.md
@@ -249,7 +249,7 @@ Even though our stubs don't handle tokens, trace logs could theoretically captur
 |--------|--------|-------------|
 | Store OAuth tokens | **Never** | `addApprovedOauthToken` is a documented no-op |
 | Forward `CLAUDE_CODE_OAUTH_TOKEN` to Claude Code CLI | **Yes — intentional** | Required for CLI auth; token flows from Claude Desktop (Anthropic) → Claude Code CLI (Anthropic) only |
-| Forward any other OAuth/credential env vars to subprocesses | **Never** | `filterEnv` + `BLOCKED_ENV_KEY_PATTERN` blocks all others; SDK bridge uses separate allowlist |
+| Forward additional OAuth/credential env vars from `additionalEnv` / `envVars` to subprocesses (e.g., `ANTHROPIC_AUTH_TOKEN`, bearer tokens, session cookies) | **Never** | `filterEnv` + `BLOCKED_ENV_KEY_PATTERN` drop credential-like keys from extra env; base `process.env` forwarding is constrained to a small allowlist (including `ANTHROPIC_API_KEY` as an intentional exception for API/CLI auth) |
 | Intercept OAuth callbacks | **Never** | `AuthRequest.isAvailable()` returns `false`; no protocol handler registered |
 | Process authentication credentials in this layer | **Never** | All auth handling is in unmodified Anthropic code (renderer + CLI) |
 | Log token values | **Never** | `redactForLogs` strips all credential patterns before any log write |


### PR DESCRIPTION
Three issues fixed:

1. Inaccurate "never forward OAuth tokens" claim: OAUTH-COMPLIANCE.md
   previously stated "Forward OAuth tokens to subprocesses: Never" and
   "No path exists for OAuth tokens to flow from the Electron process to
   Claude Code through our code." Both are false. CLAUDE_CODE_OAUTH_TOKEN
   is explicitly exempted via CREDENTIAL_EXEMPT_KEYS and IS forwarded to
   the Claude Code CLI subprocess — as required for CLI authentication.

2. Summary table updated to accurately reflect that CLAUDE_CODE_OAUTH_TOKEN
   is intentionally passed (Claude Desktop → Claude Code CLI, Anthropic →
   Anthropic), while all other credential-pattern env vars are blocked.

3. New section added addressing Anthropic's February 19, 2026 policy update
   that restricts OAuth token use to Claude Code and Claude.ai. Documents
   why this project's token passthrough (between two unmodified Anthropic
   apps) is distinct from the third-party tool usage the policy targets,
   along with a caveat that this is outside officially supported configs.

https://claude.ai/code/session_01VWG3ejeFhepZMa3bX5dM7L