### PR TITLE
Fix issues/93: ensure electron binary is found in desktop/URL handler…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -437,11 +437,13 @@ install_stubs() {
         cp -f "$stub_src"/stubs/cowork/*.js "$target_dir/cowork/"
     fi
 
-    # Also sync stubs into the install dir's stubs/ so future launches
+    # Also sync stubs and launch scripts into the install dir so future launches
     # from the install dir (via claude-desktop launcher) use current code
     if [[ "$stub_src" != "$INSTALL_DIR" && -d "$INSTALL_DIR" ]]; then
-        log_info "Syncing stubs to install dir..."
+        log_info "Syncing stubs and launch scripts to install dir..."
         cp -rf "$stub_src/stubs" "$INSTALL_DIR/"
+        cp -f "$stub_src/launch.sh" "$INSTALL_DIR/launch.sh"
+        cp -f "$stub_src/launch-devtools.sh" "$INSTALL_DIR/launch-devtools.sh"
     fi
 
     log_success "Stubs installed"

--- a/launch-devtools.sh
+++ b/launch-devtools.sh
@@ -7,9 +7,15 @@ set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Ensure ~/.local/bin is in PATH (common for user-local electron installs)
+export PATH="$HOME/.local/bin:$PATH"
+
 # Resolve electron binary: prefer system electron + local .asar-cache, fall back to AppImage
 if command -v electron >/dev/null 2>&1; then
   ELECTRON_BIN="$(command -v electron)"
+  ASAR_FILE=".asar-cache/app.asar"
+elif [[ -x "$HOME/.local/bin/electron" ]]; then
+  ELECTRON_BIN="$HOME/.local/bin/electron"
   ASAR_FILE=".asar-cache/app.asar"
 elif [[ -x "./squashfs-root/usr/lib/node_modules/electron/dist/electron" ]]; then
   ELECTRON_BIN="./squashfs-root/usr/lib/node_modules/electron/dist/electron"

--- a/launch.sh
+++ b/launch.sh
@@ -8,9 +8,16 @@ set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Ensure ~/.local/bin is in PATH (common for user-local electron installs)
+export PATH="$HOME/.local/bin:$PATH"
+
 # Resolve electron binary: prefer system electron + local .asar-cache, fall back to AppImage
 if command -v electron >/dev/null 2>&1; then
   ELECTRON_BIN="$(command -v electron)"
+  ASAR_FILE=".asar-cache/app.asar"
+  mkdir -p ".asar-cache"
+elif [[ -x "$HOME/.local/bin/electron" ]]; then
+  ELECTRON_BIN="$HOME/.local/bin/electron"
   ASAR_FILE=".asar-cache/app.asar"
   mkdir -p ".asar-cache"
 elif [[ -x "./squashfs-root/usr/lib/node_modules/electron/dist/electron" ]]; then


### PR DESCRIPTION
… AppImage in squashfs-root/

## What does this change?

<!-- Brief description of the change and why it's needed. -->

## Type

- [ #93 ] Bug fix
- [ Ubuntu ] Distro / DE compatibility
- [ No ] New feature
- [ No ] Documentation
- [ No ] Refactor

## Testing

<!-- How did you verify this? Include distro, DE, and any relevant log snippets. -->

- Distro / desktop:
Ubuntu Linux pankaj-rog 6.17.0-22-generic #22-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar 13 12:04:44 UTC 2026 x86_64 GNU/Linux

- Tested with `./install.sh --doctor`:
- ./install.sh --doctor      ✔  12:48:35 

==========================================
 Claude Desktop for Linux - Doctor
 Version: 4.0.0
==========================================

[OK] git: /usr/bin/git
[OK] 7z: /usr/bin/7z
[OK] node: /usr/bin/node
[OK] npm: /usr/bin/npm
[OK] electron: /home/pankaj/.local/bin/electron
[OK] asar: /home/pankaj/.local/bin/asar
[OK] bwrap: /usr/bin/bwrap
[OK] Node.js version: v24 (>= 18)
[OK] Claude binary: /home/pankaj/.local/bin/claude
[OK] /sessions symlink -> /home/pankaj/.config/Claude/local-agent-mode-sessions/sessions
[OK] Secret service (org.freedesktop.secrets): available
[OK] Extracted app: /home/pankaj/.local/share/claude-desktop/linux-app-extracted
[OK] Cowork patch: applied
[OK] Swift stub: installed
[OK] Python: 3.13.7 (optional)
[OK] claude-desktop launcher: /home/pankaj/.local/bin/claude-desktop
[OK] claude-cowork launcher: /home/pankaj/.local/bin/claude-cowork

==========================================
 17 passed  0 warnings  0 failed
==========================================

Everything looks good.

- Tested a full Cowork session:

## Security impact

<!-- If this touches filterEnv, spawn, AuthRequest, isPathSafe, or any credential handling:
     describe the impact and confirm it aligns with OAUTH-COMPLIANCE.md. -->

- [x] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code — explanation below:

<!-- explanation if needed -->

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [x] `./install.sh --doctor` passes cleanly on my system
