### PR TITLE
Fix Claude Code Linux IPC interception

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -582,6 +582,51 @@ doctor() {
 
     local ok=0 warn=0 fail=0
 
+    check_launcher_resolution() {
+        local cmd="$1"
+        local expected="$2"
+        local matches=""
+
+        matches=$(which -a "$cmd" 2>/dev/null | awk '!seen[$0]++') || matches=""
+        if [[ -z "$matches" ]]; then
+            log_warn "$cmd launcher: not found in PATH"
+            warn=$((warn + 1))
+            return
+        fi
+
+        local first expected_real first_real
+        first=$(printf '%s\n' "$matches" | head -1)
+        expected_real=$(readlink -f "$expected" 2>/dev/null || printf '%s' "$expected")
+        first_real=$(readlink -f "$first" 2>/dev/null || printf '%s' "$first")
+        if [[ "$first" == "$expected" || "$first_real" == "$expected_real" ]]; then
+            log_success "$cmd launcher: $first"
+            ok=$((ok + 1))
+        else
+            log_warn "$cmd launcher resolves to $first (expected $expected)"
+            warn=$((warn + 1))
+        fi
+
+        local extra
+        extra=$(printf '%s\n' "$matches" | sed -n '2,10p')
+        if [[ -n "$extra" ]]; then
+            local divergent=""
+            while IFS= read -r entry; do
+                [[ -n "$entry" ]] || continue
+                local entry_real
+                entry_real=$(readlink -f "$entry" 2>/dev/null || printf '%s' "$entry")
+                if [[ "$entry_real" != "$expected_real" ]]; then
+                    divergent=1
+                    break
+                fi
+            done <<< "$extra"
+
+            if [[ -n "$divergent" ]]; then
+                log_warn "$cmd has additional PATH entries: $(printf '%s' "$extra" | paste -sd ', ' -)"
+                warn=$((warn + 1))
+            fi
+        fi
+    }
+
     # --- Required binaries ---
     for cmd in git 7z node npm electron asar bwrap; do
         if command_exists "$cmd"; then
@@ -692,6 +737,10 @@ doctor() {
         log_warn "Python 3: not found (needed for auto-download and patches)"
         warn=$((warn + 1))
     fi
+
+    # --- Launcher resolution ---
+    check_launcher_resolution "claude-desktop" "$HOME/.local/bin/claude-desktop"
+    check_launcher_resolution "claude-cowork" "$HOME/.local/bin/claude-cowork"
 
     echo ""
     echo "=========================================="

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -196,6 +196,28 @@ function extractSessionNameFromVmPathStrict(vmPath) {
   return parts[0];
 }
 
+function getIgnoredSdkMessageType(line) {
+  if (typeof line !== 'string') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(line);
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    if (parsed.type === 'queue-operation' || parsed.type === 'rate_limit_event') {
+      return parsed.type;
+    }
+    if (parsed.type === 'message' && parsed.message && typeof parsed.message === 'object') {
+      const nestedType = parsed.message.type;
+      if (nestedType === 'queue-operation' || nestedType === 'rate_limit_event') {
+        return nestedType;
+      }
+    }
+  } catch (_) {}
+  return null;
+}
+
 function generateUUID() {
   if (typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -1561,6 +1583,13 @@ class SwiftAddonStub extends EventEmitter {
           stdoutBuffer = lines.pop();
           for (const line of lines) {
             if (line.trim() && self._onStdout) {
+              const ignoredSdkType = getIgnoredSdkMessageType(line);
+              if (ignoredSdkType) {
+                if (TRACE_IO) {
+                  trace('stdout ignored sdk message type: ' + ignoredSdkType);
+                }
+                continue;
+              }
               stdoutSeq++;
               // DEBUG: Log sequence and message type for ordering diagnosis
               let msgType = 'unknown';

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -682,7 +682,21 @@ Module.prototype.require = function(id) {
       console.log('[Cowork] IPC handler interception enabled');
     }
 
-    // Patch BrowserWindow so close events actually quit on Linux.
+    // Stub out macOS-only systemPreferences methods that cause crashes on Linux
+    if (module.systemPreferences && !global.__coworkSystemPreferencesPatched) {
+      global.__coworkSystemPreferencesPatched = true;
+      module.systemPreferences.getMediaAccessStatus = function() {
+        console.log('[Frame Fix] Stubbed systemPreferences.getMediaAccessStatus');
+        return 'granted';
+      };
+      module.systemPreferences.askForMediaAccess = async function() {
+        console.log('[Frame Fix] Stubbed systemPreferences.askForMediaAccess');
+        return true;
+      };
+      console.log('[Frame Fix] systemPreferences patched for Linux');
+    }
+
+    // Patch BrowserWindow to stub macOS-only methods and handle close events
     // The asar's close handler does `if (isMac()) return;` which swallows
     // close events since we spoof darwin. We prepend a listener that forces
     // app.quit() so killactive/WM close works on all Linux DEs.
@@ -692,6 +706,13 @@ Module.prototype.require = function(id) {
     function patchWindowClose(win) {
       if (_closePatched.has(win)) return;
       _closePatched.add(win);
+
+      // Stub macOS-only BrowserWindow methods
+      if (!win.setWindowButtonPosition) {
+        win.setWindowButtonPosition = function() {
+          // no-op on Linux
+        };
+      }
       // Use prependListener so we fire before the asar's handler
       win.prependListener('close', (event) => {
         if (REAL_PLATFORM === 'linux' && !shuttingDown) {

--- a/test-local.sh
+++ b/test-local.sh
@@ -14,10 +14,17 @@ echo "Deploying local stubs from $REPO_DIR"
 cp -v "$REPO_DIR/stubs/frame-fix/frame-fix-wrapper.js" "$INSTALL_DIR/frame-fix-wrapper.js"
 cp -v "$REPO_DIR/stubs/frame-fix/frame-fix-wrapper.js" "$EXTRACTED_DIR/frame-fix-wrapper.js" 2>/dev/null || true
 
+# Keep the installed stubs tree and extracted app in sync. Dynamic imports can
+# resolve from either location depending on launch path and packaging state.
+mkdir -p "$INSTALL_DIR/stubs/@ant/claude-swift/js" "$INSTALL_DIR/stubs/@ant/claude-native"
+mkdir -p "$EXTRACTED_DIR/node_modules/@ant/claude-swift/js" "$EXTRACTED_DIR/node_modules/@ant/claude-native"
+
 # Copy swift stub
+cp -v "$REPO_DIR/stubs/@ant/claude-swift/js/index.js" "$INSTALL_DIR/stubs/@ant/claude-swift/js/index.js"
 cp -v "$REPO_DIR/stubs/@ant/claude-swift/js/index.js" "$EXTRACTED_DIR/node_modules/@ant/claude-swift/js/index.js"
 
 # Copy native stub
+cp -v "$REPO_DIR/stubs/@ant/claude-native/index.js" "$INSTALL_DIR/stubs/@ant/claude-native/index.js"
 cp -v "$REPO_DIR/stubs/@ant/claude-native/index.js" "$EXTRACTED_DIR/node_modules/@ant/claude-native/index.js"
 
 # Clear asar cache to force rebuild


### PR DESCRIPTION
## Summary
- replace ClaudeCode IPC handlers at the earliest `_invokeHandlers` hook so Linux never reaches the unsupported-platform handler body
- extend the later `_invokeHandlers` patch to override ClaudeCode registrations as well as lookups
- tighten platform/arch spoof detection so app bundle code sees `darwin/arm64` instead of leaking `linux/x64`

## Verification
- launched `~/.local/share/claude-desktop/launch.sh` with the patched wrapper
- confirmed startup logged `platform: 'darwin'` and `arch: 'arm64'` in `/tmp/claude-cowork-verify.log`
- confirmed that verification run did not contain `Unsupported platform: linux-x64` during passive startup