### PR TITLE
fix: OAuth claude:// callback now completes login on Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -515,7 +515,7 @@ install_stubs() {
     cp "$native_src" "$target_dir/node_modules/@ant/claude-native/index.js"
 
     # Copy frame-fix files
-    for f in frame-fix-wrapper.js frame-fix-entry.js; do
+    for f in frame-fix-wrapper.js frame-fix-entry.js protocol-forwarder.js; do
         if [[ -f "$stub_src/stubs/frame-fix/$f" ]]; then
             cp "$stub_src/stubs/frame-fix/$f" "$target_dir/$f"
         fi
@@ -642,7 +642,46 @@ case "\${1:-}" in
     --devtools) shift; export CLAUDE_DEVTOOLS=1; _warn_if_untested_asar; exec ./launch.sh "\$@" ;;
     --debug)    shift; export CLAUDE_TRACE=1; _warn_if_untested_asar; exec ./launch.sh "\$@" ;;
     --doctor)   exec ./install.sh --doctor ;;
-    --update)   shift; exec ./install.sh --update "\$@" ;;
+    --update)   shift; exec ./install.sh --update "$@" ;;
+    claude://*)
+        # Protocol handler callback (e.g. OAuth redirect from browser).
+        # Skip the full launch.sh setup — just forward the URL to the already-running
+        # instance via Electron's single-instance mechanism. The running instance has
+        # a second-instance listener that picks up the claude:// URL from argv and
+        # emits open-url. This second Electron process quits immediately after forwarding.
+        FORWARDER="$COWORK_DIR/protocol-forwarder.js"
+        if [ ! -f "$FORWARDER" ]; then
+            # Forwarder not installed yet — fall through to full launch
+            nohup bash -c 'cd "$1" && shift && exec ./launch.sh "$@"' \
+                -- "$COWORK_DIR" "$@" >> "$LOG_DIR/startup.log" 2>&1 &
+            disown
+        else
+            ELECTRON_BIN=""
+            # Prefer the raw ELF binary over the node wrapper script — the node
+            # wrapper requires 'node' in PATH which is absent in xdg-open's env.
+            if [[ -x "$HOME/.local/lib/node_modules/electron/dist/electron" ]]; then
+                ELECTRON_BIN="$HOME/.local/lib/node_modules/electron/dist/electron"
+            elif [[ -x "$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron" ]]; then
+                ELECTRON_BIN="$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron"
+            elif command -v electron >/dev/null 2>&1; then
+                ELECTRON_BIN="$(command -v electron)"
+            fi
+            if [ -n "$ELECTRON_BIN" ]; then
+                # Use the minimal protocol-forwarder.js — NOT the full asar.
+                # The full asar tries to spawn 'node' early in startup and crashes
+                # in restricted PATH environments (xdg-open, systemd activation).
+                # protocol-forwarder.js handles both cases: running instance (forwards
+                # via second-instance) and no instance (launches full app via launch.sh).
+                nohup "$ELECTRON_BIN" "$FORWARDER" "$@" >> "$LOG_DIR/startup.log" 2>&1 &
+                disown
+            else
+                # No electron binary found — fall through to full launch
+                nohup bash -c 'cd "$1" && shift && exec ./launch.sh "$@"' \
+                    -- "$COWORK_DIR" "$@" >> "$LOG_DIR/startup.log" 2>&1 &
+                disown
+            fi
+        fi
+        ;;
     *)
         _warn_if_untested_asar
         nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \\
