### PR TITLE
fix(cowork): mkdir parent in createMountSymlinks for nested mount keys

### DIFF
--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -469,6 +469,10 @@ function createMountSymlinks(sessionName, additionalMounts) {
         }
       }
 
+      // Ensure parent dir exists -- nested mount keys like ".claude/skills"
+      // need ".claude/" to exist before symlinkSync can place "skills" inside.
+      // Idempotent for non-nested keys (parent already equals mntDir).
+      fs.mkdirSync(path.dirname(mountPoint), { recursive: true, mode: 0o700 });
       fs.symlinkSync(hostPath, mountPoint);
       trace('  SUCCESS: Created symlink ' + mountPoint + ' -> ' + hostPath);
     } catch (e) {


### PR DESCRIPTION
## What does this change?

Hit this while testing #90: that PR's path translation correctly resolves `/sessions/X/mnt/.claude/skills/...` to where the symlink should live, but the symlink itself wasn't there because `createMountSymlinks` silently fails on nested mount keys. `.claude/skills` and `.claude/projects` need `.claude/` to exist before `symlinkSync` can place the child symlink inside it -- otherwise it ENOENTs.

Fix is one `fs.mkdirSync(path.dirname(mountPoint), { recursive: true, mode: 0o700 })` before the existing `symlinkSync` call. No-op for non-nested keys (parent already equals `mntDir`, which the function created earlier). On macOS this works because the VM filesystem creates intermediate dirs implicitly; on Linux we have to mkdir them ourselves.

This and #90 are both needed for end-to-end Cowork on Linux but they're independent -- different functions, different failure modes. Either can merge first.

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

Asked Claude in a Cowork session to read an xlsx file from a shared workspace dir. Before the fix, the xlsx skill couldn't run because it tried `cd /sessions/X/mnt/.claude/skills/xlsx` which didn't exist. After the fix, both nested mounts get created and the skill runs first try.

- Distro / desktop: Arch + KDE Plasma 6 (Wayland)
- Tested with `./install.sh --doctor`: yes
- Tested a full Cowork session: yes

Trace excerpt before:
``Mount point: ...sessions/<n>/mnt/.claude/skills
ERROR creating symlink: ENOENT: no such file or directory, symlink ... -> ....mnt/.claude/skills
Mount point: ...sessions/<n>/mnt/.claude/projects
ERROR creating symlink: ENOENT: no such file or directory, symlink ... -> ....mnt/.claude/projects``
After:
``-- Processing mount: .claude/skills ---
SUCCESS: Created symlink ...mnt/.claude/skills -> ...skills-plugin/.../skills
--- Processing mount: .claude/projects ---
SUCCESS: Created symlink ...mnt/.claude/projects -> .../.claude/projects``

`ls -la ~/.config/Claude/local-agent-mode-sessions/sessions/<session>/mnt/` then shows the `.claude/` parent dir with both nested symlinks inside, alongside the existing `Claude`, `uploads`, and `outputs` symlinks.

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning
- [ ] This change does touch security-sensitive code -- explanation below:

The mkdirSync runs inside the per-session mount directory under `<sessionsBase>` that `createMountSymlinks` already creates with `mode: 0o700` a few lines above. Same mode here for consistency. Doesn't touch `filterEnv`, `spawn`, `AuthRequest`, or `isPathSafe`.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [x] `./install.sh --doctor` passes cleanly on my system (went back and tested both ways AUR vs install)