### PR TITLE
fix: allow bash/sh in session_orchestrator command allowlist

### DIFF
--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -522,6 +522,9 @@ class SessionOrchestrator {
     ) {
       hostCommand = resolveClaudeBinaryPath();
       trace('Translated command: ' + normalizedCommand + ' -> ' + hostCommand);
+    } else if (commandBasename === 'bash' || commandBasename === 'sh') {
+      hostCommand = '/usr/bin/' + commandBasename;
+      trace('Translated shell command: ' + normalizedCommand + ' -> ' + hostCommand);
     } else if (allowedPrefixes.some((prefix) => normalizedCommand.startsWith(prefix))) {
       if (fs.existsSync(normalizedCommand)) {
         hostCommand = normalizedCommand;


### PR DESCRIPTION
The vm.spawn validation only accepts `claude` and absolute paths under the configured prefixes. The bundled @anthropic-ai/claude-agent-sdk calls vm.spawn("bash", ["-c", ...]) for every shell tool invocation -- "bash" matches neither branch, so every call is rejected with "SECURITY: Unexpected command blocked: bash" and Cowork reports "shell is unavailable."

Route bash/sh to /usr/bin/<basename>. The downstream commandIsAllowed check at line 542 already permits /usr/bin/ paths, so the resolved path passes through naturally. Pure addition; macOS unaffected.

Repro: install via launch.sh, ask Claude any shell-tool question, watch ~/.local/state/claude-cowork/logs/claude-swift-trace.log for "Unexpected command blocked: \"bash\"".

## Testing

- Distro / desktop: Arch Linux / KDE Plasma 6 / Wayland
- Tested with `./install.sh --doctor`:
- Tested a full Cowork session