### PR TITLE
fix: stub macOS NSUserActivity app methods to prevent crash on Linux

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -19,7 +19,7 @@
 }
 
 // Patch macOS-only systemPreferences methods that don't exist on Linux
-const { systemPreferences } = require('electron');
+const { systemPreferences, app: _earlyApp } = require('electron');
 if (typeof systemPreferences.setUserDefault !== 'function') {
   systemPreferences.setUserDefault = function(key, type, value) {
     // no-op on Linux
@@ -29,6 +29,23 @@ if (typeof systemPreferences.getUserDefault !== 'function') {
   systemPreferences.getUserDefault = function(key, type) {
     return undefined;
   };
+}
+
+// Patch macOS-only app methods (NSUserActivity API) — must run before Module.prototype.require
+// override so the stubs are in place before any asar code executes. The asar calls
+// app.invalidateCurrentActivity() when the user navigates between views (e.g. selecting
+// certain UI options), but this is a macOS/NSUserActivity-only Electron method that does
+// not exist on Linux, causing an uncaught TypeError crash dialog. Same pattern as the
+// systemPreferences stubs above.
+if (_earlyApp) {
+  for (const _m of ['invalidateCurrentActivity', 'updateCurrentActivity', 'setCurrentActivity']) {
+    if (typeof _earlyApp[_m] !== 'function') {
+      _earlyApp[_m] = function() { return undefined; };
+    }
+  }
+  if (typeof _earlyApp.getCurrentActivityType !== 'function') {
+    _earlyApp.getCurrentActivityType = function() { return ''; };
+  }
 }
 
 // Inject frame fix and Cowork support before main app loads
@@ -1113,6 +1130,22 @@ Module.prototype.require = function(id) {
         return undefined;
       };
       console.log('[Frame Fix] systemPreferences patched for Linux');
+    }
+
+    // Belt-and-suspenders: also stub NSUserActivity app methods inside the
+    // require intercept in case anything requires electron after our early patch.
+    const _appForStub = resolveElectronApp(module);
+    if (_appForStub && !global.__coworkAppMacStubsPatched) {
+      global.__coworkAppMacStubsPatched = true;
+      for (const _m of ['invalidateCurrentActivity', 'updateCurrentActivity', 'setCurrentActivity']) {
+        if (typeof _appForStub[_m] !== 'function') {
+          _appForStub[_m] = function() { return undefined; };
+        }
+      }
+      if (typeof _appForStub.getCurrentActivityType !== 'function') {
+        _appForStub.getCurrentActivityType = function() { return ''; };
+      }
+      console.log('[Frame Fix] macOS-only app methods stubbed for Linux');
     }
 
     // Patch BrowserWindow to stub macOS-only methods and handle close events


### PR DESCRIPTION
## Problem

When the user selects certain UI options (e.g. navigating between tabs/views), the asar calls `app.invalidateCurrentActivity()` — part of Electron's macOS-only [NSUserActivity API](https://www.electronjs.org/docs/latest/api/app#appinvalidatecurrentactivity-macos). On Linux this method does not exist, producing an uncaught `TypeError` that crashes the main process:

```
Uncaught Exception:
TypeError: gA.app.invalidateCurrentActivity is not a function
    at Frt (.../app.asar/.vite/build/index.js:2467:9879)
    at $ir (.../app.asar/.vite/build/index.js:2467:10193)
    at WebContents.t (.../app.asar/.vite/build/index.js:3157:24129)
    at WebContents.emit (node:events:521:24)
```

The app spoofs `process.platform = 'darwin'`, so the asar's platform guard doesn't protect these calls.

## Fix

Stub the four NSUserActivity `app` methods as no-ops in `frame-fix-wrapper.js`:

- `invalidateCurrentActivity`
- `updateCurrentActivity`
- `setCurrentActivity`
- `getCurrentActivityType`

**Two insertion points** are used, mirroring the existing `systemPreferences` stub pattern:

1. **Early patch** (top of file, before `Module.prototype.require` override) — destructures `app` alongside `systemPreferences` from the initial `require('electron')` call. This ensures stubs are in place before any asar code runs.

2. **Late patch** (inside the `require('electron')` intercept block) — belt-and-suspenders for any code that requires electron after the override is installed.

## Testing

- Launch app → select options that trigger navigation/tab switches → no crash dialog
- Verified on Linux with Electron 33 / app.asar from Claude Desktop