### PR TITLE
install: pass --prefix to npm install -g (Debian/Ubuntu fix)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,12 +121,12 @@ install_dependencies() {
 
     if ! command_exists asar; then
         log_info "Installing @electron/asar..."
-        npm install --silent -g @electron/asar || die "Failed to install asar"
+        npm install --silent -g --prefix="$npm_prefix" @electron/asar || die "Failed to install asar"
     fi
 
     if ! command_exists electron; then
         log_info "Installing electron..."
-        npm install --silent -g electron || die "Failed to install electron"
+        npm install --silent -g --prefix="$npm_prefix" electron || die "Failed to install electron"
     fi
 
     # Verify


### PR DESCRIPTION
## Problem

On Debian/Ubuntu, `install.sh` fails at the dependency step with:

```
npm ERR! code EACCES
npm ERR! path /usr/local/lib/node_modules/@electron
npm ERR! Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/@electron'
[ERROR] Failed to install asar
```

even though the script does `npm config set prefix "$HOME/.local"` first.

## Root cause

Debian/Ubuntu ship a patched npm (9.2.0 in `apt`) that splits `prefix` and `globalprefix` into two separate config keys. `npm config set prefix` only writes `prefix`, but `npm install -g` resolves the install path from `globalprefix`, which is hardcoded to `/usr/local` by Debian's npm packaging and is not changed by the user-config write. Result: the install always targets `/usr/local/lib/node_modules` and fails with EACCES.

`npm config ls -l` from inside the script shows the split clearly:

```
; prefix = "/usr/local" ; overridden by project
prefix = "/home/smiie/.local"
globalprefix = "/usr/local"   <-- still /usr/local, ignores the override
```

## Fix

Pass `--prefix="$npm_prefix"` directly to the two `npm install -g` invocations. The flag forces the install location at command level, bypassing the `globalprefix` lookup entirely.

## Cross-distro behavior

`--prefix` is a standard, documented npm CLI flag — same semantics on every distro:

- **Debian/Ubuntu** (npm patched): forces install into `~/.local` instead of `/usr/local` — the bug fix.
- **Arch / Fedora / openSUSE / Nix** (upstream npm): `globalprefix` already tracks `prefix`, so the explicit `--prefix` is the same value the install would have used anyway. No behavior change.

In other words, the flag is a no-op where things already worked, and a fix where they didn't.

## Verification

On Debian-derived distro (PikaOS, Linux 7.0.2-pikaos), with the previous code:

```
[INFO] Installing @electron/asar...
[ERROR] Failed to install asar
```

After the change:

```
$ npm install -g --prefix=$HOME/.local @electron/asar
added 9 packages in 6s
$ ls ~/.local/bin/asar
/home/smiie/.local/bin/asar
```
