### PR TITLE
feat: rails + recovery -- restore manual permission flow, explicit update flow, COMPAT.md matrix

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -1,0 +1,68 @@
+# Compatibility
+
+This file tracks which Claude Desktop asar versions have been verified
+to work with claude-cowork-linux. `install.sh` and the launcher grep the
+machine-readable lines below; the table further down is for humans.
+
+<!-- machine-readable; do not remove the next two lines -->
+<!-- LAST_TESTED_ASAR_VERSION=1.6259.1 -->
+<!-- LAST_TESTED_DATE=2026-05-14 -->
+
+## Tested versions
+
+| Asar     | Status     | Date       | Notes                                                |
+|:---------|:-----------|:-----------|:-----------------------------------------------------|
+| 1.6259.1 | [OK]       | 2026-05-14 | v5.1.0 baseline. Activity stubs and bridge rails verified via test suite. |
+| 1.6608.2 | [PARTIAL]  | 2026-05-07 | `/setup-cowork` reports "Unsupported platform: linux-x64" -- see issue #114. |
+| 1.6700.0 | [UNTESTED] | -          | Not yet exercised by any contributor.                |
+
+Status legend:
+
+- `[OK]`       -- end-to-end exercised, ships clean.
+- `[PARTIAL]`  -- launches and most features work, but at least one known regression. See Notes.
+- `[FAIL]`     -- known to be broken; do not update to this version.
+- `[UNTESTED]` -- no contributor has reported results.
+
+## Reporting a tested version
+
+Open a PR that bumps `LAST_TESTED_ASAR_VERSION` (the HTML comment line
+above) and adds a row to the table. In the PR body, include:
+
+1. Distro and desktop environment (e.g. "Arch Linux + Hyprland (Wayland)").
+2. Electron version (`electron --version` from your install).
+3. Which features you exercised:
+   - First-run install via `install.sh`
+   - Login via the `claude://` OAuth callback
+   - Cowork session start with a tool permission prompt
+   - In-app shell / PTY panel
+   - At least one MCP tool call
+
+Reports that only confirm "the app launches" are useful but should be
+flagged with `[PARTIAL]` until a fuller exercise is recorded.
+
+## Why this file exists
+
+`install.sh` no longer auto-downloads the latest Claude Desktop asar
+without prompting. The installer reads `LAST_TESTED_ASAR_VERSION` from
+this file, fetches the latest version available on Anthropic's CDN, and
+warns if the latest is newer than the last tested. The user decides
+whether to proceed.
+
+The launcher (`claude-desktop`, `claude-cowork`) reads the installed
+asar version from `$INSTALL_DIR/.installed-asar-version` (written by
+`install.sh` at the end of install/update) and prints a `[WARN]` line
+to stderr if the installed version is newer than the last tested. The
+warning fires once per version change -- after the user sees it once,
+they will not see it again for the same installed asar.
+
+To re-trigger the warning manually, delete
+`$XDG_STATE_HOME/claude-cowork/logs/.last-warned-asar-version`.
+
+## See also
+
+- README.md "Recovery" section for what to do if your install breaks
+  after an update.
+- `install.sh --doctor` reports the installed-vs-tested version state
+  as an `[OK]` or `[WARN]` line.
+- `claude-desktop --update` re-runs the download/extract/repack flow
+  with the same prompt as a fresh install.

--- a/README.md
+++ b/README.md
@@ -86,14 +86,16 @@ Run `./install.sh --doctor` (or `claude-desktop --doctor`) after install to vali
 ```bash
 git clone https://github.com/johnzfitch/claude-cowork-linux.git
 cd claude-cowork-linux
-./install.sh          # auto-downloads the latest DMG via Node.js
+./install.sh          # prompts before downloading the Claude Desktop asar
 claude-desktop
 ```
+
+The installer prompts before downloading the Claude Desktop asar so you can confirm the version. See [COMPAT.md](COMPAT.md) for the tested-versions matrix. Pass `--force` (or `--yes`) to skip the prompt for scripted installs.
 
 ### Method 2: AUR (Arch Linux)
 
 ```bash
-yay -S claude-cowork-linux       # auto-downloads the latest DMG
+yay -S claude-cowork-linux
 ```
 
 ### Method 3: curl pipe
@@ -102,13 +104,27 @@ yay -S claude-cowork-linux       # auto-downloads the latest DMG
 bash <(curl -fsSL https://raw.githubusercontent.com/johnzfitch/claude-cowork-linux/master/install.sh)
 ```
 
-The installer automatically downloads the latest Claude Desktop DMG using Node.js (`scripts/fetch-dmg.js`). You can also provide a DMG manually:
+Piped (non-interactive) installs refuse to download without an explicit confirmation flag. Use:
+
+```bash
+bash <(curl -fsSL .../install.sh) --force
+```
+
+You can also provide an archive manually:
 
 ```bash
 ./install.sh ~/Downloads/Claude-*.dmg
 # or
-CLAUDE_DMG=~/Downloads/Claude-1.1.4010.dmg ./install.sh
+CLAUDE_ARCHIVE=~/Downloads/Claude-1.6259.1.dmg ./install.sh
 ```
+
+### Updating
+
+```bash
+claude-desktop --update          # re-fetch and repack with prompt
+```
+
+The launcher prints a `[WARN]` line once if your installed asar is newer than the last tested version listed in [COMPAT.md](COMPAT.md). To dismiss the warning permanently for the current version, just keep using the app -- it only fires once per asar version change.
 
 > [!IMPORTANT]
 > This repo does not include Anthropic's proprietary code. The installer downloads it directly from Anthropic's CDN.
@@ -421,6 +437,68 @@ npm install -g electron @electron/asar
 ```
 
 </details>
+
+---
+
+## Recovery
+
+If your install was working and then stopped after an update, the upstream
+asar likely changed in a way claude-cowork-linux has not yet caught up to.
+Two recovery paths:
+
+### Option 1: roll back to the last tested asar
+
+The installer reads `LAST_TESTED_ASAR_VERSION` from [COMPAT.md](COMPAT.md)
+and prompts before downloading. To roll back:
+
+```bash
+cd ~/.local/share/claude-desktop
+git pull
+
+# Wipe cached chromium artifacts (preserves your sessions and credentials):
+rm -rf ~/.config/Claude/Cache \
+       "~/.config/Claude/Code Cache" \
+       ~/.config/Claude/GPUCache \
+       ~/.config/Claude/DawnGraphiteCache
+
+# Reinstall:
+bash install.sh --force
+```
+
+When the prompt offers to download an untested version, decline and supply
+the last-tested archive manually:
+
+```bash
+CLAUDE_ARCHIVE=/path/to/Claude-<last-tested>.dmg bash install.sh --force
+```
+
+### Option 2: stay on your current install, wait for a fix
+
+The launcher prints a `[WARN]` line on the first launch after an untested
+version is installed. If the warning appears and the app is broken for
+you, the issue is likely already being tracked. Search the open issues at
+<https://github.com/johnzfitch/claude-cowork-linux/issues> for the asar
+version in the warning.
+
+To update later once a fix is published:
+
+```bash
+claude-desktop --update
+```
+
+You will be prompted before the new asar is downloaded.
+
+### Diagnostics
+
+```bash
+claude-desktop --doctor
+```
+
+Reports the installed-vs-tested asar versions plus the rest of the
+preflight checks. An `[OK] Asar version: X (matches last tested)` line
+means you are on the verified baseline. A `[WARN] Asar version: X (newer
+than last tested Y -- see COMPAT.md)` line means you are ahead of the
+matrix.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,46 @@ detect_pkg_manager() {
 }
 
 # ============================================================
+# Compatibility helpers (COMPAT.md)
+# ============================================================
+#
+# install.sh and the launcher grep machine-readable lines from
+# COMPAT.md to find the last tested asar version. The user chooses
+# whether to install a newer (untested) version when prompted.
+
+compat_read_last_tested() {
+    # Reads LAST_TESTED_ASAR_VERSION from the given COMPAT.md (or the
+    # one next to this script if no argument given). Falls back to a
+    # baked-in default if the file is missing.
+    local compat_file="${1:-}"
+    if [[ -z "$compat_file" ]]; then
+        compat_file="$(dirname "$0")/COMPAT.md"
+    fi
+    if [[ -f "$compat_file" ]]; then
+        local value
+        value=$(grep -oE '^<!-- LAST_TESTED_ASAR_VERSION=[^[:space:]]+ -->$' "$compat_file" \
+            | head -1 | sed -E 's/.*=([^[:space:]]+) -->/\1/')
+        if [[ -n "$value" ]]; then
+            printf '%s' "$value"
+            return 0
+        fi
+    fi
+    # Baked-in fallback so a malformed/missing COMPAT.md never blocks install.
+    printf '1.6259.1'
+}
+
+compat_version_is_newer() {
+    # Returns 0 (true) if $1 > $2 by semver-ish ordering (sort -V).
+    # Returns 1 otherwise (equal or older).
+    local a="$1" b="$2"
+    [[ -z "$a" || -z "$b" ]] && return 1
+    [[ "$a" == "$b" ]] && return 1
+    local newer
+    newer=$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n1)
+    [[ "$newer" == "$a" ]]
+}
+
+# ============================================================
 # Step 1: Dependencies
 # ============================================================
 
@@ -290,12 +330,62 @@ get_archive() {
         return 0
     fi
 
-    # 2. Auto-download via Node.js (Homebrew cask API)
+    # 2. Prompt before downloading. The user picks whether to fetch
+    #    the latest available version (which may be untested) or to
+    #    abort and supply a specific version via CLAUDE_ARCHIVE.
     if command_exists node; then
-        if fetch_archive_via_node "$archive_path"; then
-            return 0
+        local last_tested
+        last_tested=$(compat_read_last_tested "$script_dir/COMPAT.md")
+        local latest_version=""
+        if [[ -f "$script_dir/fetch-dmg.js" ]]; then
+            local json
+            json=$(node "$script_dir/fetch-dmg.js" --json 2>/dev/null) || true
+            if [[ -n "$json" ]]; then
+                latest_version=$(printf '%s' "$json" \
+                    | node -e "process.stdin.on('data',d=>{try{process.stdout.write(JSON.parse(d).version||'')}catch{}})" \
+                    2>/dev/null)
+            fi
         fi
-        log_warn "Auto-download failed"
+
+        echo ""
+        log_info "Last tested asar:  $last_tested  (see COMPAT.md)"
+        if [[ -n "$latest_version" ]]; then
+            log_info "Latest on CDN:     $latest_version"
+            if compat_version_is_newer "$latest_version" "$last_tested"; then
+                log_warn "Latest is newer than the last tested version."
+                log_warn "Untested versions may break features. Review COMPAT.md first."
+            fi
+        fi
+
+        local proceed=0
+        if [[ "${INSTALL_FORCE:-0}" -eq 1 ]]; then
+            proceed=1
+        elif [[ ! -t 0 ]]; then
+            # Non-interactive (piped) install: refuse without --force to
+            # avoid silently downloading an untested upstream.
+            log_error "Non-interactive install requires --force (or --yes) to confirm download."
+            log_error "Re-run as: bash install.sh --force"
+            die "Aborting: no confirmation possible"
+        else
+            local prompt_target="${latest_version:-the latest available version}"
+            echo -n "  Download Claude Desktop ${prompt_target}? [y/N] "
+            local reply
+            read -r reply
+            case "$reply" in
+                y|Y|yes|YES) proceed=1 ;;
+                *) proceed=0 ;;
+            esac
+        fi
+
+        if [[ "$proceed" -eq 1 ]]; then
+            if fetch_archive_via_node "$archive_path"; then
+                return 0
+            fi
+            log_warn "Auto-download failed"
+        else
+            log_info "Download declined. To use a specific version, set CLAUDE_ARCHIVE=/path/to/Claude.zip"
+            die "Install aborted by user"
+        fi
     fi
 
     # 3. Scan common locations, then prompt user to download if needed
@@ -450,6 +540,40 @@ install_stubs() {
 }
 
 # ============================================================
