### PR TITLE
Fix Wayland app-id, systemPreferences crash, and EPIPE dialogs

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -217,6 +217,7 @@ _electron_args=(
   --no-sandbox
   --password-store="$PASSWORD_STORE"
   --enable-features=GlobalShortcutsPortal
+  --class=Claude
 )
 
 if [[ "$_perf" == true ]]; then

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -16,7 +16,40 @@ const { createSessionStore } = require('./cowork/session_store.js');
 const { createIpcTap } = require('./cowork/ipc_tap.js');
 const { createOverrideRegistry, matchOverride, extractEipcUuid, proactivelyRegisterOverrides, isProactiveChannel } = require('./cowork/ipc_overrides.js');
 
+// Suppress EPIPE errors on stdout/stderr (normal in piped/Electron environments)
+// and prevent them from becoming uncaught exception crash dialogs.
+function _epipeHandler(err) {
+  if (err.code === 'EPIPE') return;
+  throw err;
+}
+if (process.stdout && typeof process.stdout.on === 'function') {
+  process.stdout.on('error', _epipeHandler);
+}
+if (process.stderr && typeof process.stderr.on === 'function') {
+  process.stderr.on('error', _epipeHandler);
+}
+// Catch EPIPE from any other pipe (IPC, Winston transports, CCD subprocess)
+// that would otherwise surface as uncaught exception error dialogs.
+const _origListeners = process.listeners('uncaughtException');
+process.removeAllListeners('uncaughtException');
+process.on('uncaughtException', (err, origin) => {
+  if (err && err.code === 'EPIPE') {
+    // Log once, don't crash
+    try { fs.appendFileSync(
+      path.join(process.env.CLAUDE_LOG_DIR || '/tmp', 'epipe-suppressed.log'),
+      `[${new Date().toISOString()}] EPIPE suppressed: ${err.stack || err.message}\n`,
+      { mode: 0o600 }
+    ); } catch (_) {}
+    return;
+  }
+  // Re-throw to existing handlers (Electron's dialog, etc.)
+  for (const listener of _origListeners) {
+    listener(err, origin);
+  }
+});
+
 console.log('[Frame Fix] Wrapper v2.5 loaded');
+console.log('[Frame Fix] EPIPE suppression enabled');
 if (process.env.CLAUDE_DEVTOOLS === '1') console.log('[Frame Fix] DevTools mode enabled');
 
 // ── Bridge forwardEvent patch ──────────────────────────────────────────
@@ -860,6 +893,19 @@ Module.prototype.require = function(id) {
       const chromeVersion = process.versions.chrome || '130.0.0.0';
       app.userAgentFallback = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude/' + (app.getVersion ? app.getVersion() : '1.0.0') + ' Chrome/' + chromeVersion + ' Electron/' + electronVersion + ' Safari/537.36';
       console.log('[Frame Fix] User agent spoofed to macOS');
+
+      // Set the Wayland app-id so COSMIC (and other compositors) match the
+      // running window to claude.desktop, giving it the correct icon in the
+      // taskbar and making pin-to-dock work.
+      if (REAL_PLATFORM === 'linux') {
+        if (typeof app.setDesktopName === 'function') {
+          app.setDesktopName('claude.desktop');
+          console.log('[Frame Fix] Desktop name set to claude.desktop');
+        }
+        if (typeof app.setName === 'function') {
+          app.setName('Claude');
+        }
+      }
     }
 
     // Intercept ipcMain.handle to inject our VM handlers
@@ -938,6 +984,13 @@ Module.prototype.require = function(id) {
       module.systemPreferences.askForMediaAccess = async function() {
         console.log('[Frame Fix] Stubbed systemPreferences.askForMediaAccess');
         return true;
+      };
+      module.systemPreferences.setUserDefault = function(key, type, value) {
+        console.log('[Frame Fix] Stubbed systemPreferences.setUserDefault:', key);
+      };
+      module.systemPreferences.getUserDefault = function(key, type) {
+        console.log('[Frame Fix] Stubbed systemPreferences.getUserDefault:', key);
+        return undefined;
       };
       console.log('[Frame Fix] systemPreferences patched for Linux');
     }


### PR DESCRIPTION
## What does this change?

Three fixes for Claude Desktop 1.2.234 on Linux:

1. **Wayland app-id matching** — Calls `app.setDesktopName('claude.desktop')` and `app.setName('Claude')` so Wayland compositors match the running window to `claude.desktop`. Without this, the taskbar shows a generic Electron icon and pin-to-dock doesn't work. Also passes `--class=Claude` in `launch.sh` as an X11 fallback.

2. **`systemPreferences.setUserDefault` crash** (fixes #66) — Stubs `setUserDefault` and `getUserDefault`, which are macOS-only Electron APIs called by the latest Claude Desktop build. Without these stubs, the app crashes on startup. Note: PR #67 addresses the same crash with a slightly different placement (top of file vs. grouped with existing stubs); either approach works.

3. **EPIPE dialog spam** — After the `setUserDefault` fix, the app launches but gets spammed with `write EPIPE` uncaught exception dialogs from the CCD subprocess pipe and Winston transport. This adds EPIPE suppression on stdout/stderr and a process-level uncaught exception filter that logs EPIPEs to `epipe-suppressed.log` instead of showing crash dialogs.

## Type

- [x] Bug fix
- [x] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

- Distro / desktop: Pop!_OS 24.04, COSMIC (Wayland)
- Electron: 41.1.1
- Claude Desktop: 1.2.234
- Tested with `./install.sh --doctor`: yes
- Tested a full Cowork session: yes
- Verified taskbar icon matches `claude.desktop` (sunburst icon)
- Verified pin-to-dock launches the app correctly
- Verified no EPIPE crash dialogs on startup

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [x] `./install.sh --doctor` passes cleanly on my system