### PR TITLE
fix: stub macOS NSUserActivity handoff APIs on app for Linux

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -1115,6 +1115,34 @@ Module.prototype.require = function(id) {
       console.log('[Frame Fix] systemPreferences patched for Linux');
     }
 
+    // Stub macOS-only NSUserActivity handoff methods on `app`. The asar's
+    // session-switch handler is guarded by `process.platform === "darwin"`,
+    // which we spoof, so it runs on Linux and calls these methods. Without
+    // stubs, switching sessions crashes the main process with
+    // `app.invalidateCurrentActivity is not a function`.
+    {
+      const _appForHandoff = resolveElectronApp(module);
+      if (_appForHandoff && !global.__coworkAppHandoffPatched) {
+        global.__coworkAppHandoffPatched = true;
+        if (typeof _appForHandoff.invalidateCurrentActivity !== 'function') {
+          _appForHandoff.invalidateCurrentActivity = function() {};
+        }
+        if (typeof _appForHandoff.setUserActivity !== 'function') {
+          _appForHandoff.setUserActivity = function() {};
+        }
+        if (typeof _appForHandoff.resignCurrentActivity !== 'function') {
+          _appForHandoff.resignCurrentActivity = function() {};
+        }
+        if (typeof _appForHandoff.updateCurrentActivity !== 'function') {
+          _appForHandoff.updateCurrentActivity = function() {};
+        }
+        if (typeof _appForHandoff.getCurrentActivityType !== 'function') {
+          _appForHandoff.getCurrentActivityType = function() { return ''; };
+        }
+        console.log('[Frame Fix] app NSUserActivity handoff methods stubbed for Linux');
+      }
+    }
+
     // Patch BrowserWindow to stub macOS-only methods and handle close events
     // The asar's close handler does `if (isMac()) return;` which swallows
     // close events since we spoof darwin. We prepend a listener that forces


### PR DESCRIPTION
## Summary

The asar's session-switch / handoff handler is guarded by `process.platform === "darwin"`, which `frame-fix-wrapper` spoofs to `"darwin"` on Linux. The guarded branch calls `app.invalidateCurrentActivity()` and `app.setUserActivity()` — macOS-only Electron APIs (NSUserActivity Handoff) that don't exist on Linux Electron.

Without stubs, switching sessions crashes the main process with:

```
TypeError: cA.app.invalidateCurrentActivity is not a function
  at .../app.asar/.vite/build/index.js:2502:10039
```

Surfaced as the `A JavaScript error occurred in the main process` Electron dialog on session switch in recent asar builds.

## Fix

Add no-op stubs for all five NSUserActivity handoff methods on `app`, in the same block where macOS-only `systemPreferences` methods are already stubbed. Grep of the current bundle shows only `invalidateCurrentActivity` and `setUserActivity` are actually called, but I included the full set (`resignCurrentActivity`, `updateCurrentActivity`, `getCurrentActivityType`) defensively since they're paired in Electron's NSUserActivity surface and stubs are cheap.

```js
{
  const _appForHandoff = resolveElectronApp(module);
  if (_appForHandoff && !global.__coworkAppHandoffPatched) {
    global.__coworkAppHandoffPatched = true;
    if (typeof _appForHandoff.invalidateCurrentActivity !== 'function') {
      _appForHandoff.invalidateCurrentActivity = function() {};
    }
    // ... etc
  }
}
```

The `typeof ... !== 'function'` guard means this is a no-op on real macOS (where the methods exist natively), so the patch is safe to apply unconditionally.

## Test plan

- [x] On Linux (Wayland, Electron 42.0.0): app launches without the `invalidateCurrentActivity` crash dialog
- [x] Stub block visible in startup log: `[Frame Fix] app NSUserActivity handoff methods stubbed for Linux`
- [x] Session switching no longer triggers `TypeError: ... is not a function` in the main process
- [ ] Verify on macOS that the `typeof` guard correctly leaves the real APIs intact (untested by me — no macOS box; reviewer with macOS appreciated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)