+# Version sentinel
+# ============================================================
+#
+# Write the installed asar version to $INSTALL_DIR/.installed-asar-version
+# so the launcher can compare it against COMPAT.md without re-parsing the
+# bundled package.json on every launch.
+
+seed_version_sentinel() {
+    local sentinel="$INSTALL_DIR/.installed-asar-version"
+    local pkg="$INSTALL_DIR/linux-app-extracted/package.json"
+    if [[ ! -f "$pkg" ]]; then
+        log_warn "package.json not found at $pkg; cannot seed version sentinel"
+        return 0
+    fi
+    if ! command_exists node; then
+        # Fallback: extract via grep. Less reliable but works without node.
+        local v
+        v=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$pkg" \
+            | head -1 | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+        if [[ -n "$v" ]]; then
+            printf '%s\n' "$v" > "$sentinel"
+            log_success "Version sentinel: $v (via grep fallback)"
+        fi
+        return 0
+    fi
+    local v
+    v=$(node -e "try{process.stdout.write(require('$pkg').version||'')}catch{}" 2>/dev/null)
+    if [[ -n "$v" ]]; then
+        printf '%s\n' "$v" > "$sentinel"
+        log_success "Version sentinel: $v"
+    fi
+}
+
+# ============================================================
 # Step 6: Apply patches
 # ============================================================
 
@@ -484,7 +608,7 @@ create_launcher() {
 
     cat > "$HOME/.local/bin/claude-desktop" << EOF
 #!/bin/bash
-# Claude Desktop for Linux — launcher
+# Claude Desktop for Linux -- launcher
 # Generated by install.sh v$VERSION
 
 COWORK_DIR="${INSTALL_DIR}"
@@ -495,12 +619,33 @@ mkdir -p "\$LOG_DIR"
 
 cd "\$COWORK_DIR"
 
+# Asar version vs COMPAT.md: warn once per version mismatch.
+_warn_if_untested_asar() {
+    local installed last_tested last_warned newer
+    installed=\$(cat "\$COWORK_DIR/.installed-asar-version" 2>/dev/null | tr -d '[:space:]')
+    [[ -z "\$installed" ]] && return 0
+    last_tested=\$(grep -oE '^<!-- LAST_TESTED_ASAR_VERSION=[^[:space:]]+ -->\$' \\
+        "\$COWORK_DIR/COMPAT.md" 2>/dev/null | head -1 \\
+        | sed -E 's/.*=([^[:space:]]+) -->/\\1/')
+    [[ -z "\$last_tested" || "\$installed" == "\$last_tested" ]] && return 0
+    newer=\$(printf '%s\\n%s\\n' "\$last_tested" "\$installed" | sort -V | tail -n1)
+    [[ "\$newer" != "\$installed" ]] && return 0
+    last_warned=\$(cat "\$LOG_DIR/.last-warned-asar-version" 2>/dev/null | tr -d '[:space:]')
+    [[ "\$last_warned" == "\$installed" ]] && return 0
+    printf >&2 '\\n[WARN] Installed asar %s is newer than last tested %s.\\n' "\$installed" "\$last_tested"
+    printf >&2 '[WARN] Some features may break. See COMPAT.md before reporting bugs:\\n'
+    printf >&2 '[WARN]   https://github.com/johnzfitch/claude-cowork-linux/blob/master/COMPAT.md\\n\\n'
+    printf '%s\\n' "\$installed" > "\$LOG_DIR/.last-warned-asar-version"
+}
+
 case "\${1:-}" in
-    --devtools) shift; export CLAUDE_DEVTOOLS=1; exec ./launch.sh "\$@" ;;
-    --debug)    shift; export CLAUDE_TRACE=1; exec ./launch.sh "\$@" ;;
+    --devtools) shift; export CLAUDE_DEVTOOLS=1; _warn_if_untested_asar; exec ./launch.sh "\$@" ;;
+    --debug)    shift; export CLAUDE_TRACE=1; _warn_if_untested_asar; exec ./launch.sh "\$@" ;;
     --doctor)   exec ./install.sh --doctor ;;
+    --update)   shift; exec ./install.sh --update "\$@" ;;
     *)
-        nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \
+        _warn_if_untested_asar
+        nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \\
             -- "\$COWORK_DIR" "\$@" >> "\$LOG_DIR/startup.log" 2>&1 &
         disown
         ;;
@@ -780,6 +925,30 @@ doctor() {
         warn=$((warn + 1))
     fi
 
+    # --- Asar version vs last tested ---
+    local sentinel="$INSTALL_DIR/.installed-asar-version"
+    local last_tested
+    last_tested=$(compat_read_last_tested "$INSTALL_DIR/COMPAT.md")
+    if [[ -f "$sentinel" ]]; then
+        local installed
+        installed=$(head -n1 "$sentinel" | tr -d '[:space:]')
+        if [[ -n "$installed" && -n "$last_tested" ]]; then
+            if compat_version_is_newer "$installed" "$last_tested"; then
+                log_warn "Asar version: $installed (newer than last tested $last_tested -- see COMPAT.md)"
+                warn=$((warn + 1))
+            elif [[ "$installed" == "$last_tested" ]]; then
+                log_success "Asar version: $installed (matches last tested)"
+                ok=$((ok + 1))
+            else
+                log_success "Asar version: $installed (older than last tested $last_tested)"
+                ok=$((ok + 1))
+            fi
+        fi
+    else
+        log_warn "Asar version sentinel not found; run install.sh to seed it"
+        warn=$((warn + 1))
+    fi
+
     # --- Extracted app ---
     local app_dir="${INSTALL_DIR}/linux-app-extracted"
     if [[ -d "$app_dir/.vite/build" ]]; then
@@ -844,11 +1013,15 @@ doctor() {
 
 main() {
     local archive_arg=""
+    local update_only=0
     for arg in "$@"; do
         case "$arg" in
             --doctor)
                 doctor
                 exit $?
+                ;;
+            --update)
+                update_only=1
                 ;;
             --force|--yes)
                 INSTALL_FORCE=1