@@ -680,13 +719,14 @@ setup_environment() {
     mkdir -p "$sessions_dir"
     chmod 700 "$data_dir"
 
-    # /sessions symlink — the asar passes VM-internal /sessions/... paths that
-    # our stub translates to host paths under this sessions directory.
+    # /sessions symlink — optional. The frame-fix-wrapper fs patch rewrites
+    # /sessions/ paths to SESSIONS_BASE at the Node.js fs layer, so the
+    # symlink is not required. Create it when possible for compatibility.
     if [[ ! -e /sessions ]]; then
-        log_info "Creating /sessions symlink (requires sudo)..."
+        log_info "Attempting /sessions symlink (optional, requires sudo)..."
         sudo ln -s "$sessions_dir" /sessions \
             && log_success "/sessions -> $sessions_dir" \
-            || log_warn "Failed to create /sessions symlink. Run manually: sudo ln -s \"$sessions_dir\" /sessions"
+            || log_info "/sessions symlink not created (optional — fs patch handles rewriting)"
     elif [[ -L /sessions ]]; then
         local current_target
         current_target=$(readlink /sessions)
@@ -901,6 +941,9 @@ doctor() {
     fi
 
     # --- /sessions symlink ---
+    # Note: the fs path redirect patch in frame-fix-wrapper.js rewrites
+    # /sessions/ paths to SESSIONS_BASE at runtime, so the symlink is
+    # optional. It's still created when possible for compatibility.
     if [[ -L /sessions ]]; then
         local target
         target=$(readlink /sessions)
@@ -910,8 +953,8 @@ doctor() {
         log_warn "/sessions exists but is a directory (should be a symlink)"
         warn=$((warn + 1))
     else
-        log_error "/sessions: NOT FOUND -- run: sudo ln -s \"\${XDG_CONFIG_HOME:-\$HOME/.config}/Claude/local-agent-mode-sessions/sessions\" /sessions"
-        fail=$((fail + 1))
+        log_warn "/sessions symlink not present (optional — fs patch handles path rewriting)"
+        warn=$((warn + 1))
     fi
 
     # --- Secret service (D-Bus) ---

--- a/install.sh
+++ b/install.sh
@@ -642,42 +642,42 @@ case "\${1:-}" in
     --devtools) shift; export CLAUDE_DEVTOOLS=1; _warn_if_untested_asar; exec ./launch.sh "\$@" ;;
     --debug)    shift; export CLAUDE_TRACE=1; _warn_if_untested_asar; exec ./launch.sh "\$@" ;;
     --doctor)   exec ./install.sh --doctor ;;
-    --update)   shift; exec ./install.sh --update "$@" ;;
+    --update)   shift; exec ./install.sh --update "\$@" ;;
     claude://*)
         # Protocol handler callback (e.g. OAuth redirect from browser).
         # Skip the full launch.sh setup — just forward the URL to the already-running
         # instance via Electron's single-instance mechanism. The running instance has
         # a second-instance listener that picks up the claude:// URL from argv and
         # emits open-url. This second Electron process quits immediately after forwarding.
-        FORWARDER="$COWORK_DIR/protocol-forwarder.js"
-        if [ ! -f "$FORWARDER" ]; then
+        FORWARDER="\$COWORK_DIR/protocol-forwarder.js"
+        if [ ! -f "\$FORWARDER" ]; then
             # Forwarder not installed yet — fall through to full launch
-            nohup bash -c 'cd "$1" && shift && exec ./launch.sh "$@"' \
-                -- "$COWORK_DIR" "$@" >> "$LOG_DIR/startup.log" 2>&1 &
+            nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \\
+                -- "\$COWORK_DIR" "\$@" >> "\$LOG_DIR/startup.log" 2>&1 &
             disown
         else
             ELECTRON_BIN=""
             # Prefer the raw ELF binary over the node wrapper script — the node
             # wrapper requires 'node' in PATH which is absent in xdg-open's env.
-            if [[ -x "$HOME/.local/lib/node_modules/electron/dist/electron" ]]; then
-                ELECTRON_BIN="$HOME/.local/lib/node_modules/electron/dist/electron"
-            elif [[ -x "$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron" ]]; then
-                ELECTRON_BIN="$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron"
+            if [[ -x "\$HOME/.local/lib/node_modules/electron/dist/electron" ]]; then
+                ELECTRON_BIN="\$HOME/.local/lib/node_modules/electron/dist/electron"
+            elif [[ -x "\$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron" ]]; then
+                ELECTRON_BIN="\$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron"
             elif command -v electron >/dev/null 2>&1; then
-                ELECTRON_BIN="$(command -v electron)"
+                ELECTRON_BIN="\$(command -v electron)"
             fi
-            if [ -n "$ELECTRON_BIN" ]; then
+            if [ -n "\$ELECTRON_BIN" ]; then
                 # Use the minimal protocol-forwarder.js — NOT the full asar.
                 # The full asar tries to spawn 'node' early in startup and crashes
                 # in restricted PATH environments (xdg-open, systemd activation).
                 # protocol-forwarder.js handles both cases: running instance (forwards
                 # via second-instance) and no instance (launches full app via launch.sh).
