### PR TITLE
fix(frame-fix): stub macOS-only app activity APIs on Linux

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -31,6 +31,22 @@ if (typeof systemPreferences.getUserDefault !== 'function') {
   };
 }
 
+// Patch macOS-only app activity methods that don't exist on Linux.
+// frame-fix spoofs process.platform to 'darwin', so app code gated by
+// `process.platform === "darwin"` will call these on Linux. Without
+// stubs the main process crashes with "X is not a function".
+const { app } = require('electron');
+if (typeof app.invalidateCurrentActivity !== 'function') {
+  app.invalidateCurrentActivity = function() {
+    // no-op on Linux
+  };
+}
+if (typeof app.setUserActivity !== 'function') {
+  app.setUserActivity = function(type, userInfo, webpageURL) {
+    // no-op on Linux
+  };
+}
+
 // Inject frame fix and Cowork support before main app loads
 const Module = require('module');
 const originalRequire = Module.prototype.require;


### PR DESCRIPTION
## Summary

After updating to commit `1b8df05` (asar v1.569.0 compat), the app crashes
with `TypeError: CA.app.invalidateCurrentActivity is not a function` on
session navigation and any deeplink that resolves to a session route.

This is the same class of bug that #66 / `97fbe53` fixed for
`systemPreferences.setUserDefault` — a macOS-only Electron API called
from the asar under spoofed `darwin`. Applying the same stub pattern.

## Root cause

The bundled main process contains:

```js
function Vir(e){
  if(process.platform==="darwin"){
    if(!Jir()||!e){
      CA.app.invalidateCurrentActivity();
      return
    }
    CA.app.setUserActivity(Hir,{v:Kir,sessionId:e})
  }
}
```

`Vir()` is called from the URL/deeplink router (`wOn`) on every
`webContents` navigation. It's gated by `process.platform === "darwin"`
which would skip on a real Linux Electron — but `frame-fix-wrapper`
spoofs `process.platform` to `'darwin'` for app code, so this branch
runs on Linux and hits the missing `app.*` methods.

Both `app.invalidateCurrentActivity()` and `app.setUserActivity()` are
documented as macOS-only in the Electron API.

## Stack trace (for searchability)

\`\`\`
A JavaScript error occurred in the main process
Uncaught Exception:
TypeError: CA.app.invalidateCurrentActivity is not a function
  at Vir (.../app.asar/.vite/build/index.js:6337:9884)
  at wOn (.../app.asar/.vite/build/index.js:6337:10198)
  at t  (.../app.asar/.vite/build/index.js:7031:16971)
  at WebContents.<anonymous> (.../app.asar/.vite/build/index.js:7031:17067)
  at WebContents.emit (node:events:520:35)
\`\`\`

## Fix

Stub both methods as no-ops at module load, immediately after the
\`systemPreferences\` block from #67. 16 lines, single file. Pattern
mirrors \`97fbe53\` exactly so future macOS-only API regressions follow
a consistent template.

## Test plan

- [x] \`node --test tests/node/current-path/*.test.cjs\` — 403 pass, 0 fail
- [x] \`node --check stubs/frame-fix/frame-fix-wrapper.js\` — syntax OK
- [x] Manually verified on Linux Mint / X11 (Cinnamon, PipeWire): clicking session entries that previously triggered the dialog now navigates cleanly; no regressions in normal navigation, login, or \`--doctor\` (17 passed, 1 unrelated PATH warn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)