@@ -886,12 +1059,31 @@ main() {
     setup_repo
     echo ""
 
+    # --update flow: re-fetch the asar, re-extract, re-apply stubs and
+    # patches, re-seed the version sentinel. Skip launcher/env/icon
+    # setup (already in place from the original install).
+    if [[ "$update_only" -eq 1 ]]; then
+        local archive_path="$WORK_DIR/Claude.archive"
+        get_archive "$archive_path"
+        echo ""
+        extract_archive "$archive_path"
+        echo ""
+        install_stubs
+        echo ""
+        apply_patches
+        echo ""
+        seed_version_sentinel
+        echo ""
+        log_info "Update complete. Restart claude-desktop to pick up the new asar."
+        exit 0
+    fi
+
     # Step 3: Get Claude archive (ZIP or DMG)
     local archive_path="$WORK_DIR/Claude.archive"
     get_archive "$archive_path"
     echo ""
 
-    # Step 4: Extract archive → linux-app-extracted/
+    # Step 4: Extract archive -> linux-app-extracted/
     extract_archive "$archive_path"
     echo ""
 
@@ -915,6 +1107,10 @@ main() {
     setup_icon
     echo ""
 
+    # Step 9b: Seed version sentinel for COMPAT.md launcher warnings
+    seed_version_sentinel
+    echo ""
+
     # Step 10: Preflight validation
     log_info "Running post-install checks..."
     doctor || true
@@ -932,10 +1128,17 @@ main() {
     echo "  claude-desktop --debug      Enable trace logging"
     echo "  claude-desktop --devtools   Open with DevTools"
     echo "  claude-desktop --doctor     Run preflight diagnostics"
-    echo "  bash install.sh --force     Skip confirmation before replacing old installs"
+    echo "  claude-desktop --update     Re-fetch the Claude Desktop asar"
+    echo "  bash install.sh --force     Skip the download confirmation prompt"
     echo ""
     echo "Update:"
-    echo "  cd $INSTALL_DIR && git pull && bash install.sh"
+    echo "  claude-desktop --update                    (preferred)"
+    echo "  cd $INSTALL_DIR && git pull && bash install.sh --update"
+    echo ""
+    echo "Compatibility:"
+    echo "  See COMPAT.md for the tested asar versions matrix."
+    echo "  The launcher prints a [WARN] line once if your installed"
+    echo "  asar is newer than the last tested version."
     echo ""
     echo "Installed: $INSTALL_DIR"
     echo "Logs:      \${XDG_STATE_HOME:-~/.local/state}/claude-cowork/logs/startup.log"

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -44,6 +44,7 @@ const {
   validateMountName,
   validateRelativePathWithinHome,
 } = require('../../../../cowork/dirs.js');
+const { isMountRootTooBroad } = require('../../../../cowork/mount_root_bound.js');
 const { createSessionStore } = require('../../../../cowork/session_store.js');
 const { createSessionsApi } = require('../../../../cowork/sessions_api.js');
 const { createSessionOrchestrator } = require('../../../../cowork/session_orchestrator.js');
@@ -411,6 +412,25 @@ function createMountSymlinks(sessionName, additionalMounts) {
     trace('  Relative path: "' + relativePath + '"');
     trace('  Host path: ' + hostPath);
     trace('  Mount point: ' + mountPoint);
+
+    // Phase 3: refuse mount roots that are too broad to bound the agent.
+    // Rules: not $HOME, not '/', not shallower than three path segments.
+    // The user picks the boundary by picking cwd; the wrapper enforces a
+    // sensible default. See stubs/cowork/mount_root_bound.js.
+    if (isMountRootTooBroad(hostPath, _homedir)) {
+      trace('  REJECTED: mount root too broad — Cowork refuses sessions rooted at $HOME or shallower than 3 path segments. Pick a project subdirectory.');
+      failedMounts.push(mountName);
+      try {
+        const { Notification } = require('electron');
+        if (Notification && typeof Notification.isSupported === 'function' && Notification.isSupported()) {
+          new Notification({
+            title: 'Cowork session refused',
+            body: 'Selected folder is too broad to use as a session root. Pick a project subdirectory.',
+          }).show();
+        }
+      } catch (_) {}
+      continue;
+    }
 
     // Verify host path exists
     if (!fs.existsSync(hostPath)) {

--- a/stubs/cowork/auto_permissions_cap.js
+++ b/stubs/cowork/auto_permissions_cap.js
@@ -1,0 +1,73 @@
+'use strict';
+
+// ============================================================
+// Auto-permissions toggle TTL cap (Phase 2)
+// ============================================================
+// The asar exposes two preference toggles that skip permission prompts:
+//   - autoPermissionsModeEnabled
+//   - bypassPermissionsModeEnabled
+// Both default to false and have no built-in TTL. This module wraps the
+// AppPreferences_$_setPreference IPC handler so flipping either to true
+// schedules an auto-revert to false after CAP_MS wall-clock.
+//
+// Rails not barriers: this is an opinionated default. The user can edit
+// DEFAULT_CAP_MS (or pass capMs to createAutoPermissionsCap) for a
+// different policy, or remove the cap entirely if their threat model
+// differs. The wrapper does not enforce against the user — it bounds
+// drift in upstream defaults across a multi-week shipping cadence.
+//
+// Closure-private state: no exports of state-setting functions. Each
+// call to createAutoPermissionsCap() returns its own closure with its
+// own timers. Timers reset on process exit (no persistence).
+
+const DEFAULT_CAP_MS = 60 * 60 * 1000;
+
+function createAutoPermissionsCap({ capMs = DEFAULT_CAP_MS, log = console.log } = {}) {
+  let _setPreferenceHandler = null;
+  let _capturedSender = null;
+  const _capTimers = {
+    autoPermissionsModeEnabled: null,
+    bypassPermissionsModeEnabled: null,
+  };
+
+  function _scheduleAutoDisable(key) {
+    if (_capTimers[key]) clearTimeout(_capTimers[key]);
+    _capTimers[key] = setTimeout(() => {
+      _capTimers[key] = null;
+      if (!_setPreferenceHandler || !_capturedSender) return;
+      try {
+        const fauxEvent = { sender: _capturedSender, frameId: 0, processId: 0 };
+        Promise.resolve(_setPreferenceHandler(fauxEvent, key, false))
+          .then(() => log('[auto-permissions-cap] auto-disabled ' + key + ' after ' + (capMs / 60000) + 'min cap'))
+          .catch((e) => log('[auto-permissions-cap] auto-disable of ' + key + ' failed: ' + (e && e.message)));
+      } catch (e) {
+        log('[auto-permissions-cap] sync error scheduling auto-disable: ' + (e && e.message));
+      }
+    }, capMs);
+  }
+
+  function wrapHandler(handler) {
+    _setPreferenceHandler = handler;
+    return async function wrappedSetPreference(event, key, value) {
+      if (event && event.sender) _capturedSender = event.sender;
+      const result = await handler(event, key, value);
+      if (key in _capTimers) {
+        if (value === true) {
+          _scheduleAutoDisable(key);
+        } else if (_capTimers[key]) {
+          clearTimeout(_capTimers[key]);
+          _capTimers[key] = null;
+        }
+      }
+      return result;
+    };
+  }
+
+  function hasTimer(key) {
+    return _capTimers[key] !== null && _capTimers[key] !== undefined;
+  }
+
+  return Object.freeze({ wrapHandler, hasTimer, CAP_MS: capMs });
+}
+
+module.exports = { createAutoPermissionsCap, DEFAULT_CAP_MS };

--- a/stubs/cowork/bridge_canary.js
+++ b/stubs/cowork/bridge_canary.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// ============================================================
+// Bridge channel surface canary (Phase 4)
+// ============================================================
+// Opt-in observer that fires at IPC handler registration time when a
+// previously-unseen, bridge-related channel suffix shows up. The
+// regression alarm for "Anthropic shipped a new bridge channel between
+// releases."
+//
+// Suppress repeats per-suffix per-process. One warning, one line in
+// the canary log file, then quiet for the rest of the session.
+//
+// Enable via:
+//   CLAUDE_COWORK_IPC_TAP=1   (existing env var; turns on tap + canary)
+//   CLAUDE_COWORK_BRIDGE_CANARY=1   (canary only, no full tap)
+//
+// Known-good seed = the twelve channel suffixes the wrapper used to
+// shadow (now intentionally left to the asar's native handler). Extend
+// as new cowork-original bridge channels are audited.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const DEFAULT_KNOWN_GOOD = Object.freeze(new Set([
+  'LocalAgentModeSessions_$_abandonBridgeEnvironment',
+  'LocalAgentModeSessions_$_deleteBridgeAgentMemory',
+  'LocalAgentModeSessions_$_deleteBridgeSession',
+  'LocalAgentModeSessions_$_getBridgeConsent',
+  'LocalAgentModeSessions_$_getSessionsBridgeEnabled',
+  'LocalAgentModeSessions_$_kickBridgePoll',
+  'LocalAgentModeSessions_$_onBridgePermissionPreflight',
+  'LocalAgentModeSessions_$_resetBridge',
+  'LocalAgentModeSessions_$_resetBridgeSession',
+  'LocalAgentModeSessions_$_respondBridgePermissionPreflight',
+  'LocalAgentModeSessions_$_sessionsBridgeStatus',
+  'LocalAgentModeSessions_$_setSessionsBridgeEnabled',
+]));
+
+const BRIDGE_RE = /[Bb]ridge/;
+const SUFFIX_ANCHOR = 'LocalAgentModeSessions_$_';
+
+function isEnabledByEnv() {
+  return process.env.CLAUDE_COWORK_IPC_TAP === '1'
+      || process.env.CLAUDE_COWORK_BRIDGE_CANARY === '1';
+}
+
+function defaultLogPath() {
+  const xdgState = process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state');
+  return path.join(xdgState, 'claude-cowork', 'logs', 'bridge-canary.jsonl');
+}
+
+function extractSuffix(channel) {
+  if (typeof channel !== 'string') return null;
+  const idx = channel.lastIndexOf(SUFFIX_ANCHOR);
+  if (idx < 0) return null;
+  return channel.slice(idx);
+}
+
+function isBridgeRelated(suffix) {
+  return typeof suffix === 'string' && BRIDGE_RE.test(suffix);
+}
+
+function createBridgeCanary({
+  enabled = isEnabledByEnv(),
+  knownGood = DEFAULT_KNOWN_GOOD,
+  logPath = defaultLogPath(),
+  log = console.warn,
+  writeFn = fs.appendFileSync,
+  mkdirFn = fs.mkdirSync,
+} = {}) {
+  const seen = new Set();
+
+  function observe(channel) {
+    if (!enabled) return false;
+    const suffix = extractSuffix(channel);
+    if (!suffix) return false;
+    if (!isBridgeRelated(suffix)) return false;
+    if (knownGood.has(suffix)) return false;
+    if (seen.has(suffix)) return false;
+    seen.add(suffix);
+    const msg = '[bridge-canary] new bridge-related IPC channel observed: '
+      + suffix
+      + ' — review SECURITY.md and verify whether this should be wrapped or left to the asar\'s native handler';
+    log(msg);
+    try {
+      mkdirFn(path.dirname(logPath), { recursive: true, mode: 0o700 });
+      writeFn(logPath, JSON.stringify({ ts: new Date().toISOString(), suffix }) + '\n', { mode: 0o600 });
+    } catch (_) {}
+    return true;
+  }
+
+  return Object.freeze({ observe, enabled });
+}
+
+module.exports = {
+  createBridgeCanary,
+  DEFAULT_KNOWN_GOOD,
+  extractSuffix,
+  isBridgeRelated,
+};

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -386,67 +386,13 @@ function createOverrideRegistry(getProcessState) {
       return null;
     },
 
-    // ================================================================
-    // LocalAgentModeSessions — Dispatch/Bridge handlers
-    // ================================================================
-
-    'LocalAgentModeSessions_$_abandonBridgeEnvironment': async (_event, ...args) => {
-      vlog('[ipc:abandonBridgeEnvironment] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_deleteBridgeAgentMemory': async (_event, ...args) => {
-      vlog('[ipc:deleteBridgeAgentMemory] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_deleteBridgeSession': async (_event, ...args) => {
-      vlog('[ipc:deleteBridgeSession] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_getBridgeConsent': async (_event, ...args) => {
-      vlog('[ipc:getBridgeConsent] called');
-      return { consented: false };
-    },
-
-    'LocalAgentModeSessions_$_getSessionsBridgeEnabled': async () => {
-      return false;
-    },
-
-    'LocalAgentModeSessions_$_kickBridgePoll': async (_event, ...args) => {
-      vlog('[ipc:kickBridgePoll] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_onBridgePermissionPreflight': async (_event, ...args) => {
-      vlog('[ipc:onBridgePermissionPreflight] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_resetBridge': async (_event, ...args) => {
-      vlog('[ipc:resetBridge] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_resetBridgeSession': async (_event, ...args) => {
-      vlog('[ipc:resetBridgeSession] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_respondBridgePermissionPreflight': async (_event, ...args) => {
-      vlog('[ipc:respondBridgePermissionPreflight] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_sessionsBridgeStatus': async () => {
-      return { status: 'disconnected', enabled: false };
-    },
-
-    'LocalAgentModeSessions_$_setSessionsBridgeEnabled': async (_event, enabled) => {
-      vlog('[ipc:setSessionsBridgeEnabled] called');
-      return null;
-    },
+    // LocalAgentModeSessions — Bridge handlers are intentionally NOT overridden.
+    // The asar's LocalAgentModeSessionManager owns these; overriding them blocks
+    // the manual user-acceptance flow (Allow/Deny clicks) from reaching the
+    // bridge. Wrapper-side bounds on this flow are enforced elsewhere:
+    //   - Auto-permissions toggle TTL cap: see Phase 2 in frame-fix-wrapper.js
+    //   - Working-dir refusals: see Phase 3 in claude-swift/js/index.js
+    //   - Channel surface canary: see Phase 4 in ipc_tap.js
 
     // ================================================================
     // MCP handlers — Desktop MCP integration (not CLI MCP)

--- a/stubs/cowork/mount_root_bound.js
+++ b/stubs/cowork/mount_root_bound.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// ============================================================
+// Mount-root bound (Phase 3)
+// ============================================================
+// When the user starts a Cowork session, they pick a folder to mount
+// into the session sandbox. That folder is the agent's working-dir
+// blast radius. We refuse mount roots that are so broad the bound is
+// meaningless: $HOME itself, /, or anything shallower than three path
+// segments (e.g. /home/user, /var/tmp, /opt).
+//
+// Principle, not enumeration: no allowlist of "sensitive paths". The
+// rule covers the class — shallow roots — without naming members.
+// The user can edit the rule if their threat model differs.
+
+const path = require('path');
+const fs = require('fs');
+
+function isMountRootTooBroad(hostPath, homedir) {
+  if (typeof hostPath !== 'string' || hostPath.length === 0) return true;
+  if (hostPath === homedir) return true;
+  if (hostPath === '/') return true;
+  let resolved;
+  try {
+    resolved = path.resolve(fs.realpathSync(hostPath));
+  } catch (_) {
+    resolved = path.resolve(hostPath);
+  }
+  const segments = resolved.split(path.sep).filter(Boolean);
+  return segments.length < 3;
+}
+
+module.exports = { isMountRootTooBroad };

--- a/stubs/cowork/scheduled_task_gate.js
+++ b/stubs/cowork/scheduled_task_gate.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// ============================================================
+// Scheduled-task creation gating (Phase 6 — predicate)
+// ============================================================
+// The asar exposes shouldAutoApprovePermission(scheduledTaskId, ...)
+// which auto-approves tools for scheduled tasks based on permissions
+// baked in at task creation time. That's fine *only* if scheduled-task
+// creation and modification can never happen via the bridge transport
+// (only via the renderer's user UI).
+//
+// Discovery found two namespaces in the bundled index.js:
+//   - CCDScheduledTasks_$_*
+//   - CoworkScheduledTasks_$_*
+// each with the same eight methods. Read-only methods (getAll*, get*FileContent,
+// onScheduledTaskEvent) are safe by definition. The mutating methods listed
+// below would, if bridge-reachable, let a remote message create a task whose
+// approvedPermissions then short-circuit shouldAutoApprovePermission for all
+// future runs — bypassing the manual acceptance flow Phase 1 restored.
+//
+// Bridge-reachability blocker: static grep cannot determine whether the bridge
+// transport drives these channels or only the renderer does. Resolution
+// requires CLAUDE_COWORK_IPC_TAP=1 against a real Cowork session that creates
+// and runs a scheduled task. Per the spec, this module ships the predicate
+// (testable) and a refused-handler factory; wiring lands in a follow-up after
+// live trace. See PR description.
+
+const MUTATING_SCHEDULED_TASK_SUFFIXES = Object.freeze(new Set([
+  // CCDScheduledTasks
+  'CCDScheduledTasks_$_createScheduledTask',
+  'CCDScheduledTasks_$_updateScheduledTask',
+  'CCDScheduledTasks_$_updateScheduledTaskFileContent',
+  'CCDScheduledTasks_$_updateScheduledTaskStatus',
+  'CCDScheduledTasks_$_removeApprovedPermission',
+  // CoworkScheduledTasks
+  'CoworkScheduledTasks_$_createScheduledTask',
+  'CoworkScheduledTasks_$_updateScheduledTask',
+  'CoworkScheduledTasks_$_updateScheduledTaskFileContent',
+  'CoworkScheduledTasks_$_updateScheduledTaskStatus',
+  'CoworkScheduledTasks_$_removeApprovedPermission',
+  'CoworkScheduledTasks_$_clearChromePermissions',
+]));
+
+const READ_ONLY_SCHEDULED_TASK_SUFFIXES = Object.freeze(new Set([
+  'CCDScheduledTasks_$_getAllScheduledTasks',
+  'CCDScheduledTasks_$_getScheduledTaskFileContent',
+  'CCDScheduledTasks_$_onScheduledTaskEvent',
+  'CoworkScheduledTasks_$_getAllScheduledTasks',
+  'CoworkScheduledTasks_$_getScheduledTaskFileContent',
+  'CoworkScheduledTasks_$_onScheduledTaskEvent',
+  'LocalAgentModeSessions_$_getSessionsForScheduledTask',
+  'LocalSessions_$_getSessionsForScheduledTask',
+]));
+
+function endsWithAnyOf(channel, suffixSet) {
+  if (typeof channel !== 'string') return false;
+  for (const suffix of suffixSet) {
+    if (channel.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+function isMutatingScheduledTaskChannel(channel) {
+  return endsWithAnyOf(channel, MUTATING_SCHEDULED_TASK_SUFFIXES);
+}
+
+function isReadOnlyScheduledTaskChannel(channel) {
+  return endsWithAnyOf(channel, READ_ONLY_SCHEDULED_TASK_SUFFIXES);
+}
+
+// makeRefusedHandler() returns an IPC-handler-shaped async function that
+// always refuses with a structured error. Use this to wrap the bridge-
+// reachable mutating channels ONCE that reachability is confirmed.
+function makeRefusedHandler({ log = console.warn, reason = 'bridge-reachable scheduled-task mutation refused' } = {}) {
+  return async function refusedScheduledTaskHandler() {
+    log('[scheduled-task-gate] ' + reason);
+    const err = new Error(reason);
+    err.code = 'COWORK_SCHEDULED_TASK_REFUSED';
+    throw err;
+  };
+}
+
+module.exports = {
+  MUTATING_SCHEDULED_TASK_SUFFIXES,
+  READ_ONLY_SCHEDULED_TASK_SUFFIXES,
+  isMutatingScheduledTaskChannel,
+  isReadOnlyScheduledTaskChannel,
+  makeRefusedHandler,
+};

--- a/stubs/cowork/startup_check.js
+++ b/stubs/cowork/startup_check.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// ============================================================
+// Startup self-test for wrapper rails (Phase 7)
+// ============================================================
+// Runs once per app.whenReady(). Confirms the three load-bearing rails
+// from Phase 1-3 are present, writes a single JSON-line result to
+// ~/.local/state/claude-cowork/logs/cowork-startup.log, and on failure
+// emits a [COWORK STARTUP CHECK FAILED] console line plus a one-time
+// desktop notification.
+//
+// Why this is a check, not a test: the wrapper modifies an unmodified
+// upstream asar. An asar refactor could move our IPC interception seam
+// or rename channels, silently bypassing a rail we still believe is
+// engaged. This check is the sanity verification.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function defaultLogPath() {
+  const xdgState = process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state');
+  return path.join(xdgState, 'claude-cowork', 'logs', 'cowork-startup.log');
+}
+
+function runStartupCheck({
+  ipcOverridesRegistry = null,
+  autoPermissionsCap = null,
+  mountRootBound = null,
+  log = console.log,
+  warn = console.warn,
+  writeFn = fs.appendFileSync,
+  mkdirFn = fs.mkdirSync,
+  logPath = defaultLogPath(),
+  notify = null,
+} = {}) {
+  const results = [];
+
+  // Check 1: bridge IPC overrides are absent.
+  // createOverrideRegistry(stub) returns the override map; no key should
+  // contain "Bridge" because Phase 1 removed all twelve.
+  let bridgeFound = [];
+  if (ipcOverridesRegistry && typeof ipcOverridesRegistry === 'object') {
+    for (const key of Object.keys(ipcOverridesRegistry)) {
+      if (typeof key === 'string' && key.includes('Bridge')) bridgeFound.push(key);
+    }
+  } else {
+    bridgeFound = ['<registry not provided>'];
+  }
+  results.push({
+    check: 'bridge_overrides_absent',
+    ok: bridgeFound.length === 0,
+    detail: bridgeFound,
+  });
+
+  // Check 2: AppPreferences_$_setPreference interceptor armed (the cap
+  // factory created an object with the expected shape).
+  results.push({
+    check: 'auto_permissions_cap_armed',
+    ok: !!(autoPermissionsCap && typeof autoPermissionsCap.wrapHandler === 'function'),
+  });
+
+  // Check 3: createMountSymlinks mount-bound rule is reachable (the
+  // predicate module loaded and exports the expected function).
+  results.push({
+    check: 'mount_bound_armed',
+    ok: !!(mountRootBound && typeof mountRootBound.isMountRootTooBroad === 'function'),
+  });
+
+  const ok = results.every((r) => r.ok);
+  const entry = {
+    ts: new Date().toISOString(),
+    ok,
+    results,
+  };
+
+  try {
+    mkdirFn(path.dirname(logPath), { recursive: true, mode: 0o700 });
+    writeFn(logPath, JSON.stringify(entry) + '\n', { mode: 0o600 });
+  } catch (_) {}
+
+  if (!ok) {
+    const failed = results.filter((r) => !r.ok).map((r) => r.check);
+    warn('[COWORK STARTUP CHECK FAILED] ' + failed.join(', '));
+    if (typeof notify === 'function') {
+      try { notify('Cowork wrapper rails not engaged — review startup log.'); } catch (_) {}
+    }
+  } else {
+    log('[cowork-startup] all rails engaged');
+  }
+
+  return entry;
+}
+
+module.exports = { runStartupCheck, defaultLogPath };

--- a/stubs/cowork/tool_preflight_policy.js
+++ b/stubs/cowork/tool_preflight_policy.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// ============================================================
+// Tool preflight path policy (Phase 5 — predicate)
+// ============================================================
+// When the auto-permissions toggle is on (and within the Phase 2 TTL
+// cap), this predicate decides whether a given tool invocation is
+// eligible for auto-approval. Anything that fails the predicate must
+// fall through to the asar's manual prompt.
+//
+// The complete predicate (rails, not barriers):
+//
+//   auto-approve eligible :=
+//       tool ∈ READ_SET
+//       && every path arg, realpath-resolved, is ⊆ realpath(cwd)
+//       && auto-mode timer active   (checked by caller, not here)
+//
+// READ_SET: a fixed allowlist of tools whose effects are fully
+// determined by their structured arguments and which have no exec /
+// write / network affordances. Anything else — bash, exec, write,
+// any tool with a shell-evaluated string argument — prompts every
+// time, even with auto-mode on.
+//
+// Path containment: realpath(arg) must equal realpath(cwd) or be a
+// sep-aware subpath. Symlink escapes are caught by realpath. No
+// ambient-folder rule, no depth rule, no dotfile carve-out, no
+// project-marker exceptions: cwd is the consent boundary the user
+// picked. If `.env` is in cwd, the user chose to make it readable
+// when the timer is on — pick a different cwd to change that.
+//
+// Wiring blocker (Phase 5 discovery): the actual IPC channel that
+// surfaces a permission preflight on the main side has not been
+// captured by the IPC tap in this development environment. Until
+// the channel is identified via `CLAUDE_COWORK_IPC_TAP=1` against
+// a live Cowork session that triggers a preflight, this module is
+// pure-predicate only — the predicate is correct and tested, but
+// not yet wired into frame-fix-wrapper.js. See PR description.
+
+const path = require('path');
+const fs = require('fs');
+
+const READ_SET = Object.freeze(new Set([
+  'read_file',
+  'list_dir',
+  'grep',
+  'head',
+  'tail',
+  // Add more here only after auditing that the tool has no flag-driven
+  // exec / write / network behavior. Notably NOT included:
+  //   - find: has -exec
+  //   - bash / sh / exec / run_command: shell evaluation
+  //   - any tool that takes a shell-evaluated string argument
+]));
+
+function resolveRealpath(p) {
+  if (typeof p !== 'string' || p.length === 0) return null;
+  try {
+    return path.resolve(fs.realpathSync(p));
+  } catch (_) {
+    return path.resolve(p);
+  }
+}
+
+function isContainedIn(targetReal, baseReal) {
+  if (typeof targetReal !== 'string' || typeof baseReal !== 'string') return false;
+  if (targetReal === baseReal) return true;
+  return targetReal.startsWith(baseReal + path.sep);
+}
+
+// shouldAutoApproveToolPreflight({ tool, paths, cwd }) -> boolean
+//
+// Returns true iff:
+//   - tool is in READ_SET
+//   - paths is a non-null array (may be empty for tools that take no path)
+//   - EVERY path in paths, after realpath resolution, is contained in cwd
+//
+// The caller is responsible for the "auto-mode timer active" check —
+// that lives in frame-fix-wrapper.js next to the cap, not in this pure
+// predicate. The caller is also responsible for invoking the asar's
+// manual-prompt path when this returns false.
+function shouldAutoApproveToolPreflight({ tool, paths, cwd } = {}) {
+  if (typeof tool !== 'string' || !READ_SET.has(tool)) return false;
+  if (typeof cwd !== 'string' || cwd.length === 0) return false;
+  if (!Array.isArray(paths)) return false;
+  const cwdReal = resolveRealpath(cwd);
+  if (!cwdReal) return false;
+  for (const p of paths) {
+    const real = resolveRealpath(p);
+    if (!real) return false;
+    if (!isContainedIn(real, cwdReal)) return false;
+  }
+  return true;
+}
+
+module.exports = {
+  shouldAutoApproveToolPreflight,
+  READ_SET,
+  resolveRealpath,
+  isContainedIn,
+};

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -857,6 +857,39 @@ const ipcOverrides = createOverrideRegistry(function getProcessState(args) {
   return getCoworkProcessRunningState(processId);
 });
 
+// Phase 7: startup self-test. Verifies the three load-bearing rails
+// (bridge overrides absent, auto-permissions cap armed, mount-bound
+// armed) are present at app-ready time. On failure, logs a single
+// [COWORK STARTUP CHECK FAILED] line and surfaces a desktop notification.
+(function scheduleStartupCheck() {
+  try {
+    const { runStartupCheck } = require('./cowork/startup_check.js');
+    const mountRootBound = require('./cowork/mount_root_bound.js');
+    const { app: _readyApp, Notification: _ReadyNotification } = require('electron');
+    if (!_readyApp || typeof _readyApp.whenReady !== 'function') return;
+    _readyApp.whenReady().then(() => {
+      try {
+        runStartupCheck({
+          ipcOverridesRegistry: ipcOverrides,
+          autoPermissionsCap: _autoPermissionsCap,
+          mountRootBound,
+          notify: (msg) => {
+            try {
+              if (_ReadyNotification && typeof _ReadyNotification.isSupported === 'function' && _ReadyNotification.isSupported()) {
+                new _ReadyNotification({ title: 'Claude', body: msg }).show();
+              }
+            } catch (_) {}
+          },
+        });
+      } catch (e) {
+        console.warn('[cowork-startup] check threw:', e && e.message);
+      }
+    }).catch((e) => console.warn('[cowork-startup] whenReady rejected:', e && e.message));
+  } catch (e) {
+    console.warn('[cowork-startup] failed to schedule check:', e && e.message);
+  }
+})();
+
 // ============================================================
 // GRACEFUL SHUTDOWN — on Linux, closing all windows must quit the
 // app. The asar's handler checks `process.platform === "darwin"`

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -79,6 +79,13 @@ const { createSessionOrchestrator } = require('./cowork/session_orchestrator.js'
 const { createSessionStore } = require('./cowork/session_store.js');
 const { createIpcTap } = require('./cowork/ipc_tap.js');
 const { createOverrideRegistry, matchOverride, extractEipcUuid, proactivelyRegisterOverrides, isProactiveChannel } = require('./cowork/ipc_overrides.js');
+const { createAutoPermissionsCap } = require('./cowork/auto_permissions_cap.js');
+
+// Single cap instance for the process. Closure-private state lives inside
+// the factory; we just keep the wrapHandler reference. The cap is one of
+// the "wrapper-side rails" that bounds the manual permission flow which
+// Phase 1 stopped shadowing -- see SECURITY notes in the cap module.
+const _autoPermissionsCap = createAutoPermissionsCap();
 
 // Suppress EPIPE errors on stdout/stderr (normal in piped/Electron environments)
 // and prevent them from becoming uncaught exception crash dialogs.
@@ -1098,6 +1105,16 @@ Module.prototype.require = function(id) {
         if (overrideHandler) {
           if (isProactiveChannel(channel)) return; // Already registered proactively
           return originalHandle(channel, overrideHandler);
+        }
+
+        // Auto-permissions toggle TTL cap (Phase 2). The asar exposes two
+        // toggles -- autoPermissionsModeEnabled, bypassPermissionsModeEnabled
+        // -- that skip permission prompts. Both default to false with no
+        // built-in TTL. Wrap the setPreference handler so flipping either
+        // to true schedules an auto-revert to false after the cap.
+        // EIPC UUID prefix varies per build; match by suffix.
+        if (typeof channel === 'string' && channel.endsWith('AppPreferences_$_setPreference')) {
+          return originalHandle(channel, _autoPermissionsCap.wrapHandler(handler));
         }
 
         // Debounce connect-to-mcp-server: the renderer fires duplicate connect

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -80,12 +80,17 @@ const { createSessionStore } = require('./cowork/session_store.js');
 const { createIpcTap } = require('./cowork/ipc_tap.js');
 const { createOverrideRegistry, matchOverride, extractEipcUuid, proactivelyRegisterOverrides, isProactiveChannel } = require('./cowork/ipc_overrides.js');
 const { createAutoPermissionsCap } = require('./cowork/auto_permissions_cap.js');
+const { createBridgeCanary } = require('./cowork/bridge_canary.js');
 
 // Single cap instance for the process. Closure-private state lives inside
 // the factory; we just keep the wrapHandler reference. The cap is one of
 // the "wrapper-side rails" that bounds the manual permission flow which
 // Phase 1 stopped shadowing -- see SECURITY notes in the cap module.
 const _autoPermissionsCap = createAutoPermissionsCap();
+// Opt-in canary that observes bridge-related channel registrations and
+// warns once when a previously-unseen one shows up. The regression alarm
+// for "Anthropic shipped a new bridge channel between releases."
+const _bridgeCanary = createBridgeCanary();
 
 // Suppress EPIPE errors on stdout/stderr (normal in piped/Electron environments)
 // and prevent them from becoming uncaught exception crash dialogs.
@@ -1092,6 +1097,9 @@ Module.prototype.require = function(id) {
       }
 
       ipcMain.handle = function(channel, handler) {
+        // Phase 4: canary observation -- side-effect only, never blocks.
+        _bridgeCanary.observe(channel);
+
         // Extract UUID from first EIPC channel and proactively register all overrides.
         // Handlers like ComputerUseTcc are never registered by the asar on Linux
         // (macOS-only native dependency), so registration-time interception can't
@@ -1243,6 +1251,9 @@ Module.prototype.require = function(id) {
         contents.ipc.__coworkHandlePatched = true;
         const origIpcHandle = contents.ipc.handle.bind(contents.ipc);
         contents.ipc.handle = function(channel, handler) {
+          // Phase 4: canary observation -- side-effect only, never blocks.
+          _bridgeCanary.observe(channel);
+
           // Extract UUID and proactively register overrides on ipcMain for
           // handlers the asar never registers (ComputerUseTcc, CoworkSpaces).
           const uuid = extractEipcUuid(channel);

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -19,7 +19,7 @@
 }
 
 // Patch macOS-only systemPreferences methods that don't exist on Linux
-const { systemPreferences } = require('electron');
+const { systemPreferences, app: _earlyApp } = require('electron');
 if (typeof systemPreferences.setUserDefault !== 'function') {
   systemPreferences.setUserDefault = function(key, type, value) {
     // no-op on Linux
@@ -29,6 +29,37 @@ if (typeof systemPreferences.getUserDefault !== 'function') {
   systemPreferences.getUserDefault = function(key, type) {
     return undefined;
   };
+}
+if (typeof systemPreferences.promptTouchID !== 'function') {
+  systemPreferences.promptTouchID = function(reason) {
+    return Promise.reject(new Error('Touch ID unavailable on Linux'));
+  };
+}
+
+// Patch macOS-only Electron app methods (NSUserActivity / Handoff APIs).
+// We spoof process.platform === "darwin" so the asar's darwin-gated callsites
+// reach these methods; on Linux Electron they don't exist, throwing
+// `TypeError: app.invalidateCurrentActivity is not a function` and crashing
+// the main process with a JS error dialog.
+// See: claude-cowork-linux issues #104, #106
+if (_earlyApp) {
+  const _macOnlyAppMethods = [
+    'invalidateCurrentActivity',
+    'setUserActivity',
+    'updateCurrentActivity',
+    'resignCurrentActivity',
+    'getCurrentActivityType',
+  ];
+  for (const _m of _macOnlyAppMethods) {
+    if (typeof _earlyApp[_m] !== 'function') {
+      _earlyApp[_m] = function() { /* no-op on Linux */ };
+    }
+  }
+  // moveToApplicationsFolder is macOS-only; the asar's prompt path is gated
+  // by a confirm dialog but stub it defensively so a stray call can't crash.
+  if (typeof _earlyApp.moveToApplicationsFolder !== 'function') {
+    _earlyApp.moveToApplicationsFolder = function() { return false; };
+  }
 }
 
 // Inject frame fix and Cowork support before main app loads

--- a/tests/node/current-path/auto_permissions_cap.test.cjs
+++ b/tests/node/current-path/auto_permissions_cap.test.cjs
@@ -1,0 +1,126 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const {
+  createAutoPermissionsCap,
+  DEFAULT_CAP_MS,
+} = require('../../../stubs/cowork/auto_permissions_cap.js');
+
+describe('auto-permissions TTL cap', () => {
+  test('default cap is 60 minutes', () => {
+    assert.equal(DEFAULT_CAP_MS, 60 * 60 * 1000);
+    const cap = createAutoPermissionsCap();
+    assert.equal(cap.CAP_MS, 60 * 60 * 1000);
+  });
+
+  test('setting autoPermissionsModeEnabled to true schedules a timer', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(async () => null);
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), false);
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', true);
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), true);
+  });
+
+  test('setting to false before timer fires clears the timer', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(async () => null);
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', true);
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), true);
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', false);
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), false);
+  });
+
+  test('re-setting to true resets the deadline (does not stack)', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(async () => null);
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', true);
+    t.mock.timers.tick(30 * 60 * 1000);
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', true);
+    t.mock.timers.tick(30 * 60 * 1000);
+    // Old timer would have fired 30 min ago; reset means we still have 30 min left.
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), true);
+    t.mock.timers.tick(30 * 60 * 1000);
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), false);
+  });
+
+  test('timer fire invokes captured handler with (event, key, false)', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const calls = [];
+    const original = async (event, key, value) => {
+      calls.push({ key, value, hasSender: !!(event && event.sender) });
+      return null;
+    };
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(original);
+    await wrapped({ sender: { id: 'test-sender' } }, 'autoPermissionsModeEnabled', true);
+    assert.equal(calls.length, 1, 'initial set fires through');
+    t.mock.timers.tick(60 * 60 * 1000);
+    // Synchronous part of the setTimeout callback invokes the handler;
+    // calls.push runs sync before the first await inside the async handler.
+    assert.equal(calls.length, 2, 'cap fire invokes handler');
+    assert.deepEqual(
+      { key: calls[1].key, value: calls[1].value, hasSender: calls[1].hasSender },
+      { key: 'autoPermissionsModeEnabled', value: false, hasSender: true },
+    );
+  });
+
+  test('bypassPermissionsModeEnabled has identical TTL behavior', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(async () => null);
+    await wrapped({ sender: {} }, 'bypassPermissionsModeEnabled', true);
+    assert.equal(cap.hasTimer('bypassPermissionsModeEnabled'), true);
+    await wrapped({ sender: {} }, 'bypassPermissionsModeEnabled', false);
+    assert.equal(cap.hasTimer('bypassPermissionsModeEnabled'), false);
+  });
+
+  test('setting any other preference key does not arm a timer', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(async () => null);
+    await wrapped({ sender: {} }, 'someOtherPreference', true);
+    await wrapped({ sender: {} }, 'theme', 'dark');
+    await wrapped({ sender: {} }, 'locale', 'en-US');
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), false);
+    assert.equal(cap.hasTimer('bypassPermissionsModeEnabled'), false);
+  });
+
+  test('two toggles have independent timers', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(async () => null);
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', true);
+    await wrapped({ sender: {} }, 'bypassPermissionsModeEnabled', true);
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), true);
+    assert.equal(cap.hasTimer('bypassPermissionsModeEnabled'), true);
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', false);
+    assert.equal(cap.hasTimer('autoPermissionsModeEnabled'), false);
+    assert.equal(cap.hasTimer('bypassPermissionsModeEnabled'), true, 'bypass timer should be independent');
+  });
+
+  test('wrapHandler returns a pass-through for the initial call', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ log: () => {} });
+    const wrapped = cap.wrapHandler(async (_event, _key, value) => `result-${value}`);
+    const result = await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', true);
+    assert.equal(result, 'result-true');
+  });
+
+  test('cap survives custom capMs', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const cap = createAutoPermissionsCap({ capMs: 5000, log: () => {} });
+    assert.equal(cap.CAP_MS, 5000);
+    const calls = [];
+    const wrapped = cap.wrapHandler(async (event, key, value) => { calls.push({ key, value }); });
+    await wrapped({ sender: {} }, 'autoPermissionsModeEnabled', true);
+    assert.equal(calls.length, 1);
+    t.mock.timers.tick(4000);
+    assert.equal(calls.length, 1, 'should not fire before cap');
+    t.mock.timers.tick(2000);
+    assert.equal(calls.length, 2, 'should fire after cap elapsed');
+  });
+});

