### PR TITLE
fix(swift-stub): return Promise from isGuestConnected()

### DIFF
--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1105,7 +1105,7 @@ class SwiftAddonStub extends EventEmitter {
       },
       isGuestConnected: () => {
         console.log('[claude-swift] vm.isGuestConnected() called - returning', self._guestConnected);
-        return self._guestConnected;
+        return Promise.resolve(self._guestConnected);
       },
       getRunningStatus: () => {
         const status = {
@@ -1858,7 +1858,7 @@ class SwiftAddonStub extends EventEmitter {
   }
 
   isGuestConnected() {
-    return this._guestConnected;
+    return Promise.resolve(this._guestConnected);
   }
 
   getRunningStatus() {


### PR DESCRIPTION
## Bug

`TypeError: t.isGuestConnected(...).catch is not a function` fires in a loop in the Electron renderer logs.

## Root cause

`isGuestConnected()` returns a plain boolean (`self._guestConnected`), but the asar's bundled code calls `.catch()` on the return value — it expects a Promise.

Two call sites are affected:
- **Line 1108** — the vm proxy object returned by `getVmProxy()`
- **Line 1861** — the `SwiftAddonStub` class method

## Fix

Wrap both return values in `Promise.resolve()`:

```js
// Before
return self._guestConnected;

// After
return Promise.resolve(self._guestConnected);
```

## Testing

Confirmed on **Arch Linux** (kernel 6.19.9) with **Hyprland** + **electron39** + **claude-cowork-linux v1.1.8629**:
- The TypeError loop is gone from the logs
- `isGuestConnected()` correctly resolves to the expected boolean value
- No regressions observed in session lifecycle (spawn, message, stop)