### PR TITLE
fix(pkgbuild): copy shell scripts into cowork dir during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,10 @@ TEST_RESULTS.md
 # Build artifacts
 *.exe
 *.nupkg
+*.pkg.tar.*
 pkg/
 src/
+claude-cowork-linux/
 
 # Debug scripts (not needed for users)
 analyze-logs.sh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -135,6 +135,8 @@ build() {
     mkdir -p "${srcdir}/linux-app-extracted/cowork"
     cp -f "${_repo}"/stubs/cowork/*.js \
           "${srcdir}/linux-app-extracted/cowork/"
+    cp -f "${_repo}"/stubs/cowork/*.sh \
+          "${srcdir}/linux-app-extracted/cowork/" 2>/dev/null || true
 
     # Apply cowork patch
     echo "Applying cowork patch..."


### PR DESCRIPTION
## Summary

- **PKGBUILD `build()`** only copied `*.js` from `stubs/cowork/` into the extracted app dir. Upstream added `cowork-plugin-shim.sh` which `package()` tries to install to the electron resources dir, causing the build to fail with `cannot stat '.../cowork-plugin-shim.sh'`.
- Added a `*.sh` copy step alongside the existing `*.js` copy.
- Also added `*.pkg.tar.*` and `claude-cowork-linux/` (makepkg bare clone) to `.gitignore`.

## Test plan

- [x] `makepkg -sf` builds successfully
- [x] `pacman -U` installs without errors (after `--overwrite` for pre-existing locale JSONs)
- [x] `cowork-plugin-shim.sh` present in installed electron resources dir