### PR TITLE
fix: copy resources/ from DMG into linux-app-extracted/ to prevent startup crash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -334,6 +334,22 @@ extract_dmg() {
         cp -r "$unpacked"/* "$target_dir/" 2>/dev/null || true
     fi
 
+    # Copy app resources (i18n, tray icons) that live alongside app.asar in
+    # Contents/Resources/ but are not packed inside it. The app reads these at
+    # runtime via a path relative to the asar (e.g. resources/i18n/en-US.json),
+    # so they must be present inside linux-app-extracted/ before repacking.
+    local resources_dir="$claude_app/Contents/Resources"
+    mkdir -p "$target_dir/resources"
+    for item in "$resources_dir"/*; do
+        local name
+        name=$(basename "$item")
+        # Skip the asar files themselves — only copy static assets
+        case "$name" in
+            app.asar|app.asar.unpacked) continue ;;
+        esac
+        cp -r "$item" "$target_dir/resources/$name" 2>/dev/null || true
+    done
+
     log_success "Extracted app to linux-app-extracted/"
 }
 


### PR DESCRIPTION
## Problem

On Linux with system `electron` (i.e. no AppImage), `claude-desktop` crashes immediately on startup with:

```
Error: ENOENT, resources/i18n/en-US.json not found in .asar-cache/app.asar
```

Claude Desktop reads i18n files (and tray icons) from a path relative to the asar — `resources/i18n/en-US.json`. These assets live **alongside** `app.asar` in `Claude.app/Contents/Resources/`, not inside it. When `test-launch.sh` repacks `linux-app-extracted/` into `.asar-cache/app.asar`, the `resources/` directory was never copied in, so the app crashes before rendering anything.

## Fix

In `extract_dmg()`, after extracting `app.asar`, copy all sibling static assets from `Contents/Resources/` into `linux-app-extracted/resources/`, skipping the asar files themselves.

```bash
local resources_dir="$claude_app/Contents/Resources"
mkdir -p "$target_dir/resources"
for item in "$resources_dir"/*; do
    local name
    name=$(basename "$item")
    case "$name" in
        app.asar|app.asar.unpacked) continue ;;
    esac
    cp -r "$item" "$target_dir/resources/$name" 2>/dev/null || true
done
```

## Test

Fresh install on Fedora 43 (Wayland, system electron v22, Node v22) — `claude-desktop` now launches past the i18n crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)