-                nohup "$ELECTRON_BIN" "$FORWARDER" "$@" >> "$LOG_DIR/startup.log" 2>&1 &
+                nohup "\$ELECTRON_BIN" "\$FORWARDER" "\$@" >> "\$LOG_DIR/startup.log" 2>&1 &
                 disown
             else
                 # No electron binary found — fall through to full launch
-                nohup bash -c 'cd "$1" && shift && exec ./launch.sh "$@"' \
-                    -- "$COWORK_DIR" "$@" >> "$LOG_DIR/startup.log" 2>&1 &
+                nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \\
+                    -- "\$COWORK_DIR" "\$@" >> "\$LOG_DIR/startup.log" 2>&1 &
                 disown
             fi
         fi

--- a/stubs/frame-fix/frame-fix-entry.js
+++ b/stubs/frame-fix/frame-fix-entry.js
@@ -1,4 +1,4 @@
 // Load frame fix first
 require('./frame-fix-wrapper.js');
-// Then load patched main (index.js has yukonSilver patches)
-require('./.vite/build/index.js');
+// Then load via index.pre.js (sets up logging, userData, etc.) which requires index.js itself
+require('./.vite/build/index.pre.js');

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -664,6 +664,129 @@ try {
 }
 
 // ============================================================
+// 0a. PATCH fs TO REDIRECT /sessions/ PATHS TO SESSIONS_BASE
+// ============================================================
+// The asar and our stubs use /sessions/<name>/... as the VM-internal path
+// prefix. On macOS a /sessions root symlink is created. On Linux we can't
+// always create root symlinks (immutable rootfs, no sudo). Instead, patch
+// all fs calls to rewrite /sessions/ → SESSIONS_BASE/ transparently.
+//
+// SESSIONS_BASE is resolved lazily (DIRS is created below) so we capture
+// a getter that reads from the global set during createDirs().
+(function patchFsSessionsPaths() {
+  const VM_SESSIONS_PREFIX = '/sessions/';
+
+  function rewritePath(p) {
+    if (typeof p === 'string' && p.startsWith(VM_SESSIONS_PREFIX)) {
+      // DIRS is initialised synchronously before any app code runs (line ~467).
+      // SESSIONS_BASE is set at module level after this IIFE, but because this
+      // function is only ever called at runtime (not during this IIFE), DIRS
+      // will be defined by then.
+      const base = (typeof SESSIONS_BASE !== 'undefined' ? SESSIONS_BASE : null)
+        || (global.__coworkDirs && global.__coworkDirs.claudeSessionsBase)
+        || require('path').join(
+            (process.env.XDG_CONFIG_HOME || require('path').join(require('os').homedir(), '.config')),
+            'Claude', 'local-agent-mode-sessions', 'sessions'
+          );
+      return base + '/' + p.slice(VM_SESSIONS_PREFIX.length);
+    }
+    return p;
+  }
+
+  // Wrap a single fs method whose first argument is a path.
+  function wrapFsMethod(obj, name) {
+    const orig = obj[name];
+    if (typeof orig !== 'function' || obj[name].__coworkSessionsPatched) return;
+    obj[name] = function(p, ...rest) {
+      return orig.call(this, rewritePath(p), ...rest);
+    };
+    obj[name].__coworkSessionsPatched = true;
+  }
+
+  // Path-taking fs methods (first arg is path)
+  const PATH_METHODS = [
+    'access', 'accessSync',
+    'chmod', 'chmodSync',
+    'chown', 'chownSync',
+    'copyFile', 'copyFileSync',
+    'createReadStream', 'createWriteStream',
+    'exists', 'existsSync',
+    'lchmod', 'lchmodSync',
+    'lchown', 'lchownSync',
+    'lstat', 'lstatSync',
+    'mkdir', 'mkdirSync',
+    'mkdtemp', 'mkdtempSync',
+    'open', 'openSync',
+    'opendir', 'opendirSync',
+    'readdir', 'readdirSync',
+    'readFile', 'readFileSync',
+    'readlink', 'readlinkSync',
+    'realpath', 'realpathSync',
+    'rmdir', 'rmdirSync',
+    'rm', 'rmSync',
+    'stat', 'statSync',
+    'symlink', 'symlinkSync',
+    'truncate', 'truncateSync',
+    'unlink', 'unlinkSync',
+    'utimes', 'utimesSync',
+    'watch', 'watchFile',
+    'writeFile', 'writeFileSync',
+    'appendFile', 'appendFileSync',
+  ];
+
+  for (const name of PATH_METHODS) {
+    if (typeof fs[name] === 'function') wrapFsMethod(fs, name);
+  }
+
+  // rename/renameSync take two paths
+  const origRenameForSessions = fs.rename;
+  if (origRenameForSessions && !origRenameForSessions.__coworkSessionsRenamePatched) {
+    fs.rename = function(oldPath, newPath, cb) {
+      return origRenameForSessions.call(this, rewritePath(oldPath), rewritePath(newPath), cb);
+    };
+    fs.rename.__coworkSessionsRenamePatched = true;
+  }
+  const origRenameSyncForSessions = fs.renameSync;
+  if (origRenameSyncForSessions && !origRenameSyncForSessions.__coworkSessionsRenamePatched) {
+    fs.renameSync = function(oldPath, newPath) {
+      return origRenameSyncForSessions.call(this, rewritePath(oldPath), rewritePath(newPath));
+    };
+    fs.renameSync.__coworkSessionsRenamePatched = true;
+  }
+
+  // Also patch fs/promises (async versions)
+  try {
+    const fsp = require('fs/promises') || fs.promises;
+    if (fsp) {
+      const ASYNC_PATH_METHODS = [
+        'access', 'chmod', 'chown', 'copyFile', 'lchmod', 'lchown',
+        'lstat', 'mkdir', 'mkdtemp', 'open', 'opendir', 'readdir',
+        'readFile', 'readlink', 'realpath', 'rmdir', 'rm', 'stat',
+        'symlink', 'truncate', 'unlink', 'utimes', 'writeFile', 'appendFile',
+      ];
+      for (const name of ASYNC_PATH_METHODS) {
+        if (typeof fsp[name] === 'function' && !fsp[name].__coworkSessionsPatched) {
+          const origFsp = fsp[name];
+          fsp[name] = function(p, ...rest) {
+            return origFsp.call(this, rewritePath(p), ...rest);
+          };
+          fsp[name].__coworkSessionsPatched = true;
+        }
+      }
+      if (typeof fsp.rename === 'function' && !fsp.rename.__coworkSessionsRenamePatched) {
+        const origFspRename = fsp.rename;
+        fsp.rename = function(oldPath, newPath) {
+          return origFspRename.call(this, rewritePath(oldPath), rewritePath(newPath));
+        };
+        fsp.rename.__coworkSessionsRenamePatched = true;
+      }
+    }
+  } catch (_) {}
+
+  console.log('[Sessions] fs path redirect /sessions/ → SESSIONS_BASE installed');
+})();
+
+// ============================================================
 // 0b. PATCH fs.rename TO HANDLE EXDEV ERRORS
 // ============================================================
 const originalRename = fs.rename;
