### PR TITLE
fix(ipc-overrides): remove bridge handler overrides blocking dispatch

### DIFF
--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -387,66 +387,12 @@ function createOverrideRegistry(getProcessState) {
     },
 
     // ================================================================
-    // LocalAgentModeSessions — Dispatch/Bridge handlers
+    // Bridge handlers REMOVED: these no-op overrides blocked the asar's own
+    // LocalAgentModeSessionManager from establishing the WebSocket bridge
+    // to wss://bridge.claudeusercontent.com. The asar registers and manages
+    // these handlers internally; with our overrides intercepting registration,
+    // the bridge never connected and dispatch reported "can't connect."
     // ================================================================
-
-    'LocalAgentModeSessions_$_abandonBridgeEnvironment': async (_event, ...args) => {
-      vlog('[ipc:abandonBridgeEnvironment] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_deleteBridgeAgentMemory': async (_event, ...args) => {
-      vlog('[ipc:deleteBridgeAgentMemory] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_deleteBridgeSession': async (_event, ...args) => {
-      vlog('[ipc:deleteBridgeSession] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_getBridgeConsent': async (_event, ...args) => {
-      vlog('[ipc:getBridgeConsent] called');
-      return { consented: false };
-    },
-
-    'LocalAgentModeSessions_$_getSessionsBridgeEnabled': async () => {
-      return false;
-    },
-
-    'LocalAgentModeSessions_$_kickBridgePoll': async (_event, ...args) => {
-      vlog('[ipc:kickBridgePoll] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_onBridgePermissionPreflight': async (_event, ...args) => {
-      vlog('[ipc:onBridgePermissionPreflight] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_resetBridge': async (_event, ...args) => {
-      vlog('[ipc:resetBridge] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_resetBridgeSession': async (_event, ...args) => {
-      vlog('[ipc:resetBridgeSession] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_respondBridgePermissionPreflight': async (_event, ...args) => {
-      vlog('[ipc:respondBridgePermissionPreflight] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_sessionsBridgeStatus': async () => {
-      return { status: 'disconnected', enabled: false };
-    },
-
-    'LocalAgentModeSessions_$_setSessionsBridgeEnabled': async (_event, enabled) => {
-      vlog('[ipc:setSessionsBridgeEnabled] called');
-      return null;
-    },
 
     // ================================================================
     // MCP handlers — Desktop MCP integration (not CLI MCP)

--- a/tests/node/current-path/ipc_overrides.test.cjs
+++ b/tests/node/current-path/ipc_overrides.test.cjs
@@ -201,19 +201,8 @@ test('override registry covers all known broken handlers', () => {
     'MainWindowTitleBar_$_requestMainMenuPopup',
     'BrowserNavigation_$_requestMainMenuPopup',
     'CoworkSpaces_$_getAllSpaces',
-    // Phase 4: Dispatch/Bridge
-    'LocalAgentModeSessions_$_abandonBridgeEnvironment',
-    'LocalAgentModeSessions_$_deleteBridgeAgentMemory',
-    'LocalAgentModeSessions_$_deleteBridgeSession',
-    'LocalAgentModeSessions_$_getBridgeConsent',
-    'LocalAgentModeSessions_$_getSessionsBridgeEnabled',
-    'LocalAgentModeSessions_$_kickBridgePoll',
-    'LocalAgentModeSessions_$_onBridgePermissionPreflight',
-    'LocalAgentModeSessions_$_resetBridge',
-    'LocalAgentModeSessions_$_resetBridgeSession',
-    'LocalAgentModeSessions_$_respondBridgePermissionPreflight',
-    'LocalAgentModeSessions_$_sessionsBridgeStatus',
-    'LocalAgentModeSessions_$_setSessionsBridgeEnabled',
+    // Phase 4: Dispatch/Bridge — handlers removed; the asar's own
+    // LocalAgentModeSessionManager registers and manages these internally.
     // Phase 4: MCP
     'LocalAgentModeSessions_$_mcpCallTool',
     'LocalAgentModeSessions_$_mcpListResources',
@@ -379,33 +368,12 @@ test('override handlers return fresh objects for object results (not shared refe
 });
 
 // ================================================================
-// Phase 4: Dispatch/Bridge handler tests
+// ================================================================
+// Phase 4: Dispatch/Bridge handler tests — removed.
+// Bridge handlers are now managed by the asar's own
+// LocalAgentModeSessionManager. Overriding them blocked the bridge.
 // ================================================================
 
-test('getBridgeConsent returns denied', async () => {
-  const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-  const handler = matchOverride('test_$_LocalAgentModeSessions_$_getBridgeConsent', registry);
-  const result = await handler(null);
-  assert.deepEqual(result, { consented: false });
-});
-
-test('bridge status always reports disconnected', async () => {
-  const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-  const handler = matchOverride('test_$_LocalAgentModeSessions_$_sessionsBridgeStatus', registry);
-  const result = await handler();
-  assert.equal(result.status, 'disconnected');
-  assert.equal(result.enabled, false);
-});
-
-test('setSessionsBridgeEnabled is a no-op (stays disabled)', async () => {
-  const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-  const setHandler = matchOverride('test_$_LocalAgentModeSessions_$_setSessionsBridgeEnabled', registry);
-  const getHandler = matchOverride('test_$_LocalAgentModeSessions_$_getSessionsBridgeEnabled', registry);
-  await setHandler(null, true);
-  assert.equal(await getHandler(), false);
-});
-
-// ================================================================
 // Phase 4: MCP handler tests
 // ================================================================
 

--- a/tests/node/current-path/security_hardening.test.cjs
+++ b/tests/node/current-path/security_hardening.test.cjs
@@ -145,29 +145,32 @@ describe('FileSystem allowlist-only access', () => {
 // ============================================================
 
 describe('Bridge handlers', () => {
-  it('getBridgeConsent returns consented: false', async () => {
-    const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-    const handler = matchOverride('claude.web_$_LocalAgentModeSessions_$_getBridgeConsent', registry);
-    const result = await handler();
-    assert.equal(result.consented, false);
-  });
+  // Bridge handler overrides were removed: they intercepted the asar's own
+  // LocalAgentModeSessionManager and replaced its dispatch handlers with no-ops,
+  // preventing the WebSocket bridge from ever connecting. The asar registers
+  // and manages these handlers internally; we must not shadow them.
+  const BRIDGE_CHANNELS = [
+    'claude.web_$_LocalAgentModeSessions_$_abandonBridgeEnvironment',
+    'claude.web_$_LocalAgentModeSessions_$_deleteBridgeAgentMemory',
+    'claude.web_$_LocalAgentModeSessions_$_deleteBridgeSession',
+    'claude.web_$_LocalAgentModeSessions_$_getBridgeConsent',
+    'claude.web_$_LocalAgentModeSessions_$_getSessionsBridgeEnabled',
+    'claude.web_$_LocalAgentModeSessions_$_kickBridgePoll',
+    'claude.web_$_LocalAgentModeSessions_$_onBridgePermissionPreflight',
+    'claude.web_$_LocalAgentModeSessions_$_resetBridge',
+    'claude.web_$_LocalAgentModeSessions_$_resetBridgeSession',
+    'claude.web_$_LocalAgentModeSessions_$_respondBridgePermissionPreflight',
+    'claude.web_$_LocalAgentModeSessions_$_sessionsBridgeStatus',
+    'claude.web_$_LocalAgentModeSessions_$_setSessionsBridgeEnabled',
+  ];
 
-  it('sessionsBridgeStatus reports disconnected', async () => {
-    const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-    const handler = matchOverride('claude.web_$_LocalAgentModeSessions_$_sessionsBridgeStatus', registry);
-    const result = await handler();
-    assert.equal(result.status, 'disconnected');
-    assert.equal(result.enabled, false);
-  });
-
-  it('setSessionsBridgeEnabled is a no-op', async () => {
-    const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
-    const setHandler = matchOverride('claude.web_$_LocalAgentModeSessions_$_setSessionsBridgeEnabled', registry);
-    await setHandler({}, true);
-    const statusHandler = matchOverride('claude.web_$_LocalAgentModeSessions_$_getSessionsBridgeEnabled', registry);
-    const result = await statusHandler();
-    assert.equal(result, false, 'bridge must remain disabled regardless of set calls');
-  });
+  for (const channel of BRIDGE_CHANNELS) {
+    it(`${channel.split('_$_').pop()} has no override (asar handler runs unimpeded)`, () => {
+      const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));
+      const handler = matchOverride(channel, registry);
+      assert.ok(!handler, 'override must not be registered');
+    });
+  }
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary

`stubs/cowork/ipc_overrides.js` registers 12 no-op overrides for `LocalAgentModeSessions_$_*Bridge*` channels. These were originally added defensively to prevent `No handler registered` warnings, but they intercept the asar's own `LocalAgentModeSessionManager` registration and replace its dispatch handlers with stubs that always return `null` / `disconnected` / `consented:false`. The asar's WebSocket bridge to `wss://bridge.claudeusercontent.com` therefore never connects, and dispatch reports "can't connect" for all users.

## Root cause

The handlers being shadowed are managed internally by the asar's `LocalAgentModeSessionManager` — it registers them via `ipcMain.handle()` to drive its WebSocket bridge. Our `matchOverride()` in the registration interceptor finds our entries first and substitutes them, so the asar's real handlers never run.

## Fix

Remove all 12 bridge handler entries:

- `abandonBridgeEnvironment`
- `deleteBridgeAgentMemory`
- `deleteBridgeSession`
- `getBridgeConsent`
- `getSessionsBridgeEnabled`
- `kickBridgePoll`
- `onBridgePermissionPreflight`
- `resetBridge`
- `resetBridgeSession`
- `respondBridgePermissionPreflight`
- `sessionsBridgeStatus`
- `setSessionsBridgeEnabled`

A comment block remains at the deletion site explaining why these channels must not be overridden.

## Test changes

`tests/node/current-path/security_hardening.test.cjs` had three tests asserting the broken behavior (e.g. `getBridgeConsent returns consented: false` — i.e. the override returns `false`). These are rewritten to lock in the correct behavior: `matchOverride()` for any of the 12 bridge channels must return falsy, so the asar's handler runs unimpeded.

`tests/node/current-path/ipc_overrides.test.cjs` similarly drops the override-behavior tests for these channels.

## Test plan

- [x] `node --test tests/node/current-path/*.test.cjs` — 98 affected tests pass, none regressed
- [x] `node --check stubs/cowork/ipc_overrides.js`
- [ ] Verify dispatch connects: `[sessions-bridge] WebSocket connected to wss://bridge.claudeusercontent.com` appears in startup log
- [ ] Verify "Polling for work" loop runs and tasks are received

🤖 Generated with [Claude Code](https://claude.com/claude-code)