### PR TITLE
fix: x86_64 SDK download and macOS Handoff API crash

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -115,6 +115,14 @@ if [ -f "$INDEX_JS" ] && grep -q 'e\.protocol==="file:"&&Ee\.app\.isPackaged===!
   sed -i 's/e\.protocol==="file:"&&Ee\.app\.isPackaged===!0/e.protocol==="file:"/g' "$INDEX_JS"
 fi
 
+# Fix macOS Handoff API: invalidateCurrentActivity() and setUserActivity() are
+# macOS-only Electron APIs that crash on Linux. Replace with safe no-op fallbacks.
+if [ -f "$INDEX_JS" ] && grep -q 'cA\.app\.invalidateCurrentActivity()' "$INDEX_JS"; then
+  echo "Patching macOS Handoff APIs for Linux..."
+  sed -i 's/cA\.app\.invalidateCurrentActivity()/(cA.app.invalidateCurrentActivity||function(){})()/' "$INDEX_JS"
+  sed -i 's/cA\.app\.setUserActivity(adt,/((cA.app.setUserActivity||function(){}))(adt,/' "$INDEX_JS"
+fi
+
 # Fix resource path lookup for i18n, shim-lib, icon, etc.
 # The asar uses `app.isPackaged ? process.resourcesPath : <asar-relative path>`.
 # On Arch Linux, `process.resourcesPath` is the system electron's dir

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1158,7 +1158,9 @@ class SwiftAddonStub extends EventEmitter {
           return { success: true };
         } catch {}
 
-        const arch = os.arch() === 'arm64' ? 'linux-arm64' : 'linux-x64';
+        // Use real arch, not spoofed (process.arch is spoofed to arm64 for macOS compat)
+        const realArch = require('child_process').execFileSync('uname', ['-m'], { encoding: 'utf8' }).trim();
+        const arch = realArch === 'aarch64' ? 'linux-arm64' : 'linux-x64';
         const url = 'https://downloads.claude.ai/claude-code-releases/' + encodeURIComponent(version) + '/' + arch + '/claude.zst';
         console.log('[claude-swift] Downloading SDK binary from ' + url);
         trace('vm.installSdk() downloading ' + url + ' -> ' + targetBin);

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -945,6 +945,19 @@ Module.prototype.require = function(id) {
     global.__coworkElectronPatched = true;
     console.log('[Frame Fix] Intercepting electron module');
 
+    // ── macOS Handoff API stubs (NSUserActivity) ────────────────────────
+    // app.invalidateCurrentActivity() and app.setUserActivity() are
+    // macOS-only Electron APIs. Stub them as no-ops on Linux.
+    if (module.app) {
+      if (typeof module.app.invalidateCurrentActivity !== 'function') {
+        module.app.invalidateCurrentActivity = function() {};
+      }
+      if (typeof module.app.setUserActivity !== 'function') {
+        module.app.setUserActivity = function(_type, _userInfo) {};
+      }
+      console.log('[Frame Fix] Stubbed macOS Handoff APIs (invalidateCurrentActivity, setUserActivity)');
+    }
+
     // ── Native titlebar for Linux/Wayland (KDE, GNOME, etc.) ──────────
     // On macOS, titleBarStyle:"hidden" + titleBarOverlay works fine:
     // the OS draws traffic lights and clicks pass through to child elements.


### PR DESCRIPTION
## Summary

Two bugs that prevent Cowork from working on x86_64 Linux:

- **Wrong SDK architecture**: `installSdk()` in the swift stub uses `os.arch()` to detect platform, but `frame-fix-wrapper.js` spoofs `process.arch` to `'arm64'` for macOS compatibility. This causes the ARM64 binary to be downloaded on x86_64 machines. Fixed by using `uname -m` to detect real architecture.

- **Handoff API crash**: `app.invalidateCurrentActivity()` and `app.setUserActivity()` are macOS-only Electron APIs (NSUserActivity/Handoff). The minified bundle calls these unconditionally when `process.platform === 'darwin'`, which is always true due to platform spoofing. On Linux these are undefined, causing a `TypeError` crash dialog on every launch. Fixed with no-op stubs in two layers: sed patch in `launch.sh` and runtime stub in `frame-fix-wrapper.js`.

## Test plan

- [ ] Install on x86_64 Linux, verify `~/.config/Claude/claude-code-vm/*/claude` is an x86-64 ELF binary (not ARM64)
- [ ] Launch claude-desktop, verify no "invalidateCurrentActivity is not a function" error dialog
- [ ] Send a message in Cowork tab, verify bash oneshot spawns succeed (exit code 0)
- [ ] Verify on ARM64 Linux that `uname -m` returns `aarch64` and correct binary is downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)