### PR TITLE
fix: sync claude-native stub on launch and fix import paths

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -29,6 +29,14 @@ if [ -f "$STUB_SRC_FILE" ]; then
   cp -f "$STUB_SRC_FILE" "$STUB_FILE"
 fi
 
+# Sync claude-native stub
+NATIVE_STUB_FILE="linux-app-extracted/node_modules/@ant/claude-native/index.js"
+NATIVE_STUB_SRC="stubs/@ant/claude-native/index.js"
+if [ -f "$NATIVE_STUB_SRC" ]; then
+  mkdir -p "$(dirname "$NATIVE_STUB_FILE")"
+  cp -f "$NATIVE_STUB_SRC" "$NATIVE_STUB_FILE"
+fi
+
 # Sync frame-fix files so wrapper changes take effect without a full reinstall
 for _ff_file in frame-fix-entry.js frame-fix-wrapper.js; do
   if [ -f "stubs/frame-fix/$_ff_file" ]; then

--- a/stubs/@ant/claude-native/index.js
+++ b/stubs/@ant/claude-native/index.js
@@ -22,8 +22,8 @@ const { ipcMain } = require('electron');
 const EventEmitter = require('events');
 const path = require('path');
 const fs = require('fs');
-const { createDirs } = require('../../cowork/dirs.js');
-const { redactCredentials } = require('../../cowork/credential_classifier.js');
+const { createDirs } = require('../../../cowork/dirs.js');
+const { redactCredentials } = require('../../../cowork/credential_classifier.js');
 
 const LOG_PREFIX = '[claude-native-stub]';
 const DIRS = global.__coworkDirs || createDirs();


### PR DESCRIPTION
## Summary

- Add native stub sync step in launch.sh (matching the existing swift stub sync)
- Fix require() paths in claude-native stub: `../../cowork/` → `../../../cowork/` to match the actual directory depth when copied into `linux-app-extracted/node_modules/@ant/claude-native/`

## Test plan

- [ ] Verify launch.sh copies the native stub into the extracted app tree
- [ ] Verify claude-native stub loads without module resolution errors