### PR TITLE
Patch IPC origin-validation guards for file:// renderer origin

### DIFF
--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -129,6 +129,56 @@ def patch_host_platform(filepath):
     return True
 
 
+# Bypass IPC origin-validation guards.
+#
+# In a packaged build, the renderer is served via the app:// protocol and each
+# IPC channel's main-process handler checks i.senderFrame.url against an
+# interface-specific allowlist. When running unpacked from file:// (which is
+# what we do on Linux), every one of those ~560 guard sites throws, and the
+# preload script that calls DesktopIntl.getInitialLocale() aborts before it
+# can install the contextBridge polyfills the renderer needs ("process is not
+# defined"). Each call site looks like:
+#
+#   if(!FUNC(i))throw new Error(`Incoming "METHOD" call on interface "IFACE"
+#                                from '${...}' did not pass origin validation`)
+#
+# 38+ distinct minified validator names. Replacing `!FUNC(i)` with `false`
+# at every site short-circuits the throw without touching validator bodies.
+#
+# Security: bypassing the origin check on a local desktop app is equivalent
+# to standard dev-mode Electron — the renderer is loaded only by Electron
+# from disk, not from network. No new attack surface vs. packaged macOS build.
+IPC_ORIGIN_GUARD_RE = re.compile(
+    r'if\(!\w+\(i\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
+)
+IPC_PATCH_MARKER = '/*cowork-ipc-patched*/'
+
+
+def patch_ipc_origin_guards(filepath):
+    """Bypass all IPC origin-validation throws so preload scripts execute under
+    file:// origin instead of failing on getInitialLocale and similar calls."""
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    if IPC_PATCH_MARKER in content:
+        print(f"  IPC origin guards: already patched")
+        return True
+
+    new_content, count = IPC_ORIGIN_GUARD_RE.subn(r'if(false)\1', content)
+    if count == 0:
+        print(f"  IPC origin guards: no matching sites found")
+        return True
+
+    # Stamp once at end so re-runs are no-ops
+    new_content += IPC_PATCH_MARKER
+
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+
+    print(f"  IPC origin guards patched: {count} call sites short-circuited")
+    return True
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__)
@@ -137,4 +187,5 @@ if __name__ == "__main__":
     success = patch_file(sys.argv[1])
     if success:
         patch_host_platform(sys.argv[1])
+        patch_ipc_origin_guards(sys.argv[1])
     sys.exit(0 if success else 1)


### PR DESCRIPTION
# Patch IPC origin-validation guards to support file:// renderer origin

## Problem

On a fresh v5.0.0 install against Claude Desktop 1.6608.2, the renderer fails to initialize because every preload script aborts on its first IPC call.

Symptoms in `~/.config/Claude/logs-dev/main-window.log`:

```
[error] Unable to load preload script: .../app.asar/.vite/build/mainWindow.js
[error] Error: Incoming "getInitialLocale" call on interface "DesktopIntl" from
        'file:///.../main_window/index.html' did not pass origin validation
[error] Preload script failed to execute: 'mainWindow.js'
[error] Uncaught ReferenceError: process is not defined
```

`find-in-page.log` shows the same pattern.

## Root cause

In packaged builds the renderer is served via the `app://` protocol. Every IPC channel's main-process handler validates `i.senderFrame.url` against an interface-specific allowlist. When we run unpacked from `file://` on Linux (the johnzfitch path), no allowlist contains `file://`, so all 562 guard sites throw:

```js
if(!FUNC(i))throw new Error(`Incoming "METHOD" call on interface "IFACE"
                              from '${i.senderFrame?.url}' did not pass origin validation`)
```

`enable-cowork.py` v5.0.0 patches `X2i()` and `getHostPlatform()` so cowork *availability* succeeds, but the IPC origin guards still fire on the first preload-script call. `DesktopIntl.getInitialLocale()` is one of the earliest preload calls, so when it throws the preload aborts before installing `contextBridge` polyfills — hence `process is not defined` in the renderer bundle.

There are 38+ distinct minified validator function names (`Age`, `Ld`, `A2t`, `BJt`, …), so per-function patching isn't viable. All 562 call sites share the same shape, so a single site-level regex covers them.

## Fix

One new patch pass in `enable-cowork.py` — `patch_ipc_origin_guards(filepath)` — replaces `!FUNC(i)` with `false` at every IPC guard call site, leaving validator function bodies untouched. Idempotent via an `/*cowork-ipc-patched*/` marker.

## Verification

Against Claude Desktop 1.6608.2 on Debian 13:

| Metric | Before patch | After patch |
|---|---|---|
| `did not pass origin validation` errors | many per launch | **0** |
| `Unable to load preload script` errors | both windows | **0** |
| `Uncaught ReferenceError: process is not defined` | 2+ (main_window + find_in_page) | **0** |
| `[CoworkFilePreview] Protocol handler registered` | ✓ | ✓ |
| Cowork sidebar/UI elements that depend on `contextBridge` | broken | functional |
| Bundle size delta | — | -550 bytes (562 sites × ~1 char) |

Existing patches (`xPt()` / `getHostPlatform()`) are untouched. Doctor still passes 16/17 (the failing one is the unrelated `/sessions` symlink that requires manual sudo).

## Security consideration

Bypassing IPC origin checks on a local desktop app does not introduce new attack surface compared to the packaged macOS build. The renderer is loaded only by Electron from local disk (file:// or asar), not from a network origin. Any attacker capable of writing a malicious renderer to the asar already has the equivalent of code execution as the user. This is the same trust model as standard dev-mode Electron.

For users who want defense-in-depth, a follow-up could register an `app://` custom protocol via `protocol.handle()` and switch `BrowserWindow.loadFile` calls to use it, but that's a substantially larger surgery in the minified main-process bundle. The site-level bypass is the minimal change that restores renderer functionality.

## Files changed

- `enable-cowork.py` — adds `IPC_ORIGIN_GUARD_RE` regex, `IPC_PATCH_MARKER`, `patch_ipc_origin_guards()` function, and one call from `__main__`.

No other file modified.

## Testing

- Patched bundle launches without renderer errors (see verification table)
- Patch is idempotent: second run reports "already patched"
- Patch is no-op on unpatchable builds: reports "no matching sites found" instead of corrupting the bundle
- Diff: see `enable-cowork.diff` (49 added lines, 0 deleted)

---

Local install: Debian 13, kernel 6.12.86, Electron 39 (system), Claude Desktop 1.6608.2, claude-cowork-linux v5.0.0.
