### PR TITLE
fix for invalidateCurrentActivity is not a function

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -431,7 +431,13 @@ function installLinuxMenuInterceptors(electronModule) {
     hideLinuxMenuBars(electronModule);
     return undefined;
   };
-
+  if (app && typeof app.invalidateCurrentActivity !== 'function') {
+    app.invalidateCurrentActivity = function() {};
+  }
+  if (app && typeof app.updateCurrentActivity !== 'function') {
+    app.updateCurrentActivity = function() {};
+  }
+  
   if (originalSetDefaultAppMenu) {
     menuApi.setDefaultApplicationMenu = function(...args) {
       if (REAL_PLATFORM === 'linux') {


### PR DESCRIPTION
## What does this change?

Fixes https://github.com/johnzfitch/claude-cowork-linux/issues/106

## Type
- [x] Bug fix

## Testing

- Distro / desktop: Ubuntu 26.04 LTS
- Tested with `./install.sh --doctor`: Yes
- Tested a full Cowork session: Yes

## Security impact
- [X] This change does touch security-sensitive code

## Checklist
- [X] No API keys, tokens, `.env` files, or log output with credentials included
- [X] Commit messages follow the project style (no emoji, brief summary + explanation)
- [X] `./install.sh --doctor` passes cleanly on my system
