### PR TITLE
Add linux branch to getHostPlatform() — fixes ClaudeCode.prepare on Linux

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -173,6 +173,16 @@ JSEOF
         echo "WARN: file:// preload patch skipped (target not found)"
     fi
 
+    # Add linux branch to getHostPlatform() (without this, the minified
+    # platform switch throws "Unsupported platform: linux-x64" and the
+    # ClaudeCode.prepare IPC fails -- Cowork tasks fail in the UI with a
+    # generic "Something went wrong" banner).
+    if grep -q 'win32-arm64":"win32-x64";throw new Error' "$_indexjs"; then
+        sed -i 's|win32-arm64":"win32-x64";throw new Error|win32-arm64":"win32-x64";if(process.platform==="linux")return A==="arm64"?"linux-arm64":"linux-x64";throw new Error|' "$_indexjs"
+    else
+        echo "WARN: linux-x64 platform patch skipped (target not found)"
+    fi
+
     # Duplicate i18n JSONs into resources/i18n/ (bundle reads from both paths).
     if ls "${_ext}/resources/"*.json >/dev/null 2>&1; then
         mkdir -p "${_ext}/resources/i18n"


### PR DESCRIPTION
## Summary

The bundled main process's `getHostPlatform()` function (in `.vite/build/index.js`) currently has branches for `darwin` and `win32` only, then `throw new Error(\`Unsupported platform: ${process.platform}-${A}\`)`. On Linux this fires whenever `ClaudeCode.prepare` is called over IPC, and the Cowork UI surfaces it as a generic "Something went wrong" banner the first time the user sends a message in a task — blocking the feature outright for every Linux x86_64 user.

This PR adds a one-line patch to `build()` that inserts a `linux` case before the throw, mirroring the existing macOS/Windows branches:

```diff
-    throw new Error(`Unsupported platform: ${process.platform}-${A}`)
+    if (process.platform === "linux") return A === "arm64" ? "linux-arm64" : "linux-x64";
+    throw new Error(`Unsupported platform: ${process.platform}-${A}`)
```

The `sed` is anchored on `win32-arm64":"win32-x64";throw new Error` — literal platform strings, not minified identifiers, so the anchor should survive upstream Mac asar rebuilds (the variable name `A` may eventually drift; the maintainer can re-derive then).

It uses the same `if grep -q ... sed ... else WARN` shape as the other patches in this block (titlebar, file:// preload), so a future asar that no longer needs it will surface a clear `WARN: ... target not found` line at build time rather than failing the build.

## Verified

- Distro: Arch Linux (CachyOS)
- DE: KDE on Wayland
- electron: 41.5.0
- pkgver after build: 1.5354.0
- Built with `yay -S claude-cowork-linux` (with this patch applied locally to the AUR PKGBUILD).
- Before patch: sending a Cowork test message produces `Error: Unsupported platform: linux-x64` in the renderer; UI shows "Something went wrong" with details "Unsupported platform: linux-x64".
- After patch: Cowork tasks run end-to-end. Verified bash invocation (`run pwd && ls -la && git status`), file edits in the configured working folder, and the Code tab.

## Related (not in this PR)

There's a similar `Cannot read properties of undefined (reading 'x64')` warning from `ClaudeVM.getDownloadStatus` that appears in the main log and stderr. Same class of bug — a manifest object keyed by platform that's missing a `linux:` key — but it does **not** block Cowork because the Linux flow runs in host mode rather than VM mode (`vm_bundles/claudevm.bundle/` files are stub-sized). Worth fixing eventually but out of scope here.

## Test plan

- [x] `yay -S claude-cowork-linux` (AUR build with patch applied) installs cleanly
- [x] App launches and main window renders
- [x] Cowork tab loads and tasks accept messages
- [x] First message in a task no longer triggers "Unsupported platform" error
- [x] Bash command execution inside Cowork task works
- [x] File creation in working folder works
- [x] Code tab opens and accepts a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)