--- a/tests/node/current-path/bridge_canary.test.cjs
+++ b/tests/node/current-path/bridge_canary.test.cjs
@@ -1,0 +1,164 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const {
+  createBridgeCanary,
+  DEFAULT_KNOWN_GOOD,
+  extractSuffix,
+  isBridgeRelated,
+} = require('../../../stubs/cowork/bridge_canary.js');
+
+function makeStubs() {
+  const logs = [];
+  const writes = [];
+  return {
+    logs,
+    writes,
+    log: (msg) => logs.push(msg),
+    writeFn: (p, content) => writes.push({ path: p, content }),
+    mkdirFn: () => {},
+  };
+}
+
+describe('bridge canary', () => {
+  test('extractSuffix isolates LocalAgentModeSessions_$_ tail', () => {
+    assert.equal(
+      extractSuffix('$eipc_message$_uuid_$_claude.web_$_LocalAgentModeSessions_$_newBridgeMethod'),
+      'LocalAgentModeSessions_$_newBridgeMethod',
+    );
+    assert.equal(
+      extractSuffix('FileSystem_$_readLocalFile'),
+      null,
+      'non-LocalAgentModeSessions channels return null',
+    );
+    assert.equal(extractSuffix(null), null);
+    assert.equal(extractSuffix(undefined), null);
+    assert.equal(extractSuffix(42), null);
+  });
+
+  test('isBridgeRelated matches Bridge or bridge anywhere', () => {
+    assert.equal(isBridgeRelated('LocalAgentModeSessions_$_getBridgeConsent'), true);
+    assert.equal(isBridgeRelated('LocalAgentModeSessions_$_bridge'), true);
+    assert.equal(isBridgeRelated('LocalAgentModeSessions_$_someBridgePoll'), true);
+    assert.equal(isBridgeRelated('LocalAgentModeSessions_$_start'), false);
+    assert.equal(isBridgeRelated('LocalAgentModeSessions_$_listSessions'), false);
+  });
+
+  test('disabled canary observes nothing', () => {
+    const s = makeStubs();
+    const canary = createBridgeCanary({ enabled: false, ...s });
+    assert.equal(
+      canary.observe('uuid_$_LocalAgentModeSessions_$_brandNewBridgeMethod'),
+      false,
+    );
+    assert.equal(s.logs.length, 0);
+    assert.equal(s.writes.length, 0);
+  });
+
+  test('does not fire for known-good bridge channels', () => {
+    const s = makeStubs();
+    const canary = createBridgeCanary({ enabled: true, ...s });
+    for (const suffix of DEFAULT_KNOWN_GOOD) {
+      assert.equal(canary.observe('prefix_$_' + suffix), false);
+    }
+    assert.equal(s.logs.length, 0);
+  });
+
+  test('does not fire for non-bridge LocalAgentModeSessions channels', () => {
+    const s = makeStubs();
+    const canary = createBridgeCanary({ enabled: true, ...s });
+    assert.equal(canary.observe('uuid_$_LocalAgentModeSessions_$_listSessions'), false);
+    assert.equal(canary.observe('uuid_$_LocalAgentModeSessions_$_start'), false);
+    assert.equal(s.logs.length, 0);
+  });
+
+  test('does not fire for non-LocalAgentModeSessions channels even if bridge-named', () => {
+    const s = makeStubs();
+    const canary = createBridgeCanary({ enabled: true, ...s });
+    // Suffix anchor requires LocalAgentModeSessions_$_ prefix.
+    assert.equal(canary.observe('SomethingElse_$_getBridgeStatus'), false);
+    assert.equal(s.logs.length, 0);
+  });
+
+  test('fires exactly once per new bridge suffix', () => {
+    const s = makeStubs();
+    const canary = createBridgeCanary({ enabled: true, ...s });
+    const novelSuffix = 'LocalAgentModeSessions_$_newBridgeFlow';
+    assert.equal(canary.observe('uuid_$_' + novelSuffix), true);
+    assert.equal(canary.observe('uuid_$_' + novelSuffix), false, 'second observation is suppressed');
+    assert.equal(canary.observe('anotherUuid_$_' + novelSuffix), false, 'suppression keyed on suffix, not full channel');
+    assert.equal(s.logs.length, 1);
+    assert.match(s.logs[0], /new bridge-related IPC channel observed/);
+    assert.match(s.logs[0], /newBridgeFlow/);
+    assert.match(s.logs[0], /review SECURITY\.md/);
+  });
+
+  test('fires for distinct new bridge suffixes independently', () => {
+    const s = makeStubs();
+    const canary = createBridgeCanary({ enabled: true, ...s });
+    assert.equal(canary.observe('uuid_$_LocalAgentModeSessions_$_newBridgeA'), true);
+    assert.equal(canary.observe('uuid_$_LocalAgentModeSessions_$_newBridgeB'), true);
+    assert.equal(canary.observe('uuid_$_LocalAgentModeSessions_$_newBridgeA'), false);
+    assert.equal(s.logs.length, 2);
+  });
+
+  test('writes a JSONL line per new observation', () => {
+    const s = makeStubs();
+    const canary = createBridgeCanary({ enabled: true, ...s });
+    canary.observe('uuid_$_LocalAgentModeSessions_$_newBridgeC');
+    assert.equal(s.writes.length, 1);
+    assert.match(s.writes[0].content, /"suffix":"LocalAgentModeSessions_\$_newBridgeC"/);
+    assert.match(s.writes[0].content, /"ts":"\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('CLAUDE_COWORK_IPC_TAP=1 enables via env-var gate', (t) => {
+    const prev = process.env.CLAUDE_COWORK_IPC_TAP;
+    const prev2 = process.env.CLAUDE_COWORK_BRIDGE_CANARY;
+    delete process.env.CLAUDE_COWORK_BRIDGE_CANARY;
+    process.env.CLAUDE_COWORK_IPC_TAP = '1';
+    t.after(() => {
+      if (prev === undefined) delete process.env.CLAUDE_COWORK_IPC_TAP;
+      else process.env.CLAUDE_COWORK_IPC_TAP = prev;
+      if (prev2 !== undefined) process.env.CLAUDE_COWORK_BRIDGE_CANARY = prev2;
+    });
+    const s = makeStubs();
+    const canary = createBridgeCanary({ ...s }); // default enabled = isEnabledByEnv()
+    assert.equal(canary.enabled, true);
+    canary.observe('uuid_$_LocalAgentModeSessions_$_newBridgeViaIpcTap');
+    assert.equal(s.logs.length, 1);
+  });
+
+  test('CLAUDE_COWORK_BRIDGE_CANARY=1 enables independently', (t) => {
+    const prev = process.env.CLAUDE_COWORK_IPC_TAP;
+    const prev2 = process.env.CLAUDE_COWORK_BRIDGE_CANARY;
+    delete process.env.CLAUDE_COWORK_IPC_TAP;
+    process.env.CLAUDE_COWORK_BRIDGE_CANARY = '1';
+    t.after(() => {
+      if (prev !== undefined) process.env.CLAUDE_COWORK_IPC_TAP = prev;
+      if (prev2 === undefined) delete process.env.CLAUDE_COWORK_BRIDGE_CANARY;
+      else process.env.CLAUDE_COWORK_BRIDGE_CANARY = prev2;
+    });
+    const s = makeStubs();
+    const canary = createBridgeCanary({ ...s });
+    assert.equal(canary.enabled, true);
+    canary.observe('uuid_$_LocalAgentModeSessions_$_newBridgeViaCanaryFlag');
+    assert.equal(s.logs.length, 1);
+  });
+
+  test('env-var gate off keeps canary silent', (t) => {
+    const prev = process.env.CLAUDE_COWORK_IPC_TAP;
+    const prev2 = process.env.CLAUDE_COWORK_BRIDGE_CANARY;
+    delete process.env.CLAUDE_COWORK_IPC_TAP;
+    delete process.env.CLAUDE_COWORK_BRIDGE_CANARY;
+    t.after(() => {
+      if (prev !== undefined) process.env.CLAUDE_COWORK_IPC_TAP = prev;
+      if (prev2 !== undefined) process.env.CLAUDE_COWORK_BRIDGE_CANARY = prev2;
+    });
+    const s = makeStubs();
+    const canary = createBridgeCanary({ ...s });
+    assert.equal(canary.enabled, false);
+    assert.equal(canary.observe('uuid_$_LocalAgentModeSessions_$_newBridgeSilent'), false);
+    assert.equal(s.logs.length, 0);
+  });
+});

--- a/tests/node/current-path/ipc_overrides.test.cjs
+++ b/tests/node/current-path/ipc_overrides.test.cjs
@@ -201,19 +201,6 @@ test('override registry covers all known broken handlers', () => {
     'MainWindowTitleBar_$_requestMainMenuPopup',
     'BrowserNavigation_$_requestMainMenuPopup',
     'CoworkSpaces_$_getAllSpaces',
-    // Phase 4: Dispatch/Bridge
-    'LocalAgentModeSessions_$_abandonBridgeEnvironment',
-    'LocalAgentModeSessions_$_deleteBridgeAgentMemory',
-    'LocalAgentModeSessions_$_deleteBridgeSession',
-    'LocalAgentModeSessions_$_getBridgeConsent',
-    'LocalAgentModeSessions_$_getSessionsBridgeEnabled',
-    'LocalAgentModeSessions_$_kickBridgePoll',
-    'LocalAgentModeSessions_$_onBridgePermissionPreflight',
-    'LocalAgentModeSessions_$_resetBridge',
-    'LocalAgentModeSessions_$_resetBridgeSession',
-    'LocalAgentModeSessions_$_respondBridgePermissionPreflight',
-    'LocalAgentModeSessions_$_sessionsBridgeStatus',
-    'LocalAgentModeSessions_$_setSessionsBridgeEnabled',
     // Phase 4: MCP
     'LocalAgentModeSessions_$_mcpCallTool',
     'LocalAgentModeSessions_$_mcpListResources',
@@ -379,30 +366,32 @@ test('override handlers return fresh objects for object results (not shared refe
 });
 
 // ================================================================
-// Phase 4: Dispatch/Bridge handler tests
+// Phase 4: Dispatch/Bridge — handlers intentionally NOT overridden.
+// The asar's LocalAgentModeSessionManager owns these to drive the
+// manual user-acceptance flow. matchOverride() must return falsy for
+// every bridge channel so the asar's handler runs unimpeded.
 // ================================================================
 
-test('getBridgeConsent returns denied', async () => {
+test('bridge handlers are not overridden (asar owns them)', async () => {
   const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-  const handler = matchOverride('test_$_LocalAgentModeSessions_$_getBridgeConsent', registry);
-  const result = await handler(null);
-  assert.deepEqual(result, { consented: false });
-});
-
-test('bridge status always reports disconnected', async () => {
-  const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-  const handler = matchOverride('test_$_LocalAgentModeSessions_$_sessionsBridgeStatus', registry);
-  const result = await handler();
-  assert.equal(result.status, 'disconnected');
-  assert.equal(result.enabled, false);
-});
-
-test('setSessionsBridgeEnabled is a no-op (stays disabled)', async () => {
-  const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-  const setHandler = matchOverride('test_$_LocalAgentModeSessions_$_setSessionsBridgeEnabled', registry);
-  const getHandler = matchOverride('test_$_LocalAgentModeSessions_$_getSessionsBridgeEnabled', registry);
-  await setHandler(null, true);
-  assert.equal(await getHandler(), false);
+  const bridgeChannels = [
+    'LocalAgentModeSessions_$_abandonBridgeEnvironment',
+    'LocalAgentModeSessions_$_deleteBridgeAgentMemory',
+    'LocalAgentModeSessions_$_deleteBridgeSession',
+    'LocalAgentModeSessions_$_getBridgeConsent',
+    'LocalAgentModeSessions_$_getSessionsBridgeEnabled',
+    'LocalAgentModeSessions_$_kickBridgePoll',
+    'LocalAgentModeSessions_$_onBridgePermissionPreflight',
+    'LocalAgentModeSessions_$_resetBridge',
+    'LocalAgentModeSessions_$_resetBridgeSession',
+    'LocalAgentModeSessions_$_respondBridgePermissionPreflight',
+    'LocalAgentModeSessions_$_sessionsBridgeStatus',
+    'LocalAgentModeSessions_$_setSessionsBridgeEnabled',
+  ];
+  for (const suffix of bridgeChannels) {
+    const handler = matchOverride('test_$_' + suffix, registry);
+    assert.ok(!handler, 'bridge channel must not be overridden: ' + suffix);
+  }
 });
 
 // ================================================================

--- a/tests/node/current-path/mount_root_bound.test.cjs
+++ b/tests/node/current-path/mount_root_bound.test.cjs
@@ -1,0 +1,71 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const { isMountRootTooBroad } = require('../../../stubs/cowork/mount_root_bound.js');
+
+describe('mount root bound', () => {
+  test('refuses hostPath === homedir (empty relativePath case)', () => {
+    // createMountSymlinks sets hostPath = _homedir when relativePath === ''.
+    // The predicate must catch that.
+    assert.equal(isMountRootTooBroad('/home/alice', '/home/alice'), true);
+  });
+
+  test("refuses '/' as a mount target", () => {
+    assert.equal(isMountRootTooBroad('/', '/home/alice'), true);
+  });
+
+  test('refuses two-segment paths like /home/user, /var/tmp, /opt/foo', () => {
+    assert.equal(isMountRootTooBroad('/home/alice', '/root'), true);
+    assert.equal(isMountRootTooBroad('/var/tmp', '/root'), true);
+    assert.equal(isMountRootTooBroad('/opt/foo', '/root'), true);
+  });
+
+  test('refuses single-segment paths like /usr, /etc', () => {
+    assert.equal(isMountRootTooBroad('/usr', '/root'), true);
+    assert.equal(isMountRootTooBroad('/etc', '/root'), true);
+  });
+
+  test('accepts three-segment paths like /home/user/project', () => {
+    assert.equal(isMountRootTooBroad('/home/alice/project', '/root'), false);
+    assert.equal(isMountRootTooBroad('/opt/foo/bar', '/root'), false);
+  });
+
+  test('accepts deeper paths', () => {
+    assert.equal(isMountRootTooBroad('/home/alice/projects/myapp/src', '/root'), false);
+  });
+
+  test('refuses null/undefined/empty string', () => {
+    assert.equal(isMountRootTooBroad('', '/home/alice'), true);
+    assert.equal(isMountRootTooBroad(null, '/home/alice'), true);
+    assert.equal(isMountRootTooBroad(undefined, '/home/alice'), true);
+  });
+
+  test('symlink that resolves to a shallow path is refused (realpath catches escape)', () => {
+    if (!fs.existsSync('/home')) return; // pragmatically skip in minimal containers
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mount-bound-test-'));
+    const linkPath = path.join(tmpDir, 'shallow-link');
+    try {
+      fs.symlinkSync('/home', linkPath);
+      // linkPath itself has many segments (/tmp/.../shallow-link) but realpath
+      // resolves to /home (1 segment), which is shallower than 3. Refuse.
+      assert.equal(isMountRootTooBroad(linkPath, '/root'), true);
+    } finally {
+      try { fs.unlinkSync(linkPath); } catch (_) {}
+      try { fs.rmdirSync(tmpDir); } catch (_) {}
+    }
+  });
+
+  test('non-existent 3+ segment path is accepted (lexical fallback)', () => {
+    // realpath throws ENOENT; predicate falls back to path.resolve and counts
+    // segments lexically. A 3-segment-deep planned mount root is fine.
+    assert.equal(isMountRootTooBroad('/home/alice/not-yet-created', '/root'), false);
+  });
+
+  test('non-existent shallow path is still refused (lexical fallback)', () => {
+    assert.equal(isMountRootTooBroad('/var/missing', '/root'), true);
+  });
+});

--- a/tests/node/current-path/scheduled_task_gate.test.cjs
+++ b/tests/node/current-path/scheduled_task_gate.test.cjs
@@ -1,0 +1,73 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const {
+  MUTATING_SCHEDULED_TASK_SUFFIXES,
+  READ_ONLY_SCHEDULED_TASK_SUFFIXES,
+  isMutatingScheduledTaskChannel,
+  isReadOnlyScheduledTaskChannel,
+  makeRefusedHandler,
+} = require('../../../stubs/cowork/scheduled_task_gate.js');
+
+describe('scheduled-task gate (predicate)', () => {
+  test('mutating set covers both CCD and Cowork namespaces', () => {
+    for (const namespace of ['CCDScheduledTasks', 'CoworkScheduledTasks']) {
+      assert.ok(MUTATING_SCHEDULED_TASK_SUFFIXES.has(namespace + '_$_createScheduledTask'));
+      assert.ok(MUTATING_SCHEDULED_TASK_SUFFIXES.has(namespace + '_$_updateScheduledTask'));
+      assert.ok(MUTATING_SCHEDULED_TASK_SUFFIXES.has(namespace + '_$_updateScheduledTaskStatus'));
+      assert.ok(MUTATING_SCHEDULED_TASK_SUFFIXES.has(namespace + '_$_removeApprovedPermission'));
+    }
+    assert.ok(MUTATING_SCHEDULED_TASK_SUFFIXES.has('CoworkScheduledTasks_$_clearChromePermissions'));
+  });
+
+  test('read-only set excludes mutating channels', () => {
+    for (const m of MUTATING_SCHEDULED_TASK_SUFFIXES) {
+      assert.ok(!READ_ONLY_SCHEDULED_TASK_SUFFIXES.has(m), 'overlap: ' + m);
+    }
+  });
+
+  test('isMutatingScheduledTaskChannel detects EIPC-prefixed channels', () => {
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_CCDScheduledTasks_$_createScheduledTask'), true);
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_CoworkScheduledTasks_$_updateScheduledTask'), true);
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_CoworkScheduledTasks_$_clearChromePermissions'), true);
+  });
+
+  test('isMutatingScheduledTaskChannel rejects read-only channels', () => {
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_CCDScheduledTasks_$_getAllScheduledTasks'), false);
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_CCDScheduledTasks_$_onScheduledTaskEvent'), false);
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_LocalAgentModeSessions_$_getSessionsForScheduledTask'), false);
+  });
+
+  test('isMutatingScheduledTaskChannel rejects unrelated channels', () => {
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_FileSystem_$_readLocalFile'), false);
+    assert.equal(isMutatingScheduledTaskChannel('uuid_$_claude.web_$_LocalAgentModeSessions_$_getBridgeConsent'), false);
+    assert.equal(isMutatingScheduledTaskChannel(null), false);
+    assert.equal(isMutatingScheduledTaskChannel(42), false);
+  });
+
+  test('isReadOnlyScheduledTaskChannel covers the documented get* and on* methods', () => {
+    assert.equal(isReadOnlyScheduledTaskChannel('uuid_$_claude.web_$_CCDScheduledTasks_$_getAllScheduledTasks'), true);
+    assert.equal(isReadOnlyScheduledTaskChannel('uuid_$_claude.web_$_CoworkScheduledTasks_$_onScheduledTaskEvent'), true);
+    assert.equal(isReadOnlyScheduledTaskChannel('uuid_$_claude.web_$_LocalSessions_$_getSessionsForScheduledTask'), true);
+  });
+
+  test('makeRefusedHandler rejects with structured error', async () => {
+    const logs = [];
+    const handler = makeRefusedHandler({ log: (m) => logs.push(m), reason: 'test reason' });
+    await assert.rejects(
+      () => handler({}, 'someArg'),
+      (err) => err.code === 'COWORK_SCHEDULED_TASK_REFUSED' && err.message === 'test reason',
+    );
+    assert.equal(logs.length, 1);
+    assert.match(logs[0], /\[scheduled-task-gate\]/);
+  });
+
+  test('makeRefusedHandler default reason is informative', async () => {
+    const handler = makeRefusedHandler({ log: () => {} });
+    await assert.rejects(
+      () => handler(),
+      /bridge-reachable scheduled-task mutation refused/,
+    );
+  });
+});

--- a/tests/node/current-path/security_hardening.test.cjs
+++ b/tests/node/current-path/security_hardening.test.cjs
@@ -141,32 +141,34 @@ describe('FileSystem allowlist-only access', () => {
 });
 
 // ============================================================
-// 3. Bridge handlers
+// 3. Bridge handlers — intentionally NOT overridden.
+// The asar's LocalAgentModeSessionManager owns these to drive the
+// manual user-acceptance flow (Allow/Deny clicks reach the bridge).
+// Wrapper-side bounds on this flow are enforced elsewhere
+// (auto-permissions TTL cap, mount-root refusal, channel canary).
 // ============================================================
 
 describe('Bridge handlers', () => {
-  it('getBridgeConsent returns consented: false', async () => {
+  it('matchOverride returns falsy for every bridge channel', async () => {
     const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-    const handler = matchOverride('claude.web_$_LocalAgentModeSessions_$_getBridgeConsent', registry);
-    const result = await handler();
-    assert.equal(result.consented, false);
-  });
-
-  it('sessionsBridgeStatus reports disconnected', async () => {
-    const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-    const handler = matchOverride('claude.web_$_LocalAgentModeSessions_$_sessionsBridgeStatus', registry);
-    const result = await handler();
-    assert.equal(result.status, 'disconnected');
-    assert.equal(result.enabled, false);
-  });
-
-  it('setSessionsBridgeEnabled is a no-op', async () => {
-    const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-    const setHandler = matchOverride('claude.web_$_LocalAgentModeSessions_$_setSessionsBridgeEnabled', registry);
-    await setHandler({}, true);
-    const statusHandler = matchOverride('claude.web_$_LocalAgentModeSessions_$_getSessionsBridgeEnabled', registry);
-    const result = await statusHandler();
-    assert.equal(result, false, 'bridge must remain disabled regardless of set calls');
+    const bridgeChannels = [
+      'LocalAgentModeSessions_$_abandonBridgeEnvironment',
+      'LocalAgentModeSessions_$_deleteBridgeAgentMemory',
+      'LocalAgentModeSessions_$_deleteBridgeSession',
+      'LocalAgentModeSessions_$_getBridgeConsent',
+      'LocalAgentModeSessions_$_getSessionsBridgeEnabled',
+      'LocalAgentModeSessions_$_kickBridgePoll',
+      'LocalAgentModeSessions_$_onBridgePermissionPreflight',
+      'LocalAgentModeSessions_$_resetBridge',
+      'LocalAgentModeSessions_$_resetBridgeSession',
+      'LocalAgentModeSessions_$_respondBridgePermissionPreflight',
+      'LocalAgentModeSessions_$_sessionsBridgeStatus',
+      'LocalAgentModeSessions_$_setSessionsBridgeEnabled',
+    ];
+    for (const suffix of bridgeChannels) {
+      const handler = matchOverride('claude.web_$_' + suffix, registry);
+      assert.ok(!handler, 'bridge channel must not be overridden: ' + suffix);
+    }
   });
 });
 

--- a/tests/node/current-path/startup_check.test.cjs
+++ b/tests/node/current-path/startup_check.test.cjs
@@ -1,0 +1,140 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { runStartupCheck, defaultLogPath } = require('../../../stubs/cowork/startup_check.js');
+
+function makeStubs() {
+  const logs = [];
+  const warns = [];
+  const writes = [];
+  const notifies = [];
+  return {
+    logs,
+    warns,
+    writes,
+    notifies,
+    log: (m) => logs.push(m),
+    warn: (m) => warns.push(m),
+    writeFn: (p, content) => writes.push({ path: p, content }),
+    mkdirFn: () => {},
+    notify: (m) => notifies.push(m),
+    logPath: '/tmp/cowork-startup-test.log',
+  };
+}
+
+function validDeps() {
+  return {
+    ipcOverridesRegistry: { 'FileSystem_$_readLocalFile': () => {} },
+    autoPermissionsCap: { wrapHandler: () => {}, hasTimer: () => false, CAP_MS: 0 },
+    mountRootBound: { isMountRootTooBroad: () => false },
+  };
+}
+
+describe('startup check', () => {
+  test('all rails engaged: ok=true, success log, no warn, no notify', () => {
+    const s = makeStubs();
+    const entry = runStartupCheck({ ...validDeps(), ...s });
+    assert.equal(entry.ok, true);
+    assert.equal(entry.results.length, 3);
+    for (const r of entry.results) assert.equal(r.ok, true, r.check);
+    assert.equal(s.warns.length, 0);
+    assert.equal(s.notifies.length, 0);
+    assert.equal(s.logs.length, 1);
+    assert.match(s.logs[0], /all rails engaged/);
+    assert.equal(s.writes.length, 1);
+    assert.match(s.writes[0].content, /"ok":true/);
+  });
+
+  test('bridge override found: failed check, warn, notify', () => {
+    const s = makeStubs();
+    const deps = validDeps();
+    deps.ipcOverridesRegistry = {
+      'FileSystem_$_readLocalFile': () => {},
+      'LocalAgentModeSessions_$_getBridgeConsent': () => {}, // leak
+    };
+    const entry = runStartupCheck({ ...deps, ...s });
+    assert.equal(entry.ok, false);
+    const failed = entry.results.find((r) => r.check === 'bridge_overrides_absent');
+    assert.equal(failed.ok, false);
+    assert.deepEqual(failed.detail, ['LocalAgentModeSessions_$_getBridgeConsent']);
+    assert.equal(s.warns.length, 1);
+    assert.match(s.warns[0], /\[COWORK STARTUP CHECK FAILED\]/);
+    assert.match(s.warns[0], /bridge_overrides_absent/);
+    assert.equal(s.notifies.length, 1);
+    assert.match(s.notifies[0], /rails not engaged/);
+  });
+
+  test('missing autoPermissionsCap: failed check, warn, notify', () => {
+    const s = makeStubs();
+    const deps = validDeps();
+    deps.autoPermissionsCap = null;
+    const entry = runStartupCheck({ ...deps, ...s });
+    assert.equal(entry.ok, false);
+    const failed = entry.results.find((r) => r.check === 'auto_permissions_cap_armed');
+    assert.equal(failed.ok, false);
+    assert.equal(s.warns.length, 1);
+    assert.match(s.warns[0], /auto_permissions_cap_armed/);
+  });
+
+  test('cap without wrapHandler: failed', () => {
+    const s = makeStubs();
+    const deps = validDeps();
+    deps.autoPermissionsCap = { hasTimer: () => false };
+    const entry = runStartupCheck({ ...deps, ...s });
+    assert.equal(entry.ok, false);
+    const failed = entry.results.find((r) => r.check === 'auto_permissions_cap_armed');
+    assert.equal(failed.ok, false);
+  });
+
+  test('missing mountRootBound: failed check', () => {
+    const s = makeStubs();
+    const deps = validDeps();
+    deps.mountRootBound = null;
+    const entry = runStartupCheck({ ...deps, ...s });
+    assert.equal(entry.ok, false);
+    const failed = entry.results.find((r) => r.check === 'mount_bound_armed');
+    assert.equal(failed.ok, false);
+  });
+
+  test('writes a JSON line with iso timestamp and results array', () => {
+    const s = makeStubs();
+    runStartupCheck({ ...validDeps(), ...s });
+    assert.equal(s.writes.length, 1);
+    const parsed = JSON.parse(s.writes[0].content.trim());
+    assert.equal(parsed.ok, true);
+    assert.ok(Array.isArray(parsed.results));
+    assert.match(parsed.ts, /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('absent notify callback does not crash on failure', () => {
+    const s = makeStubs();
+    const deps = validDeps();
+    deps.autoPermissionsCap = null;
+    delete s.notify;
+    const entry = runStartupCheck({ ...deps, ...s, notify: null });
+    assert.equal(entry.ok, false);
+    // No notify; warn still fired.
+    assert.equal(s.warns.length, 1);
+  });
+
+  test('write/mkdir failure is swallowed (entry still returned)', () => {
+    const s = makeStubs();
+    s.writeFn = () => { throw new Error('disk full'); };
+    s.mkdirFn = () => { throw new Error('permission denied'); };
+    const entry = runStartupCheck({ ...validDeps(), ...s });
+    assert.equal(entry.ok, true);
+    // Success log still fired because rails are fine; write failure is silent.
+    assert.equal(s.logs.length, 1);
+  });
+
+  test('defaultLogPath honors XDG_STATE_HOME', (t) => {
+    const prev = process.env.XDG_STATE_HOME;
+    process.env.XDG_STATE_HOME = '/custom/state';
+    t.after(() => {
+      if (prev === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = prev;
+    });
+    assert.equal(defaultLogPath(), '/custom/state/claude-cowork/logs/cowork-startup.log');
+  });
+});

--- a/tests/node/current-path/tool_preflight_policy.test.cjs
+++ b/tests/node/current-path/tool_preflight_policy.test.cjs
@@ -1,0 +1,155 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const {
+  shouldAutoApproveToolPreflight,
+  READ_SET,
+  isContainedIn,
+} = require('../../../stubs/cowork/tool_preflight_policy.js');
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'preflight-test-'));
+}
+
+describe('tool preflight path policy', () => {
+  test('READ_SET contains only audited read-only tools', () => {
+    assert.ok(READ_SET.has('read_file'));
+    assert.ok(READ_SET.has('list_dir'));
+    assert.ok(READ_SET.has('grep'));
+    assert.ok(READ_SET.has('head'));
+    assert.ok(READ_SET.has('tail'));
+    assert.ok(!READ_SET.has('find'), 'find has -exec');
+    assert.ok(!READ_SET.has('bash'), 'bash is shell evaluation');
+    assert.ok(!READ_SET.has('write_file'));
+    assert.ok(!READ_SET.has('run_command'));
+  });
+
+  test('read tool, path inside cwd: auto-approves', () => {
+    const cwd = makeTmp();
+    try {
+      const inside = path.join(cwd, 'foo.txt');
+      fs.writeFileSync(inside, '');
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [inside], cwd }), true);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+
+  test('read tool, dotfile inside cwd: auto-approves (no carve-out)', () => {
+    const cwd = makeTmp();
+    try {
+      const dotfile = path.join(cwd, '.env');
+      fs.writeFileSync(dotfile, 'TOKEN=secret');
+      // No dotfile carve-out: cwd is the consent boundary.
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [dotfile], cwd }), true);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+
+  test('read tool, path outside cwd: forced to prompt', () => {
+    const cwd = makeTmp();
+    const outside = makeTmp();
+    try {
+      const outsideFile = path.join(outside, 'other.txt');
+      fs.writeFileSync(outsideFile, '');
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [outsideFile], cwd }), false);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test('symlink inside cwd pointing outside: forced to prompt (realpath catches escape)', () => {
+    const cwd = makeTmp();
+    const outside = makeTmp();
+    try {
+      const linkInsideCwd = path.join(cwd, 'escape');
+      fs.symlinkSync(outside, linkInsideCwd);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [linkInsideCwd], cwd }), false);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test('write tool inside cwd: forced to prompt (writes never auto-approve)', () => {
+    const cwd = makeTmp();
+    try {
+      const inside = path.join(cwd, 'foo.txt');
+      fs.writeFileSync(inside, '');
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'write_file', paths: [inside], cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'edit_file', paths: [inside], cwd }), false);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+
+  test('bash tool even with safe-looking argv: forced to prompt', () => {
+    const cwd = makeTmp();
+    try {
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'bash', paths: [], cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'run_command', paths: [], cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'exec', paths: [], cwd }), false);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+
+  test('find with -exec NOT in READ_SET: forced to prompt', () => {
+    const cwd = makeTmp();
+    try {
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'find', paths: [cwd], cwd }), false);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+
+  test('read tool with multiple path args, one outside cwd: all-or-nothing', () => {
+    const cwd = makeTmp();
+    const outside = makeTmp();
+    try {
+      const insidePath = path.join(cwd, 'a.txt');
+      const outsidePath = path.join(outside, 'b.txt');
+      fs.writeFileSync(insidePath, '');
+      fs.writeFileSync(outsidePath, '');
+      assert.equal(
+        shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [insidePath, outsidePath], cwd }),
+        false,
+        'one out-of-bounds path forces prompt for the whole request',
+      );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test('cwd equals path: auto-approves (boundary equality counts as containment)', () => {
+    const cwd = makeTmp();
+    try {
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'list_dir', paths: [cwd], cwd }), true);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+
+  test('isContainedIn never matches a sibling sharing prefix', () => {
+    assert.equal(isContainedIn('/a/b-c', '/a/b'), false, 'no substring match — sep boundary required');
+    assert.equal(isContainedIn('/a/b/c', '/a/b'), true);
+    assert.equal(isContainedIn('/a/b', '/a/b'), true);
+  });
+
+  test('rejects invalid input shapes', () => {
+    const cwd = makeTmp();
+    try {
+      assert.equal(shouldAutoApproveToolPreflight({}), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: null, cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: 'not-array', cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [123], cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: null, paths: [], cwd }), false);
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [], cwd: null }), false);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+
+  test('empty paths array auto-approves a READ_SET tool (e.g. list_dir of cwd)', () => {
+    const cwd = makeTmp();
+    try {
+      // Tools that take no path arguments still get auto-approved if in READ_SET.
+      // (Callers can choose to require a non-empty paths array if their semantics differ.)
+      assert.equal(shouldAutoApproveToolPreflight({ tool: 'read_file', paths: [], cwd }), true);
+    } finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+  });
+});


### PR DESCRIPTION
## Summary

Two coherent tracks landing in one PR:

1. **Wrapper-side rails** (commits f93a0be -> 7e481f3) -- macOS Electron stubs plus seven phases of "rails not barriers" guards on the manual permission flow.
2. **Recovery infrastructure** (commit 7be25b6) -- explicit update flow + COMPAT.md tested-versions matrix + launcher warnings on untested asar versions.

**Rails, not barriers** -- the user is inside the threat model with their own agent. The wrapper provides defaults that constrain casual exploration without fighting the user's intent. Time and space caps protect against drift in upstream defaults, not against the user, and not against a sophisticated attacker.

## What changes

### Wrapper rails (phases 1-7)

- **Phase 1** -- remove the 12 `LocalAgentModeSessions_$_*Bridge*` IPC overrides so the asar's `LocalAgentModeSessionManager` can drive the manual user-acceptance flow (Allow/Deny clicks finally reach the bridge).
- **Phase 2** -- TTL cap on `autoPermissionsModeEnabled` / `bypassPermissionsModeEnabled` at 60 min wall-clock (CLOCK_MONOTONIC via libuv). Closure-private state, no persistent disk state. Re-toggling resets the deadline; toggling off clears it.
- **Phase 3** -- `createMountSymlinks` refuses mount roots at `$HOME`, `/`, or anything shallower than three path segments. Principle, not enumeration: no allowlist of sensitive paths.
- **Phase 4** -- opt-in canary on `ipc_tap` (`CLAUDE_COWORK_IPC_TAP=1` or `CLAUDE_COWORK_BRIDGE_CANARY=1`) that warns once when a previously-unseen bridge-related channel suffix registers. Regression alarm for "Anthropic shipped a new bridge channel between releases."
- **Phase 5** (predicate only; wiring deferred) -- pure path-policy module: `tool in READ_SET` AND every path arg, `realpath`-resolved, is contained in `realpath(cwd)`. READ_SET = `{read_file, list_dir, grep, head, tail}`. Wiring blocked on a live IPC trace of the renderer-side auto-approve seam.
- **Phase 6** (predicate only; wiring deferred) -- audit of bundled `index.js` enumerated 11 mutating + 8 read-only scheduled-task channels across two namespaces. Predicate and refused-handler factory ship now.
- **Phase 7** -- startup self-test runs once per `app.whenReady()`. Writes one JSON line to `~/.local/state/claude-cowork/logs/cowork-startup.log` confirming the Phase 1-3 rails are engaged.

### Recovery (new in this PR)

- **`COMPAT.md`** at repo root with a machine-readable `LAST_TESTED_ASAR_VERSION` line plus a human-readable status matrix. Bumped via PR each time a contributor confirms a new asar works end-to-end. Status indicators are ASCII (`[OK]`, `[PARTIAL]`, `[FAIL]`, `[UNTESTED]`).
- **`install.sh`** stops auto-downloading silently. New prompt shows the last-tested vs. latest-CDN versions and asks for confirmation before download. Refuses piped (non-interactive) installs without `--force`. `--update` flag re-fetches / re-extracts / re-stubs / re-patches without rebuilding the launcher.
- **Launcher (`claude-desktop`, `claude-cowork`)** reads a version sentinel written at install time and prints a one-time `[WARN]` line to stderr if the installed asar is newer than the last tested. Sentinel at `$LOG_DIR/.last-warned-asar-version` suppresses re-warning for the same version.
- **`doctor`** reports the installed-vs-tested version state as an `[OK]` or `[WARN]` line.
- **`README.md`** has a new **Recovery** section walking users through rollback when an update breaks their install.

## Files changed

- `stubs/cowork/ipc_overrides.js` -- bridge handlers removed (Phase 1).
- `stubs/cowork/auto_permissions_cap.js` (new) -- Phase 2 module.
- `stubs/cowork/mount_root_bound.js` (new) -- Phase 3 predicate.
- `stubs/cowork/bridge_canary.js` (new) -- Phase 4 module.
- `stubs/cowork/tool_preflight_policy.js` (new) -- Phase 5 predicate.
- `stubs/cowork/scheduled_task_gate.js` (new) -- Phase 6 predicate.
- `stubs/cowork/startup_check.js` (new) -- Phase 7 module.
- `stubs/frame-fix/frame-fix-wrapper.js` -- wires Phases 2, 4, 7; activity-stubs base.
- `stubs/@ant/claude-swift/js/index.js` -- wires Phase 3.
- `COMPAT.md` (new) -- tested-versions matrix.
- `install.sh` -- compat helpers, prompt-gated download, `--update` flag, sentinel seeding, doctor version check, updated launcher heredoc.
- `README.md` -- Quick Start prompt note, Updating subsection, Recovery section.
- `tests/node/current-path/*.test.cjs` -- 6 new test files for the new modules, plus rewrites of bridge tests.

Total: ~1700 LOC, 461 tests pass (was 403 -- +58 new). All commits squash cleanly.

## Discovery blockers (Phases 5, 6)

Phases 5 and 6 ship predicates only. Wiring requires live IPC traces this development environment cannot produce.

- **Phase 5** -- `autoPermissionsModeEnabled` appears only in preference schemas in the bundled `index.js`; the actual auto-approve decision lives in the renderer. Wiring requires `CLAUDE_COWORK_IPC_TAP=1` against a real Cowork session that triggers a tool preflight, and the resulting channel suffix recorded.
- **Phase 6** -- 11 mutating scheduled-task channels enumerated; bridge-reachability cannot be determined from static grep. Resolution requires a live trace of bridge messages exercising scheduled-task creation/modification.

Per the spec, the predicates ship now (pure, tested, correct); the wiring lands in follow-up PRs after live traces.

## Coordination

This PR's first commit (activity stubs) is duplicated by #103, #110, #115, #116 -- all closable after merge. Phase 1 (bridge override removal) overlaps with #113's same change; the second to land is a no-op for that file. Everything else is disjoint from #113 (which adds feature-coverage and PKGBUILD changes orthogonal to the rails + recovery scope).

OAuth-completion leg of #104 remains with #100. node-pty Linux ELF remains with #109.

## Verification

- `node --test tests/node/current-path/*.test.cjs` -- **461 pass, 0 fail** (was 403; +58 new)
- `node --check` on every modified `.js`
- `bash -n install.sh` -- parses clean after recovery commit
- Smoke test of `compat_version_is_newer` across `>`, `<`, `==`, and the lexical-fail case (1.5.10 > 1.5.9). All correct.
- Smoke test of launcher `_warn_if_untested_asar` across all five paths: fires once, then silent, fires again after sentinel cleared, silent on same-version, silent on older-installed.
- `LC_ALL=C grep -P '[^\x00-\x7F]'` confirms `COMPAT.md` is ASCII and new blocks in `install.sh` and `README.md` are ASCII.
- **Not** yet smoke-tested on a live Linux desktop (maintainer's local environment is unavailable). End-to-end install/--update/launch verification deferred to a contributor with a working desktop.

## Test plan

- [x] Full Node test suite (461 pass)
- [x] Bash syntax check on install.sh
- [x] Helper smoke tests (compat_version_is_newer, launcher warn-once)
- [x] ASCII audit on new content
- [ ] `./install.sh --doctor` against a fresh install -- expect new `[OK] Asar version` line
- [ ] `./install.sh` (interactive) on a fresh box -- expect prompt before download
- [ ] `./install.sh` (piped, no --force) -- expect refusal
- [ ] `claude-desktop --update` on an existing install -- expect prompt, then re-extract+repack
- [ ] Launch on a newer-than-tested asar -- expect `[WARN]` line once, then silent
- [ ] Sign in via Google -- `claude://` redirect re-focuses without crash (covered by Phase 0 stubs)

Closes #106. Closes the crash-dialog leg of #104. Addresses majority of #107 with the rails approach plus the user-facing escape hatch in COMPAT.md. The OAuth-completion leg of #104 remains with PR #100.