@@ -923,56 +1046,17 @@ for (const sig of ['SIGTERM', 'SIGHUP', 'SIGINT']) {
 }
 
 // ============================================================
-// SINGLE-INSTANCE LOCK + PROTOCOL URL FORWARDING
-// ============================================================
-// The asar takes the macOS codepath (open-url event) because we
-// spoof darwin. But Linux doesn't have macOS's Apple Event URL
-// routing — launching claude:// URLs spawns a NEW Electron process.
-// Fix: acquire a single-instance lock ourselves. When a second
-// instance launches (e.g. from a claude:// protocol redirect after
-// Google auth), extract the URL from argv, emit 'open-url' on the
-// app (which the asar IS listening for), and quit the duplicate.
+// APP NAME — set before index.js runs so requestSingleInstanceLock() uses the
+// correct userData path (~/.config/Claude). The package.json name is @ant/desktop
+// which would produce ~/.config/@ant/desktop — wrong path, breaks single-instance.
+// The asar's index.js also calls app.setName('Claude') but only inside whenReady(),
+// which is too late for the lock. We set it here at require-time.
 try {
   const { app } = require('electron');
-  const gotLock = app.requestSingleInstanceLock();
-  if (!gotLock) {
-    // We're the second instance — the first will get 'second-instance'
-    console.log('[SingleInstance] Another instance is running, quitting');
-    app.quit();
-  } else {
-    app.on('second-instance', (_event, argv, _workingDirectory) => {
-      // Find the claude:// URL in the argv of the second instance
-      const url = argv.find(a => a.startsWith('claude://'));
-      if (url) {
-
-        try {
-          const parsed = new URL(url);
-          if (parsed.protocol !== 'claude:') {
-            console.warn('[SingleInstance] Rejected non-claude protocol URL');
-          } else if (/[<>"'`]/.test(url) || url.length > 2048) {
-            console.warn('[SingleInstance] Rejected suspicious claude:// URL');
-          } else {
-            console.log('[SingleInstance] Forwarding validated protocol URL to open-url handler');
-            app.emit('open-url', { preventDefault() {} }, url);
-          }
-        } catch (e) {
-          console.warn('[SingleInstance] Rejected malformed URL:', e.message);
-        }
-      }
-      // Focus the existing window
-      const { BrowserWindow } = require('electron');
-      const wins = BrowserWindow.getAllWindows();
-      if (wins.length > 0) {
-        const win = wins[0];
-        if (win.isMinimized()) win.restore();
-        win.show();
-        win.focus();
-      }
-    });
-    console.log('[SingleInstance] Lock acquired, protocol URL forwarding enabled');
-  }
+  if (typeof app.setName === 'function') app.setName('Claude');
+  console.log('[SingleInstance] App name set to Claude — lock will use ~/.config/Claude');
 } catch (e) {
-  console.error('[SingleInstance] Failed to set up single-instance lock:', e.message);
+  console.error('[SingleInstance] Failed to set app name:', e.message);
 }
 
 Module.prototype.require = function(id) {
@@ -1204,7 +1288,33 @@ Module.prototype.require = function(id) {
       console.log('[Frame Fix] systemPreferences patched for Linux');
     }
 
-    // Patch BrowserWindow to stub macOS-only methods and handle close events
+    // ── Intercept setAsDefaultProtocolClient ──────────────────────────
+    // On Linux, Electron's setAsDefaultProtocolClient creates/overwrites a
+    // .desktop file pointing to the raw electron binary, breaking our
+    // claude-desktop wrapper as the protocol handler. We already registered
+    // the correct claude.desktop during install. Make this a no-op so
+    // Electron doesn't clobber our registration.
+    const _app = resolveElectronApp(module);
+    if (_app && typeof _app.setAsDefaultProtocolClient === 'function' && !_app.__coworkProtocolClientPatched) {
+      _app.__coworkProtocolClientPatched = true;
+      const _origSetProtocol = _app.setAsDefaultProtocolClient.bind(_app);
+      _app.setAsDefaultProtocolClient = function(protocol, ...rest) {
+        if (REAL_PLATFORM === 'linux') {
+          console.log('[Frame Fix] Suppressed setAsDefaultProtocolClient(' + protocol + ') — using install-time claude.desktop');
+          return true;
+        }
+        return _origSetProtocol(protocol, ...rest);
+      };
+      if (typeof _app.removeAsDefaultProtocolClient === 'function') {
+        _app.removeAsDefaultProtocolClient = function(protocol) {
+          if (REAL_PLATFORM === 'linux') return true;
+          return _app.removeAsDefaultProtocolClient.__orig(protocol);
+        };
+      }
+      console.log('[Frame Fix] setAsDefaultProtocolClient patched (no-op on Linux)');
+    }
+
+
     // The asar's close handler does `if (isMac()) return;` which swallows
     // close events since we spoof darwin. We prepend a listener that forces
     // app.quit() so killactive/WM close works on all Linux DEs.

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -49,6 +49,7 @@ if (_earlyApp) {
     'updateCurrentActivity',
     'resignCurrentActivity',
     'getCurrentActivityType',
+    'configureWebAuthn',
   ];
   for (const _m of _macOnlyAppMethods) {
     if (typeof _earlyApp[_m] !== 'function') {

--- a/stubs/frame-fix/protocol-forwarder.js
+++ b/stubs/frame-fix/protocol-forwarder.js
@@ -1,0 +1,59 @@
+// protocol-forwarder.js
+// Minimal Electron entry point used ONLY when invoked with a claude:// URL.
+//
+// Two cases:
+//   1. Main app IS running: requestSingleInstanceLock() returns false → main app gets
+//      'second-instance' with our argv (including the claude:// URL) → handles it → we quit.
+//   2. Main app is NOT running: requestSingleInstanceLock() returns true → we got the lock
+//      but nobody is listening. Fall back to launching the full app via launch.sh.
+
+const { app } = require('electron');
+const fs = require('fs');
+const path = require('path');
+const { execFile } = require('child_process');
+const os = require('os');
+
+const logDir = process.env.CLAUDE_LOG_DIR ||
+  path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'claude-cowork', 'logs');
+const logFile = path.join(logDir, 'startup.log');
+
+function log(msg) {
+  const line = `[protocol-forwarder] ${msg}\n`;
+  process.stdout.write(line);
+  try { fs.appendFileSync(logFile, line); } catch (_) {}
+}
+
+log(`started, argv: ${process.argv.slice(2).join(' ')}`);
+
+// Must match the app name set in frame-fix-wrapper.js before requestSingleInstanceLock(),
+// so both processes use the same userData path (~/.config/Claude/SingletonLock).
+app.setName('Claude');
+log(`userData: ${app.getPath('userData')}`);
+
+const gotLock = app.requestSingleInstanceLock();
+log(`requestSingleInstanceLock() returned: ${gotLock}`);
+
+if (!gotLock) {
+  // Main app is running and received 'second-instance' with our argv. Done.
+  log('main app is running — forwarded via second-instance, quitting');
+  app.quit();
+} else {
+  // No running instance. Launch the full app with the claude:// URL in argv
+  // so frame-fix-wrapper.js can emit it via open-url once the asar is ready.
+  log('no running instance — launching full app with URL');
+  app.releaseSingleInstanceLock();
+
+  const coworkDir = process.env.COWORK_DIR ||
+    path.join(os.homedir(), '.local', 'share', 'claude-desktop');
+  const launchSh = path.join(coworkDir, 'launch.sh');
+  const url = process.argv.find(a => a.startsWith('claude://')) || '';
+
+  log(`launching: bash ${launchSh} ${url}`);
+  execFile('bash', [launchSh, url], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env },
+  }).unref();
+
+  app.quit();
+}


### PR DESCRIPTION
## What does this change?

**NOTE:** This was fully generated by Claude. It did not work out of the box on  [Bluefin](https://projectbluefin.io/) as the root of the drive is RO and it could not create the `/sessions` to mirror the OSX structure.

After getting it up and running, it'd launch - but there were a lot of issues with the auth-flow callback not working correctly.  After awhile of iterating and testing it now works without issue.

The below  description is generated from Claude:

Three bugs prevented the auth flow from working:

1. The claude-desktop protocol handler was running launch.sh for claude:// callbacks, which repacks the asar using 'npx asar' (needs node in PATH). xdg-open invokes handlers with a restricted PATH where node isn't present, so the repack failed with 'env: node: No such file or directory' and the Electron process died before requestSingleInstanceLock() could run.

2. frame-fix-wrapper.js called requestSingleInstanceLock() before index.js, but with app name '@ant/desktop' (from package.json) instead of 'Claude'. This put the lock at ~/.config/@ant/desktop while index.js put its own lock at ~/.config/Claude — two different locks, so second-instance never fired. index.js's lock call returned false and it called app.quit(), killing the app.

3. The electron wrapper at ~/.local/bin/electron is a Node.js script that also requires node in PATH. The forwarder was invoking it via the wrapper.

Fixes:
- Add protocol-forwarder.js: minimal Electron entry that only calls requestSingleInstanceLock() to trigger second-instance on the running app, then quits. Falls back to launching the full app via launch.sh if no instance is running (handles the race where the user starts auth before launching app).
- Remove requestSingleInstanceLock() from frame-fix-wrapper.js entirely — the asar's own lock+handler in index.js already handles second-instance correctly, including forwarding claude:// URLs to the claudeURLHandler (bEe/fCA).
- Call app.setName('Claude') in frame-fix-wrapper.js before index.js runs, so index.js's requestSingleInstanceLock() uses ~/.config/Claude (correct path).
- Use the raw ELF electron binary (~/.local/lib/node_modules/electron/dist/electron) instead of the node wrapper script when spawning the forwarder from the claude-desktop protocol handler — no node in PATH required.


## Type

- [x] Bug fix
- [x] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing


- Distro / desktop: [Bluefin](https://projectbluefin.io/)
- Tested with `./install.sh --doctor`: yes
- Tested a full Cowork session: yes

## Security impact

<!-- If this touches filterEnv, spawn, AuthRequest, isPathSafe, or any credential handling:
     describe the impact and confirm it aligns with OAUTH-COMPLIANCE.md. -->

- [ ] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code — explanation below:

Please see the above message

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ x] `./install.sh --doctor` passes cleanly on my system

