### PR TITLE
fix: Session init issue #97 

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,6 +9,9 @@ license=('custom:proprietary')
 depends=(
     'electron'
     'nodejs'
+    'curl'
+    'zstd'
+    'file'
 )
 # gnome-keyring is recommended but not required; launcher detects SecretService
 # at runtime and falls back to --password-store=basic if unavailable
@@ -258,6 +261,34 @@ if ! dbus-send --session --print-reply --dest=org.freedesktop.DBus /org/freedesk
      | grep -q "boolean true"; then
     PW_STORE="basic"
 fi
+
+# getHostPlatform() spoofs darwin-x64, so the app downloads macOS binaries.
+for _ccd in "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/claude-code" \
+             "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/claude-code-vm"; do
+    [[ -d "$_ccd" ]] || continue
+    for _vdir in "$_ccd"/*/; do
+        [[ -d "$_vdir" ]] || continue
+        _bin="${_vdir}claude"
+        [[ -f "$_bin" ]] || continue
+        file "$_bin" 2>/dev/null | grep -q "Mach-O" || continue
+        _ver="$(basename "$_vdir")"
+        _arch="$(uname -m)"
+        [[ "$_arch" == "aarch64" ]] && _plat="linux-arm64" || _plat="linux-x64"
+        _url="https://downloads.claude.ai/claude-code-releases/${_ver}/${_plat}/claude.zst"
+        mv "$_bin" "${_bin}.macho-backup"
+        if curl -sfL "$_url" | zstd -d -o "$_bin" 2>/dev/null; then
+            chmod +x "$_bin"
+        else
+            mv "${_bin}.macho-backup" "$_bin"
+        fi
+    done
+done
+
+# Clear V8 bytecode cache so asar patches take effect after upgrade.
+# These are compilation artifacts only — no user data is affected.
+rm -rf "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/Code Cache" \
+       "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/GPUCache" \
+       "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/CachedData"
 
 exec electron /usr/lib/claude-cowork/app.asar \
     --no-sandbox \

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -55,6 +55,70 @@ def find_function_bounds(content, start):
 
 PATCH_MARKER = '/*cowork-patched*/'
 
+# Regex for getHostPlatform(): matches `throw new Error(...)` containing
+# "Unsupported platform" — the platform block in the session-init path.
+# Must not match unrelated "Unsupported platform" in chrome mcp
+HOST_PLATFORM_THROW_RE = re.compile(
+    r'throw new Error\([^)]*Unsupported platform[^)]*\)'
+)
+
+
+# Regex for VM file-list lookups: .files[platform][arch]??[]
+# Eo.files only has darwin/win32 keys. First bracket returned undefined
+VM_FILES_LOOKUP_RE = re.compile(
+    r'(\.files\[\w+\])\[(\w+)\](\?\?\[\])'
+)
+
+
+def patch_vm_files_lookup(filepath):
+    """Add optional chaining to VM file-list lookups for Linux safety.
+
+    The minified asar has functions like:
+        function hae(){const e=process.platform,A=Qae();return Eo.files[e][A]??[]}
+    Eo.files only has 'darwin' and 'win32' keys. On Linux, Eo.files["linux"]
+    is undefined, so [A] on it throws TypeError. Adding ?. makes the access
+    return undefined instead, which ?? catches and returns [].
+    """
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    matches = VM_FILES_LOOKUP_RE.findall(content)
+    if not matches:
+        print("  vm files lookup: no unsafe patterns found (already patched or not present)")
+        return True
+
+    content = VM_FILES_LOOKUP_RE.sub(r'\1?.[\2]\3', content)
+
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+    print(f"  vm files lookup patched: {len(matches)} unsafe .files[platform][arch] access(es) fixed")
+    return True
+
+
+def patch_host_platform(filepath):
+    """Patch getHostPlatform() to return 'darwin-x64' instead of throwing on Linux.
+
+    The minified getHostPlatform() method only handles darwin and win32,
+    throwing Error('Unsupported platform: ...') for anything else.
+    Replace the throw with return"darwin-x64" so session init succeeds.
+    """
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    match = HOST_PLATFORM_THROW_RE.search(content)
+    if not match:
+        print(f"  getHostPlatform(): no throw found (already patched or not present)")
+        return True
+
+    content = HOST_PLATFORM_THROW_RE.sub('return"darwin-x64"', content)
+
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+    print(f"  getHostPlatform() patched: throw replaced with return\"darwin-x64\"")
+    return True
+
 
 def patch_file(filepath):
     with open(filepath, 'r') as f:
@@ -106,4 +170,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     success = patch_file(sys.argv[1])
+    if success:
+        patch_host_platform(sys.argv[1])
+        patch_vm_files_lookup(sys.argv[1])
     sys.exit(0 if success else 1)

