### PR TITLE
Fix locale crash on Arch: patch resourcesPath branches in asar

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -108,6 +108,18 @@ if [ -f "$INDEX_JS" ] && grep -q 'e\.protocol==="file:"&&Ee\.app\.isPackaged===!
   sed -i 's/e\.protocol==="file:"&&Ee\.app\.isPackaged===!0/e.protocol==="file:"/g' "$INDEX_JS"
 fi
 
+# Fix resource path lookup for i18n, shim-lib, icon, etc.
+# The asar uses `app.isPackaged ? process.resourcesPath : <asar-relative path>`.
+# On Arch Linux, `process.resourcesPath` is the system electron's dir
+# (e.g., /usr/lib/electron39/resources/), which only has default_app.asar —
+# locales live at /usr/lib/electron39/locales/*.pak (wrong format, wrong path).
+# The fallback branch resolves to resources/ inside our asar, where launch.sh
+# populates resources/i18n/*.json. Always use the fallback so locale JSONs load.
+if [ -f "$INDEX_JS" ] && grep -qE '[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?process\.resourcesPath:' "$INDEX_JS"; then
+  echo "Patching resourcesPath lookups to use asar-internal resources/..."
+  sed -i -E 's/[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?process\.resourcesPath://g' "$INDEX_JS"
+fi
+
 # Only repack if stub is newer than asar (or asar doesn't exist)
 # Repack if any file in the extracted tree is newer than the cached asar.
 _needs_repack=false


### PR DESCRIPTION
## Summary
- On Arch Linux (system electron), `process.resourcesPath` is `/usr/lib/electron39/resources/`, which only contains `default_app.asar` — the locale files live at `/usr/lib/electron39/locales/*.pak` in the wrong format and wrong directory.
- When `launch.sh` runs the repacked app via `electron ./app.asar`, `app.isPackaged` is `true`, so the asar's locale loader (`Upt()` and 3 sibling helpers) reads `process.resourcesPath/<lang>.json` and crashes at module load with `ENOENT: no such file or directory, open '/usr/lib/electron39/resources/en-US.json'`.
- Adds a `sed` patch in `launch.sh` that strips `<var>.app.isPackaged?process.resourcesPath:` from all 4 matching sites in `.vite/build/index.js`, forcing each one to use its asar-internal fallback path (`__dirname/../../resources[/i18n]`). The existing i18n fix earlier in the script already populates `resources/i18n/*.json` inside the repacked asar, so the fallback resolves correctly for both system-electron and AppImage runs.

## Test plan
- [x] Reproduced the original crash: `App threw an error during load / Error: ENOENT: no such file or directory, open '/usr/lib/electron39/resources/en-US.json'` in `startup.log`.
- [x] After the patch, `bash launch.sh` boots cleanly on Arch with system `electron` — 0 `ENOENT` errors, 0 `App threw` lines, webapp loads and renderer starts.
- [x] Verified the `sed` pattern matches exactly the 4 intended occurrences (i18n locale loader, shim-lib copy, generic resources resolver, and `getAppIcon`) and nothing else.
- [ ] AppImage path not re-verified here (no AppImage on this host), but the patched code path is strictly a superset of the non-packaged fallback the app already uses in dev builds.