### PR TITLE
Allow bash -c invocations in vm.spawn allowlist

### DIFF
--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -522,6 +522,20 @@ class SessionOrchestrator {
     ) {
       hostCommand = resolveClaudeBinaryPath();
       trace('Translated command: ' + normalizedCommand + ' -> ' + hostCommand);
+      } else if (
+      normalizedCommand === 'bash' ||
+      commandBasename === 'bash'
+    ) {
+      const bashCandidates = ['/usr/bin/bash', '/bin/bash'];
+      hostCommand = bashCandidates.find((c) => fs.existsSync(c));
+      if (!hostCommand) {
+        trace('SECURITY: bash requested but not found on host');
+        if (typeof onError === 'function') {
+          onError(processId, 'bash not found', '');
+        }
+        return { success: false, error: 'bash not found' };
+      }
+      trace('Translated bash command: ' + normalizedCommand + ' -> ' + hostCommand);
     } else if (allowedPrefixes.some((prefix) => normalizedCommand.startsWith(prefix))) {
       if (fs.existsSync(normalizedCommand)) {
         hostCommand = normalizedCommand;


### PR DESCRIPTION
Recent Claude Desktop builds issue shell tool calls as `bash -c \"cd <dir> && <cmd>\" `

instead of invoking the claude binary directly. The allowlist in session_orchestrator.js rejects bare 'bash' as an unvetted command, blocking every shell tool call with 'SECURITY: Unexpected command blocked' and surfacing in the UI as an immediate session crash.

Add a branch that resolves bash to /usr/bin/bash or /bin/bash (both already covered by the existing allowedPrefixes list), so the spawn proceeds through the normal path with the same security posture as any other /usr/bin binary.

## What does this change?

Bypassing bash `SECURITY: Unexpected command blocked: "bash" (type=string)` on latest co work v2.1.114


## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

<!-- How did you verify this? Include distro, DE, and any relevant log snippets. -->

- Distro / desktop: Gentoo / KDE - Wayland
- Tested with `./install.sh --doctor`: Yes
- Tested a full Cowork session: Yes

## Security impact

spawn only: resolved a new hostCommand and let the existing spawn path run unchanged

The patch only adds a branch that resolves `bash` / basename `bash` to `/usr/bin/bash` or `/bin/bash` — both already covered by `allowedPrefixes`. The dispatch then falls through to the existing spawn path, inheriting all env filtering, credential classification, and log redaction unchanged.


- [x] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code — explanation below:

<!-- explanation if needed -->

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [x] `./install.sh --doctor` passes cleanly on my system