--- a/install.sh
+++ b/install.sh
@@ -744,10 +744,28 @@ doctor() {
     if [[ -n "$claude_found" ]]; then
         log_success "Claude binary: $claude_found"
         ok=$((ok + 1))
+        # Check for Mach-O binaries
+        if file "$claude_found" 2>/dev/null | grep -q "Mach-O"; then
+            log_error "Claude binary is macOS Mach-O (won't execute on Linux): $claude_found"
+            fail=$((fail + 1))
+        fi
     else
         log_warn "Claude binary: not found (Cowork will download it on first run)"
         warn=$((warn + 1))
     fi
+
+    # --- Mach-O binary check in SDK dirs ---
+    for _sdk_dir in "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/claude-code" \
+                    "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/claude-code-vm"; do
+        [[ -d "$_sdk_dir" ]] || continue
+        for _vbin in "$_sdk_dir"/*/claude; do
+            [[ -f "$_vbin" ]] || continue
+            if file "$_vbin" 2>/dev/null | grep -q "Mach-O"; then
+                log_warn "Mach-O binary found: $_vbin (launch.sh will replace on next run)"
+                warn=$((warn + 1))
+            fi
+        done
+    done
 
     # --- /sessions symlink ---
     if [[ -L /sessions ]]; then

--- a/launch.sh
+++ b/launch.sh
@@ -141,35 +141,32 @@ else
 fi
 
 # ============================================================
-# Fix Code tab binary: the asar downloads a macOS Mach-O binary to
-# claude-code/<version>/claude. Replace with the Linux binary so
-# HostCLIRunner (Code tab) works on Linux.
+# getHostPlatform() spoofs darwin-x64, so the asar may download macOS
+# Covers both claude-code/ (Code tab) and claude-code-vm/ (Cowork).
 # ============================================================
-CLAUDE_CODE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/Claude/claude-code"
-if [[ -d "$CLAUDE_CODE_DIR" ]]; then
-  LINUX_CLAUDE=""
-  for _candidate in "$HOME/.local/bin/claude" "$HOME/.npm-global/bin/claude" "/usr/local/bin/claude" "/usr/bin/claude"; do
-    if [[ -x "$_candidate" ]]; then
-      LINUX_CLAUDE="$_candidate"
-      break
+for _ccd in "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/claude-code" \
+             "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/claude-code-vm"; do
+  [[ -d "$_ccd" ]] || continue
+  for _vdir in "$_ccd"/*/; do
+    [[ -d "$_vdir" ]] || continue
+    _bin="${_vdir}claude"
+    [[ -f "$_bin" ]] || continue
+    file "$_bin" 2>/dev/null | grep -q "Mach-O" || continue
+    _ver="$(basename "$_vdir")"
+    _arch="$(uname -m)"
+    [[ "$_arch" == "aarch64" ]] && _plat="linux-arm64" || _plat="linux-x64"
+    _url="https://downloads.claude.ai/claude-code-releases/${_ver}/${_plat}/claude.zst"
+    echo "Replacing Mach-O binary: $_bin (v${_ver})"
+    mv "$_bin" "${_bin}.macho-backup"
+    if curl -sfL "$_url" | zstd -d -o "$_bin" 2>/dev/null; then
+      chmod +x "$_bin"
+      echo "  Downloaded Linux binary from CDN"
+    else
+      echo "  CDN download failed, restoring backup"
+      mv "${_bin}.macho-backup" "$_bin"
     fi
   done
-  if [[ -n "$LINUX_CLAUDE" ]]; then
-    LINUX_CLAUDE_REAL="$(readlink -f "$LINUX_CLAUDE")"
-    for _version_dir in "$CLAUDE_CODE_DIR"/*/; do
-      _ccd_bin="${_version_dir}claude"
-      if [[ -f "$_ccd_bin" && ! -L "$_ccd_bin" ]]; then
-        # Check if it's a Mach-O binary (not a Linux ELF)
-        if file "$_ccd_bin" 2>/dev/null | grep -q "Mach-O"; then
-          echo "Fixing Code tab binary: replacing macOS binary with Linux symlink"
-          echo "  $_ccd_bin -> $LINUX_CLAUDE_REAL"
-          mv "$_ccd_bin" "${_ccd_bin}.macho-backup"
-          ln -s "$LINUX_CLAUDE_REAL" "$_ccd_bin"
-        fi
-      fi
-    done
-  fi
-fi
+done
 
 # --devtools flag opens DevTools + asset dumper on launch
 # --perf flag enables Chromium tracing + Node inspector for profiling
@@ -275,6 +272,12 @@ if [[ "$_perf" == true ]]; then
   echo "  Trace IO:      Enabled (stdin/stdout logging)"
   echo ""
 fi
+
+# Clear V8 bytecode cache so asar patches take effect after upgrade.
+# These are compilation artifacts only — no user data is affected.
+rm -rf "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/Code Cache" \
+       "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/GPUCache" \
+       "${XDG_CONFIG_HOME:-$HOME/.config}/Claude/CachedData"
 
 # Run electron with the repacked app.asar
 if [[ "$_dev" == true ]]; then

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1155,7 +1155,41 @@ class SwiftAddonStub extends EventEmitter {
       installSdk: async (subpath, version) => {
         console.log('[claude-swift] vm.installSdk() subpath=' + subpath + ' version=' + version);
         trace('vm.installSdk() subpath=' + subpath + ' version=' + version);
-        return { success: true };
+
+        // On macOS the VM handles, here we grab from CDN
+        const targetDir = path.join('/', subpath, version);
+        const targetBin = path.join(targetDir, 'claude');
+        const verifiedMarker = path.join(targetDir, '.verified');
+
+        // Skip if already installed
+        try {
+          fs.accessSync(targetBin, fs.constants.X_OK);
+          fs.accessSync(verifiedMarker);
+          trace('vm.installSdk() already installed at ' + targetBin);
+          return { success: true };
+        } catch {}
+
+        const arch = os.arch() === 'arm64' ? 'linux-arm64' : 'linux-x64';
+        const url = 'https://downloads.claude.ai/claude-code-releases/' + version + '/' + arch + '/claude.zst';
+        console.log('[claude-swift] Downloading Cowork binary from ' + url);
+        trace('vm.installSdk() downloading ' + url + ' -> ' + targetBin);
+
+        try {
+          fs.mkdirSync(targetDir, { recursive: true });
+          execFileSync('sh', ['-c', 'curl -sfL "$1" | zstd -d -o "$2"', '--', url, targetBin], {
+            timeout: 120000,
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+          fs.chmodSync(targetBin, 0o755);
+          fs.writeFileSync(verifiedMarker, '');
+          console.log('[claude-swift] Cowork binary installed at ' + targetBin);
+          trace('vm.installSdk() installed successfully');
+          return { success: true };
+        } catch (e) {
+          console.error('[claude-swift] vm.installSdk() download failed:', e.message);
+          trace('vm.installSdk() FAILED: ' + e.message);
+          return { success: false, error: e.message };
+        }
       },
 
       // Check VM download/install status
@@ -1462,7 +1496,7 @@ class SwiftAddonStub extends EventEmitter {
 
   async installSdk(subpath, version) {
     console.log('[claude-swift] installSdk() subpath=' + subpath + ' version=' + version);
-    return { success: true };
+    return this.vm.installSdk(subpath, version);
   }
 
   kill(id, signal) {

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -32,7 +32,7 @@ const { createOverrideRegistry, matchOverride, extractEipcUuid, proactivelyRegis
 // Suppress EPIPE errors on stdout/stderr (normal in piped/Electron environments)
 // and prevent them from becoming uncaught exception crash dialogs.
 function _epipeHandler(err) {
-  if (err.code === 'EPIPE') return;
+  if (err.code === 'EPIPE' || err.code === 'EBADF') return;
   throw err;
 }
 if (process.stdout && typeof process.stdout.on === 'function') {
@@ -46,7 +46,7 @@ if (process.stderr && typeof process.stderr.on === 'function') {
 const _origListeners = process.listeners('uncaughtException');
 process.removeAllListeners('uncaughtException');
 process.on('uncaughtException', (err, origin) => {
-  if (err && err.code === 'EPIPE') {
+  if (err && (err.code === 'EPIPE' || err.code === 'EBADF')) {
     // Log once, don't crash
     try { fs.appendFileSync(
       path.join(process.env.CLAUDE_LOG_DIR || '/tmp', 'epipe-suppressed.log'),


### PR DESCRIPTION
Fixes issue #97 all three items, additionally fixed a crash that surfaced from fixing item 1


Commit 1:
-Patched getHostPlatform() throw
-Patched Eo.files[platform][arch] 
-installSdk(): ELF binary from CDN works over no-op 
-launch.sh: CDN download instead of sym  link for claude-code/ and claude-code-vm/ *doesn't touch your claude code install just the expected one from cowork*
-launch.sh: clear V8 byte cache before launch *this does not touch session files only electron cache that was breaking people's installation on updates*

Commit 2: Split from commit 1 - i decided I was a POS for making the initial PR AUR only 

These resolve:

1. getHostPlatform() throwing linux-x64
2. Mach-O binary downloaded | launcher replaces remaining Mach-O 
3. --effort xhigh rejected | only needed the binary in claude-code-vm
4. Eo.files[linux] undefined 


Testing:

-Clean slate rm -rf ~/.config/Claude/claude-code{,-vm} | I have the same dev environment as the repo owner but I have confirmed the patches via running the install on my main driver and my sandbox pc that had no cowork install

-Ran cowork for a day after applying these fixes, applied the non AUR only ones, uninstalled, then reinstalled- my sessions stayed 

-no TypeErrors in logs, ran from terminal to monitor 

- '--doctor' reported no Mach-O warnings  

Commit 3: 

- upstream did not suppress EBADF, presented stability issues 



