### PR TITLE
fix(cowork): redirect resourcesPath so disclaimer wrapper installs

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -1,3 +1,37 @@
+// Override process.resourcesPath BEFORE any other code (asar's jHi(), our own
+// disclaimer install) reads it. The asar's jHi() helper computes the disclaimer
+// wrapper path as path.dirname(process.resourcesPath) + '/Helpers/disclaimer'.
+// On the system Electron in dev mode (no PKGBUILD trampoline), this resolves to
+// /usr/lib/electron${V}/Helpers/disclaimer — a root-owned path our runtime
+// install (line ~546) can't write to (EACCES), so the SDK then spawns into
+// thin air ("Claude Code native binary not found"). Repoint to a user-writable
+// XDG location so the install succeeds and jHi() returns the same path.
+//
+// Conditional: skip when a disclaimer wrapper already exists at jHi()'s path
+// (PKGBUILD users, where the trampoline points at /usr/lib/claude-cowork/
+// resources and the wrapper is installed by the package). Overriding there
+// would also misroute the asar's locale lookups, which the packaged build
+// keeps reading via process.resourcesPath.
+{
+  const _fs = require('fs');
+  const _path = require('path');
+  const _existing = _path.join(_path.dirname(process.resourcesPath || ''), 'Helpers', 'disclaimer');
+  let _haveDisclaimer = false;
+  try {
+    _fs.accessSync(_existing, _fs.constants.X_OK);
+    _haveDisclaimer = true;
+  } catch (_) {}
+  if (!_haveDisclaimer) {
+    const _xdgConfigHome = process.env.XDG_CONFIG_HOME || _path.join(require('os').homedir(), '.config');
+    Object.defineProperty(process, 'resourcesPath', {
+      value: _path.join(_xdgConfigHome, 'Claude', 'cowork-resources'),
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
+}
+
 // Patch macOS-only systemPreferences methods that don't exist on Linux
 const { systemPreferences } = require('electron');
 if (typeof systemPreferences.setUserDefault !== 'function') {


### PR DESCRIPTION
## Summary

- Fixes cowork failing on dev launches with `Claude Code native binary not found at /usr/lib/electron${V}/Helpers/disclaimer` (or, if a stale wrapper is present, exit 126 / `cannot execute binary file` against the underlying Mach-O bundle).
- Repoints `process.resourcesPath` to `~/.config/Claude/cowork-resources` at the very top of `frame-fix-wrapper.js`, before any code reads it, so the existing runtime install of the disclaimer wrapper writes to a user-writable location and the asar's `jHi()` resolves to that same file.
- Conditional on no pre-installed disclaimer at the current `jHi()` path — PKGBUILD users (whose trampoline points `resourcesPath` at `/usr/lib/claude-cowork/resources` and ships the wrapper) keep their setup and locale lookups intact.

## Why

On the system Electron in dev mode there is no PKGBUILD trampoline, so `process.resourcesPath` stays at `/usr/lib/electron${V}/resources`. The wrapper install at `frame-fix-wrapper.js` then tries to write to `/usr/lib/electron${V}/Helpers/disclaimer` and fails with `EACCES`. The asar's `jHi()` (used by the Claude Code SDK to compute `pathToClaudeCodeExecutable`) returns the same non-existent path, so the SDK errors out before it ever spawns. A naive bypass of the asar's `Np()` wrapper avoids this surface error but breaks the macOS-bundle path translation the disclaimer shim performs, leading to direct exec of the `claude.app/Contents/MacOS/claude` Mach-O binary and exit 126.

## Test plan

- [x] `./launch.sh` on Arch + system Electron — cowork session starts, CLI spawns via `~/.local/bin/claude`, transcripts persist
- [x] Disclaimer wrapper exists at `~/.config/Claude/Helpers/disclaimer` and is executable
- [x] `process.resourcesPath` override is skipped when an existing disclaimer is present at `jHi()`'s path (PKGBUILD path unchanged)
- [ ] PKGBUILD build + install: locale loads, cowork session starts (sanity check from a packager appreciated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)