### PR TITLE
feat: enable Code tab on Linux via CLAUDE_CODE_LOCAL_BINARY

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -124,6 +124,16 @@ if [[ -d "$CLAUDE_CODE_DIR" ]]; then
   fi
 fi
 
+# Code tab: tell the asar to use the host Claude Code CLI directly,
+# bypassing the darwin-arm64 binary download that fails on Linux.
+for _candidate in "$HOME/.local/bin/claude" "$HOME/.npm-global/bin/claude" "/usr/local/bin/claude" "/usr/bin/claude"; do
+  if [[ -x "$_candidate" ]]; then
+    export CLAUDE_CODE_LOCAL_BINARY="$_candidate"
+    echo "Code tab: using local binary $CLAUDE_CODE_LOCAL_BINARY"
+    break
+  fi
+done
+
 # --devtools flag opens DevTools + asset dumper on launch
 _args=()
 for arg in "$@"; do


### PR DESCRIPTION
## Summary

The asar's `ClaudeCodeManager` (`HostCLIRunner`) downloads a platform-specific Claude Code binary on first use. With platform spoofed to `darwin`, it tries to download a Mach-O binary that can't execute on Linux.

Setting `CLAUDE_CODE_LOCAL_BINARY` tells the manager to use the host's existing `claude` CLI directly, skipping the download entirely. This makes the Code tab functional on Linux.

`launch.sh` now searches a short list of common install paths and exports the first executable it finds before Electron starts.