### PR TITLE
Extend disclaimer-unwrap allowlist to cover user-local install dirs

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -581,7 +581,29 @@ try {
       '/usr/local/bin/claude',
       '/usr/bin/claude',
     ];
-    const ALLOWED_CMD_DIRS = ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'];
+    // Disclaimer-unwrap allowlist. On macOS the asar wraps every spawn with
+    // Helpers/disclaimer; the spoofed-darwin Linux path activates the same
+    // wrap, so we unwrap it back to the original command. Restrict the unwrap
+    // to known-good directories so a compromised caller can't trivially
+    // smuggle in arbitrary binaries via the disclaimer args.
+    //
+    // System paths are always trusted. User-local paths cover MCP servers and
+    // CLI tools the user installs via cargo, npm-global, mise, asdf, volta,
+    // and Linux distro conventions. These are user-controlled regardless, so
+    // including them adds no privilege the caller doesn't already have.
+    const ALLOWED_CMD_DIRS = [
+      '/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/', '/opt/',
+      os.homedir() + '/.local/bin/',
+      os.homedir() + '/.npm-global/bin/',
+      os.homedir() + '/.cargo/bin/',
+      os.homedir() + '/go/bin/',
+      os.homedir() + '/.bun/bin/',
+      os.homedir() + '/.deno/bin/',
+      os.homedir() + '/.local/share/mise/shims/',
+      os.homedir() + '/.asdf/shims/',
+      os.homedir() + '/.volta/bin/',
+      os.homedir() + '/bin/',
+    ];
 
     function _resolveDisclaimerArgs(file, args) {
       if (file !== disclaimerBin) return null;


### PR DESCRIPTION
# Extend disclaimer-unwrap allowlist to cover user-local install dirs

## Problem

Custom MCP servers configured in `claude_desktop_config.json` with an absolute path under `$HOME` fail to launch on Claude Desktop with cowork enabled:

```
[error] [<mcp-name>] spawn /home/<user>/.config/Claude/Helpers/disclaimer EACCES
[info]  [<mcp-name>] Server transport closed unexpectedly
[error] [<mcp-name>] Server disconnected
```

Reproducer: add an MCP server whose `command` is, e.g., `/home/<user>/.local/bin/my-mcp` or `/home/<user>/go/bin/my-mcp` and start Claude Desktop. MCPs that use `node`, `python3`, or any binary under `/usr/bin`, `/usr/local/bin`, `/usr/lib`, or `/snap/bin` launch normally; everything else fails identically.

## Root cause

In `frame-fix-wrapper.js`, the comment at line 559–565 explains that Claude Desktop's asar wraps **every** `spawn` call on macOS with `Helpers/disclaimer + [original_cmd, ...original_args]` — confirmed in `.vite/build/index.js`:

```js
function Wd(e) {
  return process.platform !== "darwin"
    ? e
    : { cmd: Nii(), args: [e.cmd, ...e.args] }
}
```

`Nii()` returns `${path.dirname(process.resourcesPath)}/Helpers/disclaimer`.

`enable-cowork.py` spoofs `process.platform` and `getHostPlatform()` to `"darwin"`, which activates this wrap on Linux too. The wrapper creates a stub `Helpers/disclaimer` file (mode 0o444, no execute bit) and monkey-patches `child_process.spawn` / `execFile` to intercept calls to it and re-dispatch to the original command:

```js
function _resolveDisclaimerArgs(file, args) {
  if (file !== disclaimerBin) return null;
  if (!Array.isArray(args) || args.length === 0) return null;
  let cmd = args[0];
  const rest = args.slice(1);
  if (/claude\.app\/Contents\/MacOS\/[Cc]laude$/.test(cmd)) {
    // ... claude.app special case ...
  } else if (!ALLOWED_CMD_DIRS.some(d => cmd.startsWith(d))) {
    return null;  // <-- bug: rejects user-local paths
  }
  return { cmd, rest };
}
```

When the interceptor returns `null`, `_origSpawn` is called with `file = disclaimerBin`, which is non-executable, producing `EACCES`. Result: the MCP never starts.

The current allowlist (`['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/']`) excludes every user-local install directory — `~/.local/bin/`, `~/go/bin/`, `~/.cargo/bin/`, `~/.npm-global/bin/`, mise/asdf/volta shims — which are the standard locations for user-installed CLI tools and MCP servers on Linux.

## Fix

Extend `ALLOWED_CMD_DIRS` to include common user-local install dirs and `/opt/`. Each entry is computed once at module load via `os.homedir()`. The `os` module is already required at the top of `frame-fix-wrapper.js`.

```js
const ALLOWED_CMD_DIRS = [
  '/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/', '/opt/',
  os.homedir() + '/.local/bin/',
  os.homedir() + '/.npm-global/bin/',
  os.homedir() + '/.cargo/bin/',
  os.homedir() + '/go/bin/',
  os.homedir() + '/.bun/bin/',
  os.homedir() + '/.deno/bin/',
  os.homedir() + '/.local/share/mise/shims/',
  os.homedir() + '/.asdf/shims/',
  os.homedir() + '/.volta/bin/',
  os.homedir() + '/bin/',
];
```

Single-file diff against `stubs/frame-fix/frame-fix-wrapper.js`. See `frame-fix-allowlist.diff`.

## Verification

Against Claude Desktop 1.6608.2 + claude-cowork-linux v5.0.0 on Debian 13, with one MCP server whose `command` is `/home/$USER/.local/bin/test-mcp` (a noop binary):

| Metric | Before patch | After patch |
|---|---|---|
| `spawn Helpers/disclaimer EACCES` errors on launch | 1 per user-path MCP | **0** |
| MCP `Server started and connected successfully` | only `node`/`python3` paths | all configured MCPs |
| Bundle size delta | — | +890 bytes (one block) |

Other MCPs (`/usr/local/bin/node`, `/usr/bin/python3`) continue to launch correctly — their paths matched the original allowlist and still do.

## Security consideration

The allowlist exists to prevent a compromised caller from smuggling arbitrary binaries through the disclaimer-rewrite path. The additions don't widen the trust boundary: `$HOME` is already user-writable, so any process that can drop a binary into `~/.cargo/bin/` already has user-level code execution. The allowlist's purpose is to refuse to *legitimize* paths like `/tmp/` or `/dev/shm/`, which are world-writable; those are still rejected.

`/opt/` is included because most third-party CLI tools (zoom, slack, jetbrains) install there and are commonly added to `PATH`.

## Files changed

- `stubs/frame-fix/frame-fix-wrapper.js` — extends `ALLOWED_CMD_DIRS`. 1 deletion, 23 additions.

No other file modified. `enable-cowork.py` is not touched — `frame-fix-wrapper.js` is hand-edited source code, not a patcher target.

## Testing

- Tested on Debian 13 (Trixie), Electron 39, with MCP servers under `~/.local/bin/`, `~/go/bin/`, and `~/.npm-global/bin/` — all launch cleanly.
- No regression against existing system-path MCPs (`node`, `python3`).
- macOS unaffected: the wrap was always intended to be no-op there because the real disclaimer binary exists.

---

Companion PR: `enable-cowork.diff` / `PR_DESCRIPTION.md` patches IPC origin guards. Both PRs are independent and can land in either order.

Local install: Debian 13, kernel 6.12.86, Electron 39 (system), Claude Desktop 1.6608.2, claude-cowork-linux v5.0.0.
