### PR TITLE
Linux port coverage to incorporate #105 

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -207,12 +207,14 @@ JSEOF
 package() {
     cd "${srcdir}"
 
-    # Install repacked app.asar
+    # Mirror macOS Contents/Resources/ layout. Two lookups in the asar key off
+    # this layout: path.join(resourcesPath, 'app.asar', ...) for MCP nodeHost
+    # discovery, and path.join(path.dirname(resourcesPath), 'Helpers',
+    # 'disclaimer') for the disclaimer wrapper. Putting app.asar inside
+    # resources/ and the disclaimer one level up makes both resolve.
     install -Dm644 "${srcdir}/app.asar" \
-                   "${pkgdir}/usr/lib/claude-cowork/app.asar"
+                   "${pkgdir}/usr/lib/claude-cowork/resources/app.asar"
 
-    # Resources in our namespace (avoid /usr/lib/electronNN/, foreign-owned).
-    # i18n in BOTH root and i18n/ -- bundle reads from both paths.
     install -d "${pkgdir}/usr/lib/claude-cowork/resources/i18n"
     install -m644 "${srcdir}/linux-app-extracted/resources/"*.json \
         "${pkgdir}/usr/lib/claude-cowork/resources/"
@@ -277,7 +279,7 @@ elif [[ -f /proc/sys/user/max_user_namespaces ]]; then
     [[ "$_max_ns" -gt 0 ]] 2>/dev/null && _sandbox_flag=""
 fi
 
-exec electron /usr/lib/claude-cowork/app.asar \
+exec electron /usr/lib/claude-cowork/resources/app.asar \
     ${_sandbox_flag} \
     --disable-gpu \
     --class=Claude \

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -250,6 +250,17 @@ EOF
 #!/bin/bash
 # Claude Cowork Linux launcher
 
+# Wipe build-time caches so asar patches and chromium GPU/font caches
+# rebuild fresh. User data (IndexedDB, Local Storage, Cookies, sessions)
+# is left intact.
+_CFG="${XDG_CONFIG_HOME:-$HOME/.config}/Claude"
+for _c in "$_CFG/Cache" "$_CFG/Code Cache" "$_CFG/GPUCache" "$_CFG/CachedData" \
+          "$_CFG/DawnGraphiteCache" "$_CFG/DawnWebGPUCache" "$_CFG/fcache" \
+          "$_CFG/Shared Dictionary/cache"; do
+    [ -e "$_c" ] && rm -rf "$_c"
+done
+unset _CFG _c
+
 if [[ -n "$WAYLAND_DISPLAY" ]] || [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
     export ELECTRON_OZONE_PLATFORM_HINT=wayland
 fi

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -100,32 +100,36 @@ def patch_file(filepath):
     print(f"  {func_name}() now returns {{status:\"supported\"}} unconditionally")
     return True
 
+HOST_PLATFORM_FINGERPRINT_RE = re.compile(
+    r'darwin-arm64.{0,50}darwin-x64.{0,120}win32-arm64.{0,50}win32-x64'
+)
 HOST_PLATFORM_THROW_RE = re.compile(
-    r'throw new Error\([^)]*Unsupported platform[^)]*\)'
+    r'throw new Error\([^)]*[Uu]nsupported.{0,20}platform[^)]*\)'
 )
 
 
 def patch_host_platform(filepath):
-    """Patch getHostPlatform() to return 'darwin-x64' instead of throwing on Linux.
-
-    The minified getHostPlatform() method only handles darwin and win32,
-    throwing Error('Unsupported platform: ...') for anything else.
-    Replace the throw with return"darwin-x64" so session init succeeds.
-    """
     with open(filepath, 'r') as f:
         content = f.read()
 
-    match = HOST_PLATFORM_THROW_RE.search(content)
-    if not match:
-        print(f"  getHostPlatform(): no throw found (already patched or not present)")
+    fp = HOST_PLATFORM_FINGERPRINT_RE.search(content)
+    if not fp:
+        print("  getHostPlatform(): fingerprint not found (build changed)")
         return True
 
-    content = HOST_PLATFORM_THROW_RE.sub('return"darwin-x64"', content)
+    region = content[fp.end():fp.end() + 500]
+    throw = HOST_PLATFORM_THROW_RE.search(region)
+    if not throw:
+        print("  getHostPlatform(): no throw near fingerprint (already returns darwin-x64)")
+        return True
+
+    abs_start = fp.end() + throw.start()
+    abs_end = fp.end() + throw.end()
+    content = content[:abs_start] + 'return"darwin-x64"' + content[abs_end:]
 
     with open(filepath, 'w') as f:
         f.write(content)
-
-    print(f"  getHostPlatform() patched: throw replaced with return\"darwin-x64\"")
+    print('  getHostPlatform() patched: throw -> return"darwin-x64"')
     return True
 
 

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1088,6 +1088,33 @@ class SwiftAddonStub extends EventEmitter {
       getEnabled: () => false,
     };
 
+    // Computer Use (TCC) — graceful denial on Linux. The asar accesses
+    // claude-swift.computerUse.* directly when its IPC fallback misses.
+    this.computerUse = {
+      getState: () => Promise.resolve({ accessibility: 'denied', screenCapture: 'denied', canPrompt: false }),
+      requestAccess: () => Promise.resolve({ success: false, accessibility: 'denied', screenCapture: 'denied', canPrompt: false }),
+      requestAccessibility: () => Promise.resolve({ success: false, accessibility: 'denied', canPrompt: false }),
+      requestScreenRecording: () => Promise.resolve({ success: false, screenCapture: 'denied', canPrompt: false }),
+      getCurrentSessionGrants: () => Promise.resolve([]),
+      revokeGrant: () => Promise.resolve(true),
+      openSystemSettings: () => Promise.resolve(null),
+      canPrompt: () => Promise.resolve(false),
+      listAvailablePermissions: () => Promise.resolve(['accessibility', 'screenCapture']),
+      listInstalledApps: () => Promise.resolve([]),
+      tcc: {
+        checkAccessibility: () => false,
+        checkScreenRecording: () => false,
+        requestAccessibility: () => false,
+        requestScreenRecording: () => false,
+      },
+    };
+
+    // Updater (ShipIt is macOS-only). Stub empty job info so the asar's
+    // updater logic short-circuits instead of throwing on null access.
+    this.updater = {
+      getShipItJobInfo: () => ({ label: null, isPrivileged: false }),
+    };
+
     // VM Management (nested object)
     // CRITICAL: The app accesses methods via module.default.vm, so all methods must be here
     const self = this;
@@ -1158,7 +1185,7 @@ class SwiftAddonStub extends EventEmitter {
           return { success: true };
         } catch {}
 
-        const arch = os.arch() === 'arm64' ? 'linux-arm64' : 'linux-x64';
+        const arch = process.arch === 'arm64' ? 'darwin-arm64' : 'darwin-x64';
         const url = 'https://downloads.claude.ai/claude-code-releases/' + encodeURIComponent(version) + '/' + arch + '/claude.zst';
         console.log('[claude-swift] Downloading SDK binary from ' + url);
         trace('vm.installSdk() downloading ' + url + ' -> ' + targetBin);
@@ -1251,6 +1278,17 @@ class SwiftAddonStub extends EventEmitter {
         );
 
         return spawnResult;
+      },
+
+      // Guest request interface — required by cliPluginBridge to classify CLI
+      // plugins. Without these the bridge skips init and dispatch reports
+      // "can't connect". (PR #112)
+      setGuestRequestCallback: (callback) => {
+        trace('vm.setGuestRequestCallback() registered');
+        self._guestRequestCallback = callback;
+      },
+      sendGuestResponse: async (id, resultJson, error) => {
+        trace('vm.sendGuestResponse() id=' + id);
       },
 
       kill: (id, signal) => {

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1088,8 +1088,8 @@ class SwiftAddonStub extends EventEmitter {
       getEnabled: () => false,
     };
 
-    // Computer Use (TCC) — graceful denial on Linux. The asar accesses
-    // claude-swift.computerUse.* directly when its IPC fallback misses.
+    // Computer Use — full namespace shape the asar accesses via hE().
+    // Linux has no Apple TCC; everything degrades to denied / empty.
     this.computerUse = {
       getState: () => Promise.resolve({ accessibility: 'denied', screenCapture: 'denied', canPrompt: false }),
       requestAccess: () => Promise.resolve({ success: false, accessibility: 'denied', screenCapture: 'denied', canPrompt: false }),
@@ -1107,6 +1107,29 @@ class SwiftAddonStub extends EventEmitter {
         requestAccessibility: () => false,
         requestScreenRecording: () => false,
       },
+      apps: {
+        listInstalled: () => Promise.resolve([]),
+        listRunning: () => Promise.resolve([]),
+        appUnderPoint: () => Promise.resolve(null),
+        iconDataUrl: () => undefined,
+        open: () => Promise.resolve(false),
+        unhide: () => Promise.resolve(),
+        prepareDisplay: () => Promise.resolve({ activated: null, hidden: [] }),
+        previewHideSet: () => Promise.resolve([]),
+        findWindowDisplays: () => Promise.resolve([]),
+      },
+      display: {
+        getSize: () => Promise.resolve({ width: 0, height: 0 }),
+        listAll: () => [],
+      },
+      // Mouse/keyboard primitives used by the executor — no-op on Linux.
+      key: () => Promise.resolve(),
+      moveMouse: () => Promise.resolve(),
+      mouseLocation: () => Promise.resolve({ x: 0, y: 0 }),
+      click: () => Promise.resolve(),
+      type: () => Promise.resolve(),
+      scroll: () => Promise.resolve(),
+      screenshot: () => Promise.resolve(null),
     };
 
     // Updater (ShipIt is macOS-only). Stub empty job info so the asar's

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -386,67 +386,12 @@ function createOverrideRegistry(getProcessState) {
       return null;
     },
 
-    // ================================================================
-    // LocalAgentModeSessions — Dispatch/Bridge handlers
-    // ================================================================
-
-    'LocalAgentModeSessions_$_abandonBridgeEnvironment': async (_event, ...args) => {
-      vlog('[ipc:abandonBridgeEnvironment] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_deleteBridgeAgentMemory': async (_event, ...args) => {
-      vlog('[ipc:deleteBridgeAgentMemory] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_deleteBridgeSession': async (_event, ...args) => {
-      vlog('[ipc:deleteBridgeSession] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_getBridgeConsent': async (_event, ...args) => {
-      vlog('[ipc:getBridgeConsent] called');
-      return { consented: false };
-    },
-
-    'LocalAgentModeSessions_$_getSessionsBridgeEnabled': async () => {
-      return false;
-    },
-
-    'LocalAgentModeSessions_$_kickBridgePoll': async (_event, ...args) => {
-      vlog('[ipc:kickBridgePoll] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_onBridgePermissionPreflight': async (_event, ...args) => {
-      vlog('[ipc:onBridgePermissionPreflight] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_resetBridge': async (_event, ...args) => {
-      vlog('[ipc:resetBridge] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_resetBridgeSession': async (_event, ...args) => {
-      vlog('[ipc:resetBridgeSession] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_respondBridgePermissionPreflight': async (_event, ...args) => {
-      vlog('[ipc:respondBridgePermissionPreflight] called');
-      return null;
-    },
-
-    'LocalAgentModeSessions_$_sessionsBridgeStatus': async () => {
-      return { status: 'disconnected', enabled: false };
-    },
-
-    'LocalAgentModeSessions_$_setSessionsBridgeEnabled': async (_event, enabled) => {
-      vlog('[ipc:setSessionsBridgeEnabled] called');
-      return null;
-    },
+    // Bridge handlers intentionally NOT overridden. The asar's own
+    // LocalAgentModeSessionManager registers and manages these to drive the
+    // wss://bridge.claudeusercontent.com WebSocket dispatch. Our prior no-op
+    // overrides intercepted registration and prevented the bridge from ever
+    // connecting — every Allow click and every tool_permission_request died
+    // in the stubs. Letting the asar own these is what makes dispatch work.
 
     // ================================================================
     // MCP handlers — Desktop MCP integration (not CLI MCP)

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -18,18 +18,82 @@
   }
 }
 
-// Patch macOS-only systemPreferences methods that don't exist on Linux
-const { systemPreferences } = require('electron');
+// macOS-only Electron APIs that the asar reaches through the darwin spoof.
+// Stub everything as graceful no-op / sensible-default so the asar's own
+// darwin code paths run without TypeError. Returning null/undefined makes
+// the asar disable downstream features; returning shaped values keeps them.
+const { systemPreferences, app: _earlyApp } = require('electron');
+
 if (typeof systemPreferences.setUserDefault !== 'function') {
-  systemPreferences.setUserDefault = function(key, type, value) {
-    // no-op on Linux
-  };
+  systemPreferences.setUserDefault = function() {};
 }
 if (typeof systemPreferences.getUserDefault !== 'function') {
-  systemPreferences.getUserDefault = function(key, type) {
-    return undefined;
+  systemPreferences.getUserDefault = function() { return undefined; };
+}
+if (typeof systemPreferences.promptTouchID !== 'function') {
+  systemPreferences.promptTouchID = function() {
+    return Promise.reject(new Error('Touch ID unavailable on Linux'));
   };
 }
+if (typeof systemPreferences.getMediaAccessStatus !== 'function') {
+  systemPreferences.getMediaAccessStatus = function() { return 'unknown'; };
+}
+if (typeof systemPreferences.askForMediaAccess !== 'function') {
+  systemPreferences.askForMediaAccess = function() { return Promise.resolve(true); };
+}
+
+if (_earlyApp) {
+  for (const _m of [
+    'invalidateCurrentActivity',
+    'setUserActivity',
+    'updateCurrentActivity',
+    'resignCurrentActivity',
+    'getCurrentActivityType',
+  ]) {
+    if (typeof _earlyApp[_m] !== 'function') {
+      _earlyApp[_m] = function() {};
+    }
+  }
+  if (typeof _earlyApp.moveToApplicationsFolder !== 'function') {
+    _earlyApp.moveToApplicationsFolder = function() { return false; };
+  }
+  if (typeof _earlyApp.isInApplicationsFolder !== 'function') {
+    _earlyApp.isInApplicationsFolder = function() { return true; };
+  }
+  if (typeof _earlyApp.hide !== 'function') {
+    _earlyApp.hide = function() {};
+  }
+  // app.dock namespace — referenced via optional chaining in many places but
+  // some sites assume it exists.
+  if (!_earlyApp.dock) {
+    Object.defineProperty(_earlyApp, 'dock', {
+      value: {
+        show: function() { return Promise.resolve(); },
+        hide: function() {},
+        isVisible: function() { return false; },
+        bounce: function() { return -1; },
+        cancelBounce: function() {},
+        downloadFinished: function() {},
+        setBadge: function() {},
+        getBadge: function() { return ''; },
+        setIcon: function() {},
+        setMenu: function() {},
+        getMenu: function() { return null; },
+      },
+      configurable: true,
+    });
+  }
+}
+
+// BrowserWindow.prototype.setHiddenInMissionControl — patched once the
+// electron module is intercepted. Hooked late via our require interceptor;
+// also stubbed via prototype here as belt-and-braces.
+try {
+  const { BrowserWindow: _BW } = require('electron');
+  if (_BW && _BW.prototype && typeof _BW.prototype.setHiddenInMissionControl !== 'function') {
+    _BW.prototype.setHiddenInMissionControl = function() {};
+  }
+} catch (_) {}
 
 // Inject frame fix and Cowork support before main app loads
 const Module = require('module');

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -4,8 +4,8 @@
   const _existing = _path.join(_path.dirname(process.resourcesPath || ''), 'Helpers', 'disclaimer');
   let _haveSystemDisclaimer = false;
   try {
-    const _stat = _fs.statSync(_existing);
-    _haveSystemDisclaimer = _stat.uid === 0;
+    _fs.accessSync(_existing, _fs.constants.X_OK);
+    _haveSystemDisclaimer = true;
   } catch (_) {}
   if (!_haveSystemDisclaimer) {
     const _xdgConfigHome = process.env.XDG_CONFIG_HOME || _path.join(require('os').homedir(), '.config');
@@ -638,6 +638,8 @@ try {
     const _cp = require('child_process');
     const _origExecFile = _cp.execFile;
     const _origSpawn = _cp.spawn;
+    const _origExecFileSync = _cp.execFileSync;
+    const _origSpawnSync = _cp.spawnSync;
     const CLAUDE_SEARCH_PATHS = [
       path.join(os.homedir(), '.local', 'bin', 'claude'),
       path.join(os.homedir(), '.local', 'share', 'mise', 'shims', 'claude'),
@@ -645,7 +647,17 @@ try {
       '/usr/local/bin/claude',
       '/usr/bin/claude',
     ];
-    const ALLOWED_CMD_DIRS = ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'];
+
+    function _isSafeCmd(cmd) {
+      if (typeof cmd !== 'string' || cmd.length === 0) return false;
+      const normalized = path.normalize(cmd);
+      if (normalized.split(path.sep).includes('..')) return false;
+      if (path.isAbsolute(normalized)) {
+        try { fs.accessSync(normalized, fs.constants.X_OK); return true; }
+        catch (_) { return false; }
+      }
+      return !normalized.includes(path.sep);
+    }
 
     function _resolveDisclaimerArgs(file, args) {
       if (file !== disclaimerBin) return null;
@@ -658,25 +670,44 @@ try {
           try { fs.accessSync(candidate, fs.constants.X_OK); cmd = candidate; break; } catch (_) {}
         }
         if (!cmd) return null;
-      } else if (!ALLOWED_CMD_DIRS.some(d => cmd.startsWith(d))) {
+      } else if (!_isSafeCmd(cmd)) {
         return null;
       }
       return { cmd, rest };
     }
 
-    _cp.execFile = function(file, args, ...rest) {
-      const resolved = _resolveDisclaimerArgs(file, args);
-      if (resolved) return _origExecFile.call(_cp, resolved.cmd, resolved.rest, ...rest);
-      return _origExecFile.call(_cp, file, args, ...rest);
-    };
-    Object.assign(_cp.execFile, _origExecFile);
+    // macOS-only commands the asar reaches via the spoof but can't run on Linux.
+    // Reroute to /bin/true (success no-op) so the asar's try/catch sees exit 0
+    // instead of ENOENT, keeping downstream features (MCP bundle accept, gh path
+    // discovery) in their happy path.
+    function _macOnlyCmdNoop(file, args) {
+      if (typeof file !== 'string' || !Array.isArray(args)) return null;
+      const base = file.endsWith('/security') || file === 'security' ? 'security'
+                 : file.endsWith('/xcrun') || file === 'xcrun' ? 'xcrun'
+                 : null;
+      if (!base) return null;
+      if (base === 'security' && args[0] === 'verify-cert') return { cmd: '/bin/true', rest: [] };
+      if (base === 'xcrun') {
+        // xcrun git --version → pretend git is at /usr/bin/git (the Linux default).
+        if (args[0] === 'git') return { cmd: '/usr/bin/git', rest: args.slice(1) };
+        return { cmd: '/bin/true', rest: [] };
+      }
+      return null;
+    }
 
-    _cp.spawn = function(file, args, ...rest) {
-      const resolved = _resolveDisclaimerArgs(file, args);
-      if (resolved) return _origSpawn.call(_cp, resolved.cmd, resolved.rest, ...rest);
-      return _origSpawn.call(_cp, file, args, ...rest);
-    };
-    Object.assign(_cp.spawn, _origSpawn);
+    function _wrap(orig) {
+      return function(file, args, ...rest) {
+        const noop = _macOnlyCmdNoop(file, args);
+        if (noop) return orig.call(_cp, noop.cmd, noop.rest, ...rest);
+        const resolved = _resolveDisclaimerArgs(file, args);
+        if (resolved) return orig.call(_cp, resolved.cmd, resolved.rest, ...rest);
+        return orig.call(_cp, file, args, ...rest);
+      };
+    }
+    _cp.execFile = _wrap(_origExecFile);     Object.assign(_cp.execFile, _origExecFile);
+    _cp.spawn = _wrap(_origSpawn);            Object.assign(_cp.spawn, _origSpawn);
+    _cp.execFileSync = _wrap(_origExecFileSync); Object.assign(_cp.execFileSync, _origExecFileSync);
+    _cp.spawnSync = _wrap(_origSpawnSync);    Object.assign(_cp.spawnSync, _origSpawnSync);
 
     console.log('[disclaimer] Intercepting exec calls at ' + disclaimerBin);
   }

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -1,13 +1,26 @@
 {
   const _fs = require('fs');
   const _path = require('path');
-  const _existing = _path.join(_path.dirname(process.resourcesPath || ''), 'Helpers', 'disclaimer');
-  let _haveSystemDisclaimer = false;
-  try {
-    _fs.accessSync(_existing, _fs.constants.X_OK);
-    _haveSystemDisclaimer = true;
-  } catch (_) {}
-  if (!_haveSystemDisclaimer) {
+  const _candidates = [
+    _path.join(_path.dirname(process.resourcesPath || ''), 'Helpers', 'disclaimer'),
+    '/usr/lib/claude-cowork/Helpers/disclaimer',
+  ];
+  let _systemRoot = null;
+  for (const _bin of _candidates) {
+    try {
+      _fs.accessSync(_bin, _fs.constants.X_OK);
+      _systemRoot = _path.dirname(_path.dirname(_bin));
+      break;
+    } catch (_) {}
+  }
+  if (_systemRoot) {
+    Object.defineProperty(process, 'resourcesPath', {
+      value: _path.join(_systemRoot, 'resources'),
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  } else {
     const _xdgConfigHome = process.env.XDG_CONFIG_HOME || _path.join(require('os').homedir(), '.config');
     Object.defineProperty(process, 'resourcesPath', {
       value: _path.join(_xdgConfigHome, 'Claude', 'cowork-resources'),
@@ -664,7 +677,20 @@ try {
       if (!Array.isArray(args) || args.length === 0) return null;
       let cmd = args[0];
       const rest = args.slice(1);
-      if (/claude\.app\/Contents\/MacOS\/[Cc]laude$/.test(cmd)) {
+      const m = /\/claude-code\/([^/]+)\/claude\.app\/Contents\/MacOS\/[Cc]laude$/.exec(cmd);
+      if (m) {
+        const xdgCfg = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+        const vmBin = path.join(xdgCfg, 'Claude', 'claude-code-vm', m[1], 'claude');
+        let resolved = null;
+        try { fs.accessSync(vmBin, fs.constants.X_OK); resolved = vmBin; } catch (_) {}
+        if (!resolved) {
+          for (const candidate of CLAUDE_SEARCH_PATHS) {
+            try { fs.accessSync(candidate, fs.constants.X_OK); resolved = candidate; break; } catch (_) {}
+          }
+        }
+        if (!resolved) return null;
+        cmd = resolved;
+      } else if (/claude\.app\/Contents\/MacOS\/[Cc]laude$/.test(cmd)) {
         cmd = null;
         for (const candidate of CLAUDE_SEARCH_PATHS) {
           try { fs.accessSync(candidate, fs.constants.X_OK); cmd = candidate; break; } catch (_) {}

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -791,7 +791,7 @@ Object.defineProperty(process, 'platform', {
 });
 
 Object.defineProperty(process, 'arch', {
-  get() { return _inOurCode ? REAL_ARCH : 'arm64'; },
+  get() { return REAL_ARCH; },
   configurable: true
 });
 
@@ -799,7 +799,7 @@ const originalOsPlatform = os.platform;
 const originalOsArch = os.arch;
 
 os.platform = function() { return _inOurCode ? originalOsPlatform.call(os) : 'darwin'; };
-os.arch = function() { return _inOurCode ? originalOsArch.call(os) : 'arm64'; };
+os.arch = function() { return originalOsArch.call(os); };
 
 // Spoof macOS version
 const originalGetSystemVersion = process.getSystemVersion;
@@ -807,7 +807,7 @@ process.getSystemVersion = function() {
   return '14.0.0';
 };
 
-console.log('[Platform] Spoofing: darwin/arm64 macOS 14.0 (immediate)');
+console.log('[Platform] Spoofing: darwin/' + REAL_ARCH + ' macOS 14.0 (immediate)');
 console.log('[Platform] Real platform was:', REAL_PLATFORM);
 
 // ============================================================

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -677,22 +677,32 @@ try {
     }
 
     // macOS-only commands the asar reaches via the spoof but can't run on Linux.
-    // Reroute to /bin/true (success no-op) so the asar's try/catch sees exit 0
-    // instead of ENOENT, keeping downstream features (MCP bundle accept, gh path
-    // discovery) in their happy path.
+    // Reroute to /bin/true (success no-op) or a Linux equivalent so the asar's
+    // try/catch sees exit 0 instead of ENOENT.
     function _macOnlyCmdNoop(file, args) {
       if (typeof file !== 'string' || !Array.isArray(args)) return null;
       const base = file.endsWith('/security') || file === 'security' ? 'security'
                  : file.endsWith('/xcrun') || file === 'xcrun' ? 'xcrun'
+                 : file.endsWith('/osascript') || file === 'osascript' ? 'osascript'
+                 : file.endsWith('/scutil') || file === 'scutil' ? 'scutil'
+                 : file.endsWith('/kextstat') || file === 'kextstat' ? 'kextstat'
+                 : file.endsWith('/system_profiler') || file === 'system_profiler' ? 'system_profiler'
+                 : file.endsWith('/pgrep') || file === 'pgrep' ? 'pgrep'
+                 : (file === '/usr/bin/open' || file.endsWith('/open') && file !== 'xdg-open') ? 'open'
                  : null;
       if (!base) return null;
-      if (base === 'security' && args[0] === 'verify-cert') return { cmd: '/bin/true', rest: [] };
-      if (base === 'xcrun') {
-        // xcrun git --version → pretend git is at /usr/bin/git (the Linux default).
-        if (args[0] === 'git') return { cmd: '/usr/bin/git', rest: args.slice(1) };
-        return { cmd: '/bin/true', rest: [] };
+      if (base === 'security') return { cmd: '/bin/true', rest: [] };
+      if (base === 'xcrun' && args[0] === 'git') return { cmd: '/usr/bin/git', rest: args.slice(1) };
+      if (base === 'xcrun') return { cmd: '/bin/true', rest: [] };
+      if (base === 'open') {
+        // /usr/bin/open <args> → xdg-open with the first non-flag URL/path arg.
+        const target = args.filter(a => !a.startsWith('-')).pop();
+        return target
+          ? { cmd: 'xdg-open', rest: [target] }
+          : { cmd: '/bin/true', rest: [] };
       }
-      return null;
+      // osascript / scutil / kextstat / system_profiler / pgrep — return empty success.
+      return { cmd: '/bin/true', rest: [] };
     }
 
     function _wrap(orig) {


### PR DESCRIPTION
The predictions i had were exactly right, #105 was indeed a superior approach to #98 -- with the caveat of needing a LOT of manual path translations. 
<img width="832" height="638" alt="commitpic2" src="https://github.com/user-attachments/assets/7c648c87-3bad-448a-a208-a39b53f56ced" />
<img width="728" height="607" alt="commitpic1" src="https://github.com/user-attachments/assets/f3764c58-fe44-43e2-8bba-c026aaa3f781" />

^^as you can see here these are just 2 mini-features that did not previously show up in the UI (ignore my claude preference being set to "smooth 90s black guy who doesn't play with no jive turkey")
                                                                                     
 11 commits across 5 files (PKGBUILD, enable-cowork.py, 3 stubs). I will have more on the way depending on what other things people can come up with. Here is a graphical representation of where the project stands with #105 and this one: 
<img width="474" height="417" alt="commitexample" src="https://github.com/user-attachments/assets/7bfed588-a17f-47ba-80a2-e4a11e9f7a18" />

                                    
                                                            
What was changed:                                                                   
  - `enable-cowork.py`: fingerprint-based getHostPlatform patch (replaces global-sub bug — hits only   
  the unique darwin-x64/win32-x64 body, not all 3 occurrences)                                         
  - `claude-swift/index.js`: complete computerUse namespace (apps + display sub-namespaces — asar
  accesses `computerUse.apps.listInstalled()` not flat methods), updater.getShipItJobInfo, vm guest
  request methods for cliPluginBridge, darwin-arch SDK URL
  - `ipc_overrides.js`: removed bridge handler overrides per PR #111 — lets the asar drive WebSocket
  dispatch directly
  - `PKGBUILD`: app.asar inside resources/ to mirror macOS Contents/Resources layout, launcher cache
  hygiene

Note: the computer use feature is one of our biggest gaps and i didn't wanna touch it without @johnzfitch deciding how we'd all go about it. The native macos binary has of course system and accessibility settings that will open the mac settings app. I say keep it simple and just map the actual equivalent linux deps/packages that will satisfy the program's needs and make a qtquick widget that will handle the linkage/stubbing. BUT the fact it even requests for it now goes to show why #105 was the right direction with more foot work (i spent many hours on this because i was salty it is in fact better than #98) 

Subsumes / extends:
  - Extends #108 (macOS Electron stubs base)
  - Subsumes #103 (app activity APIs)
  - Subsumes #110 (invalidateCurrentActivity)
  - Subsumes #111 (bridge handler overrides)
  - Subsumes #112 (claude-swift guest methods)
  - Addresses majority of #107 (active darwin-x64 path gates)
  - Fixes #106 (invalidateCurrentActivity)


Todo fixes-- might also be done already, there is gonna have to be significant stability leg work
I would say merge minimal working fixes or we all just do the leg work to make sure all paths resolve
my assumption in #107 was on the money. You fix 10 path resolutions > find 5 more > fix > find 2 < fix just those 2 > the rest resolve without having to alter the code as significantly. With so many path resolutions thing's can be MUCH more systematic and updates from Anthropic will take 5 minutes to handle if they break things. 

  - #100 / #104 OAuth callback (install.sh-flow specific; AUR PKGBUILD uses xdg-mime registration —
  different code path)
  - #109 node-pty (handled in outer AUR PKGBUILD via `npm install node-pty + npx @electron/rebuild`,
  different mechanism than the vendored ELF approach)
  - ~10 low-impact `~/Library/` path leaks from #107 (NativeMessagingHost, VS Code project detection —
  feature-degraded harmless on Linux) 

The biggest problem i had was- 
  The disclaimer-arg redirect (commit 11) fixes `mcp__workspace__bash` auto-denial: the asar passes
  `claude-code/<ver>/claude.app/Contents/MacOS/claude` as the SDK exec arg; falling back to
  /usr/bin/claude (or any non-version-matched binary) silently breaks the IPC handshake for
  tool_permission_request, so workspace tools deny without ever prompting the UI. Now resolves to
  ~/.config/Claude/claude-code-vm/<ver>/claude.