### PR TITLE
fix(swift-stub): add guest request methods for cliPluginBridge

### DIFF
--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1370,6 +1370,18 @@ class SwiftAddonStub extends EventEmitter {
         // In our stub, this is controlled by env var, so we just log
       },
 
+      // Guest request interface — required by the cliPluginBridge to
+      // classify CLI plugins. Without these the bridge skips init and
+      // dispatch reports "can't connect".
+      setGuestRequestCallback: (callback) => {
+        trace('vm.setGuestRequestCallback() registered');
+        self._guestRequestCallback = callback;
+      },
+
+      sendGuestResponse: async (id, resultJson, error) => {
+        trace('vm.sendGuestResponse() id=' + id);
+      },
+
       /**
        * Stop the VM
        */


### PR DESCRIPTION
## Summary

The asar's `cliPluginBridge` initializer probes `vm.setGuestRequestCallback` and `vm.sendGuestResponse` on the VM API. When these methods are missing, the bridge logs `VMAPI missing guest-request methods` and skips registration, leaving CLI-plugin classification disabled and contributing to the dispatch/bridge connection failures users see on Linux.

## Fix

Add minimal stubs to `SwiftAddonStub.vm`:

- `setGuestRequestCallback(callback)` — stores the callback reference on the instance for later invocation by future code paths. Currently nothing else in the stub triggers it; the registration alone is what `cliPluginBridge` needs to proceed.
- `sendGuestResponse(id, resultJson, error)` — async no-op that traces the call. The macOS path has the VM's MITM proxy on the receiving end; on Linux the CLI talks directly to `api.anthropic.com`, so there's no transport for this side to forward to.

## Security note

- `setGuestRequestCallback` only stores a callback reference. No external input is consumed.
- `sendGuestResponse` is a no-op trace log. It does not handle credentials, spawn processes, or write to disk.

Both methods are inert today; they exist solely to satisfy the bridge's feature detection so it doesn't bail out of init.

## Test plan

- [x] `node --check stubs/@ant/claude-swift/js/index.js`
- [ ] Verify `[claude-swift] vm.setGuestRequestCallback() registered` appears in trace log on launch
- [ ] Verify `cliPluginBridge` no longer logs `VMAPI missing guest-request methods`
- [ ] Combined with #111 (bridge override removal), dispatch should connect end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)