### PR TITLE
feat: consolidate 8 PRs + 4 issues, OCap registry, verifyPath, zero os.homedir()

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -175,6 +175,16 @@ JSEOF
         echo "WARN: file:// preload patch skipped (target not found)"
     fi
 
+    # Add linux branch to getHostPlatform() (without this, the minified
+    # platform switch throws "Unsupported platform: linux-x64" and the
+    # ClaudeCode.prepare IPC fails -- Cowork tasks fail in the UI with a
+    # generic "Something went wrong" banner).
+    if grep -q 'win32-arm64":"win32-x64";throw new Error' "$_indexjs"; then
+        sed -i 's|win32-arm64":"win32-x64";throw new Error|win32-arm64":"win32-x64";if(process.platform==="linux")return A==="arm64"?"linux-arm64":"linux-x64";throw new Error|' "$_indexjs"
+    else
+        echo "WARN: linux-x64 platform patch skipped (target not found)"
+    fi
+
     # Duplicate i18n JSONs into resources/i18n/ (bundle reads from both paths).
     if ls "${_ext}/resources/"*.json >/dev/null 2>&1; then
         mkdir -p "${_ext}/resources/i18n"

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -129,6 +129,93 @@ def patch_host_platform(filepath):
     return True
 
 
+# Bypass IPC origin-validation guards.
+#
+# In a packaged build, the renderer is served via the app:// protocol and each
+# IPC channel's main-process handler checks i.senderFrame.url against an
+# interface-specific allowlist. When running unpacked from file:// (which is
+# what we do on Linux), every one of those ~560 guard sites throws, and the
+# preload script that calls DesktopIntl.getInitialLocale() aborts before it
+# can install the contextBridge polyfills the renderer needs ("process is not
+# defined"). Each call site looks like:
+#
+#   if(!FUNC(i))throw new Error(`Incoming "METHOD" call on interface "IFACE"
+#                                from '${...}' did not pass origin validation`)
+#
+# 38+ distinct minified validator names. Replacing `!FUNC(i)` with `false`
+# at every site short-circuits the throw without touching validator bodies.
+#
+# Security: bypassing the origin check on a local desktop app is equivalent
+# to standard dev-mode Electron — the renderer is loaded only by Electron
+# from disk, not from network. No new attack surface vs. packaged macOS build.
+IPC_ORIGIN_GUARD_RE = re.compile(
+    r'if\(!\w+\(i\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
+)
+IPC_PATCH_MARKER = '/*cowork-ipc-patched*/'
+
+
+def patch_ipc_origin_guards(filepath):
+    """Bypass all IPC origin-validation throws so preload scripts execute under
+    file:// origin instead of failing on getInitialLocale and similar calls."""
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    if IPC_PATCH_MARKER in content:
+        print(f"  IPC origin guards: already patched")
+        return True
+
+    new_content, count = IPC_ORIGIN_GUARD_RE.subn(r'if(false)\1', content)
+    if count == 0:
+        print(f"  IPC origin guards: no matching sites found")
+        return True
+
+    # Stamp once at end so re-runs are no-ops
+    new_content += IPC_PATCH_MARKER
+
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+
+    print(f"  IPC origin guards patched: {count} call sites short-circuited")
+    return True
+
+
+# Patch return-style platform gates (issue #114).
+#
+# Some functions (e.g. Mrt() for Chrome extension installer) use
+# return {status: Error, error: `Unsupported platform: ...`} instead of
+# throw. The HOST_PLATFORM_THROW_RE regex doesn't match these.
+PLATFORM_RETURN_GATE_RE = re.compile(
+    r'return\s*\{[^}]*error:\s*`Unsupported platform:\s*\$\{process\.platform\}[^`]*`[^}]*\}'
+)
+PLATFORM_RETURN_MARKER = '/*cowork-platform-return-patched*/'
+
+
+def patch_platform_return_gates(filepath):
+    """Neutralize return-style 'Unsupported platform' gates that block features
+    like Chrome extension installation on Linux."""
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    if PLATFORM_RETURN_MARKER in content:
+        print(f"  Platform return gates: already patched")
+        return True
+
+    new_content, count = PLATFORM_RETURN_GATE_RE.subn(
+        'return{status:"supported"}', content
+    )
+    if count == 0:
+        print(f"  Platform return gates: no matching sites found")
+        return True
+
+    new_content += PLATFORM_RETURN_MARKER
+
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+
+    print(f"  Platform return gates patched: {count} sites neutralized")
+    return True
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__)
@@ -137,4 +224,6 @@ if __name__ == "__main__":
     success = patch_file(sys.argv[1])
     if success:
         patch_host_platform(sys.argv[1])
+        patch_ipc_origin_guards(sys.argv[1])
+        patch_platform_return_gates(sys.argv[1])
     sys.exit(0 if success else 1)

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -129,7 +129,7 @@ def patch_host_platform(filepath):
     return True
 
 
-# Bypass IPC origin-validation guards.
+# Extend IPC origin-validation guards to accept file:// origins.
 #
 # In a packaged build, the renderer is served via the app:// protocol and each
 # IPC channel's main-process handler checks i.senderFrame.url against an
@@ -142,21 +142,19 @@ def patch_host_platform(filepath):
 #   if(!FUNC(i))throw new Error(`Incoming "METHOD" call on interface "IFACE"
 #                                from '${...}' did not pass origin validation`)
 #
-# 38+ distinct minified validator names. Replacing `!FUNC(i)` with `false`
-# at every site short-circuits the throw without touching validator bodies.
-#
-# Security: bypassing the origin check on a local desktop app is equivalent
-# to standard dev-mode Electron — the renderer is loaded only by Electron
-# from disk, not from network. No new attack surface vs. packaged macOS build.
+# 38+ distinct minified validator names. Rather than disabling all checks, we
+# add a file:// origin exemption at each call site: the original FUNC(i) still
+# validates non-file:// origins (e.g. would reject http://evil.com), so the
+# defense-in-depth layer is preserved for everything except our local renderer.
 IPC_ORIGIN_GUARD_RE = re.compile(
-    r'if\(!\w+\(i\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
+    r'if\(!(\w+)\(i\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
 )
 IPC_PATCH_MARKER = '/*cowork-ipc-patched*/'
 
 
 def patch_ipc_origin_guards(filepath):
-    """Bypass all IPC origin-validation throws so preload scripts execute under
-    file:// origin instead of failing on getInitialLocale and similar calls."""
+    """Add file:// as an accepted origin at each IPC validation call site,
+    preserving the original validator for all other origins."""
     with open(filepath, 'r') as f:
         content = f.read()
 
@@ -164,18 +162,22 @@ def patch_ipc_origin_guards(filepath):
         print(f"  IPC origin guards: already patched")
         return True
 
-    new_content, count = IPC_ORIGIN_GUARD_RE.subn(r'if(false)\1', content)
+    # Replace if(!FUNC(i)) with if(!FUNC(i)&&!(i.senderFrame&&i.senderFrame.url&&i.senderFrame.url.startsWith("file://")))
+    # This lets file:// through while keeping the validator for everything else.
+    new_content, count = IPC_ORIGIN_GUARD_RE.subn(
+        r'if(!\1(i)&&!(i.senderFrame&&i.senderFrame.url&&i.senderFrame.url.startsWith("file://")))\2',
+        content
+    )
     if count == 0:
         print(f"  IPC origin guards: no matching sites found")
         return True
 
-    # Stamp once at end so re-runs are no-ops
     new_content += IPC_PATCH_MARKER
 
     with open(filepath, 'w') as f:
         f.write(new_content)
 
-    print(f"  IPC origin guards patched: {count} call sites short-circuited")
+    print(f"  IPC origin guards patched: {count} call sites — file:// origin exempted, other origins still validated")
     return True
 
 

--- a/install.sh
+++ b/install.sh
@@ -617,6 +617,7 @@ STATE_HOME="\${XDG_STATE_HOME:-\$HOME/.local/state}"
 LOG_DIR="\${CLAUDE_LOG_DIR:-\$STATE_HOME/claude-cowork/logs}"
 export CLAUDE_LOG_DIR="\$LOG_DIR"
 mkdir -p "\$LOG_DIR"
+chmod 700 "\$LOG_DIR"
 
 cd "\$COWORK_DIR"
 
@@ -708,6 +709,9 @@ setup_environment() {
     mkdir -p "$cache_dir"
     mkdir -p "$sessions_dir"
     chmod 700 "$data_dir"
+    chmod 700 "$log_dir"
+    chmod 700 "$cache_dir"
+    chmod 700 "$sessions_dir"
 
     # /sessions symlink — optional. The frame-fix-wrapper fs patch rewrites
     # /sessions/ paths to SESSIONS_BASE at the Node.js fs layer, so the

--- a/install.sh
+++ b/install.sh
@@ -332,14 +332,18 @@ get_archive() {
 
     # 2. Prompt before downloading. The user picks whether to fetch
     #    the latest available version (which may be untested) or to
-    #    abort and supply a specific version via CLAUDE_ARCHIVE.
+    #    supply a tested version manually via CLAUDE_ARCHIVE.
     if command_exists node; then
         local last_tested
         last_tested=$(compat_read_last_tested "$script_dir/COMPAT.md")
         local latest_version=""
-        if [[ -f "$script_dir/fetch-dmg.js" ]]; then
+        local fetch_script=""
+        [[ -f "$script_dir/fetch-dmg.js" ]] && fetch_script="$script_dir/fetch-dmg.js"
+        [[ -z "$fetch_script" && -f "$INSTALL_DIR/fetch-dmg.js" ]] && fetch_script="$INSTALL_DIR/fetch-dmg.js"
+
+        if [[ -n "$fetch_script" ]]; then
             local json
-            json=$(node "$script_dir/fetch-dmg.js" --json 2>/dev/null) || true
+            json=$(node "$fetch_script" --json 2>/dev/null) || true
             if [[ -n "$json" ]]; then
                 latest_version=$(printf '%s' "$json" \
                     | node -e "process.stdin.on('data',d=>{try{process.stdout.write(JSON.parse(d).version||'')}catch{}})" \
@@ -351,29 +355,57 @@ get_archive() {
         log_info "Last tested asar:  $last_tested  (see COMPAT.md)"
         if [[ -n "$latest_version" ]]; then
             log_info "Latest on CDN:     $latest_version"
-            if compat_version_is_newer "$latest_version" "$last_tested"; then
-                log_warn "Latest is newer than the last tested version."
-                log_warn "Untested versions may break features. Review COMPAT.md first."
-            fi
+        fi
+
+        local is_untested=false
+        if [[ -n "$latest_version" ]] && compat_version_is_newer "$latest_version" "$last_tested"; then
+            is_untested=true
+            log_warn "Latest is newer than the last tested version."
+            log_warn "Untested versions may break features. Review COMPAT.md first."
         fi
 
         local proceed=0
         if [[ "${INSTALL_FORCE:-0}" -eq 1 ]]; then
             proceed=1
         elif [[ ! -t 0 ]]; then
-            # Non-interactive (piped) install: refuse without --force to
-            # avoid silently downloading an untested upstream.
             log_warn "Repository updated. Stub-only fixes are live — run launch.sh to apply them without a re-download."
             log_error "Non-interactive install requires --force (or --yes) to confirm download."
             log_error "Re-run as: bash install.sh --force"
             die "Aborting: no confirmation possible"
         else
-            local prompt_target="${latest_version:-the latest available version}"
-            echo -n "  Download Claude Desktop ${prompt_target}? [y/N] "
+            if [[ "$is_untested" == true ]]; then
+                echo ""
+                echo "  Options:"
+                echo "    y  - download $latest_version (untested, may break)"
+                echo "    t  - show instructions for installing the tested version ($last_tested)"
+                echo "    n  - cancel"
+                echo ""
+                echo -n "  Choice [y/t/N]: "
+            else
+                local prompt_target="${latest_version:-the latest available version}"
+                echo -n "  Download Claude Desktop ${prompt_target}? [y/N] "
+            fi
             local reply
             read -r reply
             case "$reply" in
                 y|Y|yes|YES) proceed=1 ;;
+                t|T)
+                    # Tell the user how to get the tested version. We do NOT
+                    # construct download URLs -- the user gets the archive
+                    # from Anthropic directly and passes it to us.
+                    echo ""
+                    echo "  To install the tested version ($last_tested):"
+                    echo ""
+                    echo "  1. Download the Claude Desktop $last_tested DMG from Anthropic."
+                    echo "     The macOS installer is at: https://claude.ai/download"
+                    echo "     (You may need to find the specific version in your download history"
+                    echo "     or ask Anthropic support for a direct link.)"
+                    echo ""
+                    echo "  2. Re-run the installer with the downloaded file:"
+                    echo "     CLAUDE_ARCHIVE=/path/to/Claude-${last_tested}.dmg bash install.sh"
+                    echo ""
+                    die "Install paused. Re-run with CLAUDE_ARCHIVE set."
+                    ;;
                 *) proceed=0 ;;
             esac
         fi

--- a/install.sh
+++ b/install.sh
@@ -363,6 +363,7 @@ get_archive() {
         elif [[ ! -t 0 ]]; then
             # Non-interactive (piped) install: refuse without --force to
             # avoid silently downloading an untested upstream.
+            log_warn "Repository updated. Stub-only fixes are live — run launch.sh to apply them without a re-download."
             log_error "Non-interactive install requires --force (or --yes) to confirm download."
             log_error "Re-run as: bash install.sh --force"
             die "Aborting: no confirmation possible"
@@ -515,7 +516,7 @@ install_stubs() {
     cp "$native_src" "$target_dir/node_modules/@ant/claude-native/index.js"
 
     # Copy frame-fix files
-    for f in frame-fix-wrapper.js frame-fix-entry.js; do
+    for f in frame-fix-wrapper.js frame-fix-entry.js protocol-forwarder.js; do
         if [[ -f "$stub_src/stubs/frame-fix/$f" ]]; then
             cp "$stub_src/stubs/frame-fix/$f" "$target_dir/$f"
         fi
@@ -643,6 +644,34 @@ case "\${1:-}" in
     --debug)    shift; export CLAUDE_TRACE=1; _warn_if_untested_asar; exec ./launch.sh "\$@" ;;
     --doctor)   exec ./install.sh --doctor ;;
     --update)   shift; exec ./install.sh --update "\$@" ;;
+    claude://*)
+        # Protocol handler callback (e.g. OAuth redirect from browser).
+        # Skip the full launch.sh setup — just forward the URL to the already-running
+        # instance via Electron's single-instance mechanism.
+        FORWARDER="\$COWORK_DIR/protocol-forwarder.js"
+        if [ ! -f "\$FORWARDER" ]; then
+            nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \\
+                -- "\$COWORK_DIR" "\$@" >> "\$LOG_DIR/startup.log" 2>&1 &
+            disown
+        else
+            ELECTRON_BIN=""
+            if [[ -x "\$HOME/.local/lib/node_modules/electron/dist/electron" ]]; then
+                ELECTRON_BIN="\$HOME/.local/lib/node_modules/electron/dist/electron"
+            elif [[ -x "\$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron" ]]; then
+                ELECTRON_BIN="\$COWORK_DIR/squashfs-root/usr/lib/node_modules/electron/dist/electron"
+            elif command -v electron >/dev/null 2>&1; then
+                ELECTRON_BIN="\$(command -v electron)"
+            fi
+            if [ -n "\$ELECTRON_BIN" ]; then
+                nohup "\$ELECTRON_BIN" "\$FORWARDER" "\$@" >> "\$LOG_DIR/startup.log" 2>&1 &
+                disown
+            else
+                nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \\
+                    -- "\$COWORK_DIR" "\$@" >> "\$LOG_DIR/startup.log" 2>&1 &
+                disown
+            fi
+        fi
+        ;;
     *)
         _warn_if_untested_asar
         nohup bash -c 'cd "\$1" && shift && exec ./launch.sh "\$@"' \\
@@ -680,13 +709,14 @@ setup_environment() {
     mkdir -p "$sessions_dir"
     chmod 700 "$data_dir"
 
-    # /sessions symlink — the asar passes VM-internal /sessions/... paths that
-    # our stub translates to host paths under this sessions directory.
+    # /sessions symlink — optional. The frame-fix-wrapper fs patch rewrites
+    # /sessions/ paths to SESSIONS_BASE at the Node.js fs layer, so the
+    # symlink is not required. Create it when possible for compatibility.
     if [[ ! -e /sessions ]]; then
-        log_info "Creating /sessions symlink (requires sudo)..."
+        log_info "Attempting /sessions symlink (optional, requires sudo)..."
         sudo ln -s "$sessions_dir" /sessions \
             && log_success "/sessions -> $sessions_dir" \
-            || log_warn "Failed to create /sessions symlink. Run manually: sudo ln -s \"$sessions_dir\" /sessions"
+            || log_info "/sessions symlink not created (optional — fs patch handles rewriting)"
     elif [[ -L /sessions ]]; then
         local current_target
         current_target=$(readlink /sessions)
@@ -901,6 +931,9 @@ doctor() {
     fi
 
     # --- /sessions symlink ---
+    # Note: the fs path redirect patch in frame-fix-wrapper.js rewrites
+    # /sessions/ paths to SESSIONS_BASE at runtime, so the symlink is
+    # optional. It's still created when possible for compatibility.
     if [[ -L /sessions ]]; then
         local target
         target=$(readlink /sessions)
@@ -910,8 +943,8 @@ doctor() {
         log_warn "/sessions exists but is a directory (should be a symlink)"
         warn=$((warn + 1))
     else
-        log_error "/sessions: NOT FOUND -- run: sudo ln -s \"\${XDG_CONFIG_HOME:-\$HOME/.config}/Claude/local-agent-mode-sessions/sessions\" /sessions"
-        fail=$((fail + 1))
+        log_warn "/sessions symlink not present (optional — fs patch handles path rewriting)"
+        warn=$((warn + 1))
     fi
 
     # --- Secret service (D-Bus) ---

--- a/launch.sh
+++ b/launch.sh
@@ -274,8 +274,9 @@ if [[ -n "$WAYLAND_DISPLAY" ]] || [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
   fi
 fi
 
-# Create log directory
+# Create log directory (mode 700: logs may contain session metadata)
 mkdir -p "$LOG_DIR"
+chmod 700 "$LOG_DIR"
 
 # Detect password store backend.
 # gnome-libsecret is preferred (works with gnome-keyring, KeePassXC, KDE Wallet

--- a/launch.sh
+++ b/launch.sh
@@ -11,6 +11,21 @@ cd "$SCRIPT_DIR"
 # Ensure ~/.local/bin is in PATH (common for user-local electron installs)
 export PATH="$HOME/.local/bin:$PATH"
 
+# Point Cowork at the user's Claude Code CLI binary
+if [ -z "$CLAUDE_CODE_PATH" ]; then
+  for _candidate in "$HOME/.local/bin/claude" "$HOME/.npm-global/bin/claude" "/usr/local/bin/claude"; do
+    if [ -x "$_candidate" ]; then
+      export CLAUDE_CODE_PATH="$_candidate"
+      break
+    fi
+  done
+fi
+
+# Wayland auto-detect: let Electron use native Wayland when available
+if [ -z "$ELECTRON_OZONE_PLATFORM_HINT" ]; then
+  export ELECTRON_OZONE_PLATFORM_HINT=auto
+fi
+
 # Resolve electron binary: prefer system electron + local .asar-cache, fall back to AppImage
 if command -v electron >/dev/null 2>&1; then
   ELECTRON_BIN="$(command -v electron)"
@@ -57,6 +72,16 @@ done
 if [ -d "stubs/cowork" ]; then
   mkdir -p "linux-app-extracted/cowork"
   cp -f stubs/cowork/*.js "linux-app-extracted/cowork/"
+fi
+
+# Replace macOS pty.node with the Linux ELF build. The DMG ships a Mach-O
+# universal binary that dlopen rejects ("invalid ELF header"), breaking
+# any LocalSessions.startShellPty path. Built against Electron 41 ABI.
+if [ -f "stubs/node-pty-linux/pty.node" ]; then
+  _PTY_DEST="linux-app-extracted/node_modules/node-pty/build/Release"
+  if [ -d "$_PTY_DEST" ]; then
+    cp -f stubs/node-pty-linux/pty.node "$_PTY_DEST/pty.node"
+  fi
 fi
 
 # Install plugin permission shim so the asar can find it.
@@ -113,6 +138,33 @@ fi
 if [ -f "$INDEX_JS" ] && grep -q 'e\.protocol==="file:"&&Ee\.app\.isPackaged===!0' "$INDEX_JS"; then
   echo "Patching origin validation for file:// preloads..."
   sed -i 's/e\.protocol==="file:"&&Ee\.app\.isPackaged===!0/e.protocol==="file:"/g' "$INDEX_JS"
+fi
+
+# Fix preload origin validation: the mainView.js preload's h() guard checks
+# if window.location.href origin matches claude.ai/preview.claude.ai etc.
+# On Linux with file:// protocol, origin is "null" and h() returns false,
+# preventing CoworkSpaces (and other IPC bridges) from being exposed to the
+# renderer. This causes the Projects page to be empty and spaces to not persist.
+# Patch: add file:// protocol as an allowed origin.
+MAINVIEW_JS="linux-app-extracted/.vite/build/mainView.js"
+if [ -f "$MAINVIEW_JS" ] && ! grep -q 'e\.protocol==="file:"' "$MAINVIEW_JS"; then
+  echo "Patching preload origin validation for file:// protocol..."
+  sed -i 's/e\.hostname==="localhost"/e.hostname==="localhost"||e.protocol==="file:"/g' "$MAINVIEW_JS"
+fi
+
+# Fix --effort xhigh: Claude Desktop may pass --effort xhigh but the SDK binary
+# only supports low/medium/high/max. Remap xhigh -> max in the CLI arg builder.
+if [ -f "$INDEX_JS" ] && grep -q 'O\.push("--effort",this\.options\.effort)' "$INDEX_JS"; then
+  echo "Patching --effort xhigh -> max..."
+  sed -i 's/O\.push("--effort",this\.options\.effort)/O.push("--effort",this.options.effort==="xhigh"?"max":this.options.effort)/' "$INDEX_JS"
+fi
+
+# Fix macOS Handoff API: invalidateCurrentActivity() and setUserActivity() are
+# macOS-only Electron APIs that crash on Linux. Replace with safe no-op fallbacks.
+if [ -f "$INDEX_JS" ] && grep -q 'cA\.app\.invalidateCurrentActivity()' "$INDEX_JS"; then
+  echo "Patching macOS Handoff APIs for Linux..."
+  sed -i 's/cA\.app\.invalidateCurrentActivity()/(cA.app.invalidateCurrentActivity||function(){})()/' "$INDEX_JS"
+  sed -i 's/cA\.app\.setUserActivity(adt,/((cA.app.setUserActivity||function(){}))(adt,/' "$INDEX_JS"
 fi
 
 # Fix resource path lookup for i18n, shim-lib, icon, etc.
@@ -215,8 +267,8 @@ fi
 
 # Wayland support for Hyprland, Sway, and other Wayland compositors
 if [[ -n "$WAYLAND_DISPLAY" ]] || [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
-  export ELECTRON_OZONE_PLATFORM_HINT=wayland
-  echo "Wayland detected, using Ozone platform"
+  export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
+  echo "Wayland detected, using Ozone platform (hint=${ELECTRON_OZONE_PLATFORM_HINT})"
   if [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]]; then
     echo "NOTE: GNOME Wayland does not support the GlobalShortcuts portal — configure shortcuts via GNOME Settings instead"
   fi

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1630,7 +1630,21 @@ class SwiftAddonStub extends EventEmitter {
     processState.deferredResultLine = null;
     processState.stdoutSeq = 0;
 
-    const proc = nodeSpawn(processState.command, processState.args || [], spawnContext.spawnOptions);
+    // Optional bwrap sandbox (CLAUDE_COWORK_SANDBOX=1). Off by default;
+    // when enabled and bwrap is installed, wraps the spawn with a
+    // conservative sandbox profile defined in process_manager.wrapWithBwrap.
+    var spawnCmd = processState.command;
+    var spawnArgs = processState.args || [];
+    try {
+      var { wrapWithBwrap: _wrapBwrap } = require('../../../cowork/process_manager.js');
+      var wrapped = _wrapBwrap ? _wrapBwrap(spawnCmd, spawnArgs, spawnContext.spawnOptions && spawnContext.spawnOptions.cwd) : null;
+      if (wrapped) {
+        trace('[sandbox] wrapping spawn with bwrap: ' + wrapped.command);
+        spawnCmd = wrapped.command;
+        spawnArgs = wrapped.args;
+      }
+    } catch (_) {}
+    const proc = nodeSpawn(spawnCmd, spawnArgs, spawnContext.spawnOptions);
     this._processes.set(processState.id, proc);
     this._attachProcessListeners(processState, proc);
 

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1122,10 +1122,17 @@ class SwiftAddonStub extends EventEmitter {
         trace('vm.isSupported() called');
         return true;
       },
-      isGuestConnected: () => {
-        console.log('[claude-swift] vm.isGuestConnected() called - returning', self._guestConnected);
-        return Promise.resolve(self._guestConnected);
-      },
+      isGuestConnected: (() => {
+        let _lastLog = 0;
+        return () => {
+          const now = Date.now();
+          if (now - _lastLog > 60000) {
+            console.log('[claude-swift] vm.isGuestConnected() ->', self._guestConnected);
+            _lastLog = now;
+          }
+          return Promise.resolve(self._guestConnected);
+        };
+      })(),
       getRunningStatus: () => {
         const status = {
           running: true,
@@ -1178,7 +1185,9 @@ class SwiftAddonStub extends EventEmitter {
           return { success: true };
         } catch {}
 
-        const arch = os.arch() === 'arm64' ? 'linux-arm64' : 'linux-x64';
+        // Use real arch, not spoofed (process.arch is spoofed to arm64 for macOS compat)
+        const realArch = require('child_process').execFileSync('uname', ['-m'], { encoding: 'utf8' }).trim();
+        const arch = realArch === 'aarch64' ? 'linux-arm64' : 'linux-x64';
         const url = 'https://downloads.claude.ai/claude-code-releases/' + encodeURIComponent(version) + '/' + arch + '/claude.zst';
         console.log('[claude-swift] Downloading SDK binary from ' + url);
         trace('vm.installSdk() downloading ' + url + ' -> ' + targetBin);

--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -203,7 +203,7 @@ function resolveClaudeBinaryPath() {
     }
   }
 
-  const home = os.homedir();
+  const home = (global.__coworkPasswdHomedir || os.userInfo().homedir);
   const linuxCandidates = [
     path.join(home, '.local/bin/claude'),
     path.join(home, '.npm-global/bin/claude'),
@@ -321,7 +321,7 @@ function createMountSymlinks(sessionName, additionalMounts) {
         failedMounts.push(mountName);
         continue;
       }
-      const hostUploadsPath = path.join(os.homedir(), uploadsRelPath);
+      const hostUploadsPath = path.join((global.__coworkPasswdHomedir || os.userInfo().homedir), uploadsRelPath);
       try {
         fs.mkdirSync(hostUploadsPath, { recursive: true, mode: 0o700 });
         if (fs.existsSync(mountPoint)) {
@@ -399,7 +399,7 @@ function createMountSymlinks(sessionName, additionalMounts) {
     // Since Claude Desktop v1.569.0+, getVMStorageSubpath returns root-relative
     // subpaths (e.g. "home/user/.config/...") instead of homedir-relative paths.
     // Detect this format to avoid doubled paths like /home/user/home/user/...
-    const _homedir = os.homedir();
+    const _homedir = (global.__coworkPasswdHomedir || os.userInfo().homedir);
     const _asAbsolute = '/' + relativePath;
     const hostPath = relativePath === ''
       ? _homedir

--- a/stubs/cowork/asar_adapter.js
+++ b/stubs/cowork/asar_adapter.js
@@ -6,7 +6,7 @@ const { filterTranscriptMessages } = require('./session_normalization.js');
 // Compute the macOS-style legacy path that the asar's minified code constructs
 // and the XDG path that Electron actually uses on Linux.
 const os = require('os');
-const _homeDir = os.homedir();
+const _homeDir = global.__coworkPasswdHomedir || os.userInfo().homedir;
 const _xdgConfigHome = (typeof process.env.XDG_CONFIG_HOME === 'string' && process.env.XDG_CONFIG_HOME.trim())
   ? path.resolve(process.env.XDG_CONFIG_HOME)
   : path.join(_homeDir, '.config');

--- a/stubs/cowork/bridge_canary.js
+++ b/stubs/cowork/bridge_canary.js
@@ -47,7 +47,7 @@ function isEnabledByEnv() {
 }
 
 function defaultLogPath() {
-  const xdgState = process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state');
+  const xdgState = process.env.XDG_STATE_HOME || path.join(global.__coworkPasswdHomedir || os.userInfo().homedir, '.local', 'state');
   return path.join(xdgState, 'claude-cowork', 'logs', 'bridge-canary.jsonl');
 }
 

--- a/stubs/cowork/dirs.js
+++ b/stubs/cowork/dirs.js
@@ -87,7 +87,7 @@ function createDirs(options) {
   const env = options && options.env && typeof options.env === 'object' ? options.env : process.env;
   const homeDir = options && typeof options.homeDir === 'string' && options.homeDir.trim()
     ? path.resolve(options.homeDir)
-    : os.homedir();
+    : (global.__coworkPasswdHomedir || os.userInfo().homedir);
 
   // Resolve XDG paths with fallbacks to Linux defaults
   const xdgConfigHome = resolveAbsoluteDirectory(env.XDG_CONFIG_HOME, path.join(homeDir, '.config'));
@@ -249,7 +249,7 @@ function validateMountName(mountName) {
 function validateRelativePathWithinHome(relativePath) {
   if (typeof relativePath !== 'string') return false;
   if (relativePath === '') return true;
-  return isPathSafe(os.homedir(), relativePath);
+  return isPathSafe(global.__coworkPasswdHomedir || os.userInfo().homedir, relativePath);
 }
 
 const VM_PATH_RE = /\/sessions\/[^\/\s'"`<>|&;()$\n]+\/mnt\/[^\/\s'"`<>|&;()$\n]+(?:\/[^\s'"`<>|&;()$\n]*)?/g;

--- a/stubs/cowork/exec_capability_registry.js
+++ b/stubs/cowork/exec_capability_registry.js
@@ -138,38 +138,24 @@ function createExecCapabilityRegistry({
     return null;
   }
 
+  var CAPABILITY_LABELS = Object.freeze({
+    bash: 'Bash shell', git: 'Git',
+    'xdg-open': 'XDG open', 'xdg-mime': 'XDG MIME query',
+    which: 'which', curl: 'curl',
+    'notify-send': 'notify-send', gdbus: 'D-Bus client',
+  });
+
   function resolveCapability(id) {
     if (id === 'claude-cli') {
       var p = resolveClaudeCli();
       return p ? { exec: p, label: 'Claude Code CLI' } : null;
     }
-    if (id === 'system-bash') {
-      var paths = SYSTEM_PATHS.bash;
+    var name = typeof id === 'string' && id.startsWith('system-') ? id.slice(7) : null;
+    if (name && SYSTEM_PATHS[name]) {
+      var paths = SYSTEM_PATHS[name];
       for (var i = 0; i < paths.length; i++) {
-        if (existsExecutable(paths[i])) return { exec: paths[i], label: 'Bash shell' };
+        if (existsExecutable(paths[i])) return { exec: paths[i], label: CAPABILITY_LABELS[name] || name };
       }
-      return null;
-    }
-    if (id === 'system-git') {
-      var gp = SYSTEM_PATHS.git;
-      for (var gi = 0; gi < gp.length; gi++) {
-        if (existsExecutable(gp[gi])) return { exec: gp[gi], label: 'Git' };
-      }
-      return null;
-    }
-    if (id === 'system-xdg-open') {
-      var xp = SYSTEM_PATHS['xdg-open'];
-      for (var xi = 0; xi < xp.length; xi++) {
-        if (existsExecutable(xp[xi])) return { exec: xp[xi], label: 'XDG open' };
-      }
-      return null;
-    }
-    if (id === 'system-xdg-mime') {
-      var mp = SYSTEM_PATHS['xdg-mime'];
-      for (var mi = 0; mi < mp.length; mi++) {
-        if (existsExecutable(mp[mi])) return { exec: mp[mi], label: 'XDG MIME query' };
-      }
-      return null;
     }
     return null;
   }

--- a/stubs/cowork/exec_capability_registry.js
+++ b/stubs/cowork/exec_capability_registry.js
@@ -33,7 +33,10 @@ function createExecCapabilityRegistry({
   resolveClaudeBinaryPath = null,
 } = {}) {
   var home;
-  try { home = fs.realpathSync(homedir); } catch (_) { home = homedir; }
+  try { home = fs.realpathSync(homedir); } catch (e) {
+    console.warn('[exec-capability] homedir realpath failed, using raw path: ' + (e && e.message));
+    home = homedir;
+  }
 
   var SYSTEM_PATHS = Object.freeze({
     git:          Object.freeze(['/usr/bin/git', '/usr/local/bin/git']),
@@ -160,6 +163,12 @@ function createExecCapabilityRegistry({
     return null;
   }
 
+  // Disclaimer unwrap only accepts system-owned binaries or the resolved
+  // claude CLI. User-writable paths (USER_MCP_PREFIXES) are EXCLUDED here
+  // because the asar shouldn't invoke user-installed binaries through the
+  // macOS disclaimer wrapper — only system tools like git. Accepting
+  // user-mcp here would let any IPC-influenced args[0] execute arbitrary
+  // user-installed binaries.
   function resolveDisclaimerCommand(args) {
     if (!Array.isArray(args) || args.length === 0) return null;
     var cmd = args[0];
@@ -169,7 +178,12 @@ function createExecCapabilityRegistry({
       return claudePath ? { cmd: claudePath, rest: rest } : null;
     }
     var resolved = resolve(cmd, rest);
-    return resolved ? { cmd: resolved.cmd, rest: rest } : null;
+    if (!resolved) return null;
+    if (resolved.capabilityId === 'user-mcp') {
+      console.warn('[exec-capability] disclaimer unwrap REJECTED user-mcp path: ' + cmd);
+      return null;
+    }
+    return { cmd: resolved.cmd, rest: rest };
   }
 
   function invalidateClaudeCache() {

--- a/stubs/cowork/exec_capability_registry.js
+++ b/stubs/cowork/exec_capability_registry.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function existsExecutable(p) {
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function realpathSafe(p) {
+  if (typeof p !== 'string' || p.length === 0) return null;
+  if (p.charCodeAt(0) !== 47) return null;
+  if (p.indexOf('\0') >= 0) return null;
+  var segs = p.split('/');
+  for (var i = 1; i < segs.length; i++) {
+    if (segs[i] === '' || segs[i] === '.' || segs[i] === '..') return null;
+  }
+  try {
+    return fs.realpathSync(p);
+  } catch (_) {
+    return null;
+  }
+}
+
+function createExecCapabilityRegistry({
+  homedir = os.userInfo().homedir,
+  resolveClaudeBinaryPath = null,
+} = {}) {
+  var home;
+  try { home = fs.realpathSync(homedir); } catch (_) { home = homedir; }
+
+  var SYSTEM_PATHS = Object.freeze({
+    git:          Object.freeze(['/usr/bin/git', '/usr/local/bin/git']),
+    bash:         Object.freeze(['/usr/bin/bash', '/bin/bash']),
+    'xdg-open':   Object.freeze(['/usr/bin/xdg-open']),
+    'xdg-mime':   Object.freeze(['/usr/bin/xdg-mime', '/usr/local/bin/xdg-mime']),
+    which:        Object.freeze(['/usr/bin/which']),
+    curl:         Object.freeze(['/usr/bin/curl', '/usr/local/bin/curl']),
+    'notify-send':Object.freeze(['/usr/bin/notify-send']),
+    gdbus:        Object.freeze(['/usr/bin/gdbus']),
+  });
+
+  var systemPathIndex = new Map();
+  for (var name in SYSTEM_PATHS) {
+    var paths = SYSTEM_PATHS[name];
+    for (var pi = 0; pi < paths.length; pi++) {
+      systemPathIndex.set(paths[pi], 'system-' + name);
+    }
+  }
+
+  var USER_MCP_PREFIXES = Object.freeze([
+    home + '/.local/bin/',
+    home + '/.npm-global/bin/',
+    home + '/.cargo/bin/',
+    home + '/go/bin/',
+    home + '/.bun/bin/',
+    home + '/.deno/bin/',
+    home + '/.local/share/mise/shims/',
+    home + '/.asdf/shims/',
+    home + '/.volta/bin/',
+    home + '/bin/',
+  ]);
+
+  var SYSTEM_CMD_PREFIXES = Object.freeze([
+    '/usr/bin/',
+    '/usr/local/bin/',
+    '/usr/lib/',
+    '/snap/bin/',
+  ]);
+
+  var CLAUDE_SEARCH_PATHS = Object.freeze([
+    home + '/.local/bin/claude',
+    home + '/.local/share/mise/shims/claude',
+    home + '/.asdf/shims/claude',
+    '/usr/local/bin/claude',
+    '/usr/bin/claude',
+  ]);
+
+  var _claudeBinaryCache = undefined;
+
+  function resolveClaudeCli() {
+    if (_claudeBinaryCache !== undefined) return _claudeBinaryCache;
+    if (typeof resolveClaudeBinaryPath === 'function') {
+      var result = resolveClaudeBinaryPath();
+      if (result) { _claudeBinaryCache = result; return result; }
+    }
+    for (var ci = 0; ci < CLAUDE_SEARCH_PATHS.length; ci++) {
+      if (existsExecutable(CLAUDE_SEARCH_PATHS[ci])) {
+        _claudeBinaryCache = CLAUDE_SEARCH_PATHS[ci];
+        return _claudeBinaryCache;
+      }
+    }
+    _claudeBinaryCache = null;
+    return null;
+  }
+
+  function resolve(binaryPath, args) {
+    if (typeof binaryPath !== 'string' || binaryPath.length === 0) return null;
+
+    var real = realpathSafe(binaryPath);
+
+    var claudePath = resolveClaudeCli();
+    if (claudePath && (binaryPath === claudePath || real === claudePath)) {
+      return { capabilityId: 'claude-cli', cmd: claudePath, args: args || [] };
+    }
+
+    if (real) {
+      var sysId = systemPathIndex.get(real);
+      if (sysId) {
+        return { capabilityId: sysId, cmd: real, args: args || [] };
+      }
+    }
+
+    if (!real) {
+      console.warn('[exec-capability] BLOCKED (unresolvable): ' + binaryPath);
+      return null;
+    }
+
+    for (var si = 0; si < SYSTEM_CMD_PREFIXES.length; si++) {
+      if (real.startsWith(SYSTEM_CMD_PREFIXES[si])) {
+        return { capabilityId: 'system-cmd', cmd: real, args: args || [] };
+      }
+    }
+
+    for (var ui = 0; ui < USER_MCP_PREFIXES.length; ui++) {
+      if (real.startsWith(USER_MCP_PREFIXES[ui])) {
+        return { capabilityId: 'user-mcp', cmd: real, args: args || [] };
+      }
+    }
+
+    console.warn('[exec-capability] BLOCKED: ' + binaryPath);
+    return null;
+  }
+
+  function resolveCapability(id) {
+    if (id === 'claude-cli') {
+      var p = resolveClaudeCli();
+      return p ? { exec: p, label: 'Claude Code CLI' } : null;
+    }
+    if (id === 'system-bash') {
+      var paths = SYSTEM_PATHS.bash;
+      for (var i = 0; i < paths.length; i++) {
+        if (existsExecutable(paths[i])) return { exec: paths[i], label: 'Bash shell' };
+      }
+      return null;
+    }
+    if (id === 'system-git') {
+      var gp = SYSTEM_PATHS.git;
+      for (var gi = 0; gi < gp.length; gi++) {
+        if (existsExecutable(gp[gi])) return { exec: gp[gi], label: 'Git' };
+      }
+      return null;
+    }
+    if (id === 'system-xdg-open') {
+      var xp = SYSTEM_PATHS['xdg-open'];
+      for (var xi = 0; xi < xp.length; xi++) {
+        if (existsExecutable(xp[xi])) return { exec: xp[xi], label: 'XDG open' };
+      }
+      return null;
+    }
+    if (id === 'system-xdg-mime') {
+      var mp = SYSTEM_PATHS['xdg-mime'];
+      for (var mi = 0; mi < mp.length; mi++) {
+        if (existsExecutable(mp[mi])) return { exec: mp[mi], label: 'XDG MIME query' };
+      }
+      return null;
+    }
+    return null;
+  }
+
+  function resolveDisclaimerCommand(args) {
+    if (!Array.isArray(args) || args.length === 0) return null;
+    var cmd = args[0];
+    var rest = args.slice(1);
+    if (/claude\.app\/Contents\/MacOS\/[Cc]laude$/.test(cmd)) {
+      var claudePath = resolveClaudeCli();
+      return claudePath ? { cmd: claudePath, rest: rest } : null;
+    }
+    var resolved = resolve(cmd, rest);
+    return resolved ? { cmd: resolved.cmd, rest: rest } : null;
+  }
+
+  function invalidateClaudeCache() {
+    _claudeBinaryCache = undefined;
+  }
+
+  return Object.freeze({
+    resolve: resolve,
+    resolveCapability: resolveCapability,
+    resolveDisclaimerCommand: resolveDisclaimerCommand,
+    invalidateClaudeCache: invalidateClaudeCache,
+    SYSTEM_PATHS: SYSTEM_PATHS,
+    USER_MCP_PREFIXES: USER_MCP_PREFIXES,
+    SYSTEM_CMD_PREFIXES: SYSTEM_CMD_PREFIXES,
+  });
+}
+
+module.exports = Object.freeze({
+  createExecCapabilityRegistry: createExecCapabilityRegistry,
+  realpathSafe: realpathSafe,
+  existsExecutable: existsExecutable,
+});

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -34,10 +34,13 @@ function vlog(msg) { if (_verbose) console.log(msg); }
 // isn't set yet (e.g. during tests).
 const _homeDir = global.__coworkPasswdHomedir || require('os').userInfo().homedir;
 // User-scoped tmpdir: os.tmpdir() is patched by frame-fix-wrapper.js to return
-// a private dir under ~/.config/Claude (mode 0700). We use that instead of
-// the world-writable /tmp to keep the trust boundary within user-owned paths.
-const _userTmpDir = require('os').tmpdir();
-const _allowedFsRoots = [_homeDir, _userTmpDir];
+// a private dir under ~/.config/Claude (mode 0700). We read it lazily because
+// this module loads before the patch runs.
+let _allowedFsRoots = null;
+function getAllowedFsRoots() {
+  if (!_allowedFsRoots) _allowedFsRoots = [_homeDir, require('os').tmpdir()];
+  return _allowedFsRoots;
+}
 
 // Lazy-initialized spaces store — uses global.__coworkDirs set by frame-fix-wrapper.js
 let _spacesStore = null;
@@ -106,7 +109,7 @@ function isPathWithinAllowedRoots(filePath) {
     }
     if (!resolved) resolved = normalized;
   }
-  return _allowedFsRoots.some(root =>
+  return getAllowedFsRoots().some(root =>
     resolved === root || resolved.startsWith(root + path.sep)
   );
 }
@@ -204,7 +207,7 @@ function resolveTerminal() {
           _resolvedTerminal = { bin: resolvedPath, spawn: ['-e'] };
           return _resolvedTerminal;
         }
-      } else if (resolvedPath && resolvedPath.startsWith('/usr/')) {
+      } else if (resolvedPath && ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'].some(d => resolvedPath.startsWith(d))) {
         _resolvedTerminal = { bin: resolvedPath, spawn: ['-e'] };
         return _resolvedTerminal;
       }

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -29,7 +29,10 @@ const { createSpacesStore } = require('./spaces_store.js');
 const _verbose = process.env.CLAUDE_COWORK_VERBOSE === '1';
 function vlog(msg) { if (_verbose) console.log(msg); }
 
-const _homeDir = require('os').homedir();
+// Security boundary: homedir from /etc/passwd (set by frame-fix-wrapper.js),
+// NOT from $HOME env var. Falls back to os.userInfo().homedir if the global
+// isn't set yet (e.g. during tests).
+const _homeDir = global.__coworkPasswdHomedir || require('os').userInfo().homedir;
 // User-scoped tmpdir: os.tmpdir() is patched by frame-fix-wrapper.js to return
 // a private dir under ~/.config/Claude (mode 0700). We use that instead of
 // the world-writable /tmp to keep the trust boundary within user-owned paths.

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -38,7 +38,7 @@ function getSpacesStore() {
   if (!_spacesStore) {
     const dirs = global.__coworkDirs;
     const localAgentRoot = dirs ? dirs.claudeLocalAgentRoot : path.join(_homeDir, '.config', 'Claude', 'local-agent-mode-sessions');
-    _spacesStore = createSpacesStore({ localAgentRoot, trace: vlog });
+    _spacesStore = createSpacesStore({ localAgentRoot, isPathAllowed: isPathWithinAllowedRoots, trace: vlog });
   }
   return _spacesStore;
 }

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -131,14 +131,26 @@ function isBinaryMime(mime) {
   return BINARY_MIME_PREFIXES.some(p => mime.startsWith(p));
 }
 
-function readLocalFileContent(filePath) {
-  const buf = fs.readFileSync(filePath);
-  const mime = getMimeType(filePath);
-  const fileName = path.basename(filePath);
-  if (isBinaryMime(mime)) {
-    return { content: buf.toString('base64'), mimeType: mime, fileName, encoding: 'base64' };
+// Public API: front-door validator. Logs every block with the original
+// input. Returns the file content or null. Internal _readVerifiedContent
+// trusts its input — it can only be reached after verifyPath succeeds.
+function readLocalFileContent(rawPath, context) {
+  var real = verifyPath(rawPath);
+  if (!real) {
+    console.warn('[Cowork] ' + (context || 'readLocalFileContent') + ' BLOCKED:', rawPath);
+    return null;
   }
-  return { content: buf.toString('utf-8'), mimeType: mime, fileName, encoding: 'utf-8' };
+  return _readVerifiedContent(real);
+}
+
+function _readVerifiedContent(real) {
+  var buf = fs.readFileSync(real);
+  var mime = getMimeType(real);
+  var fileName = path.basename(real);
+  if (isBinaryMime(mime)) {
+    return { content: buf.toString('base64'), mimeType: mime, fileName: fileName, encoding: 'base64' };
+  }
+  return { content: buf.toString('utf-8'), mimeType: mime, fileName: fileName, encoding: 'utf-8' };
 }
 
 const XDG_APP_DIRS = [
@@ -231,32 +243,40 @@ function resolveTerminal() {
   return null;
 }
 
-function xdgOpen(filePath) {
-  // Directories should always open in the file manager via xdg-open
-  try { if (fs.statSync(filePath).isDirectory()) {
-    const child = execFile('xdg-open', [filePath], { stdio: 'ignore' });
+// Public API: front-door validator. Logs blocks with the original input.
+// Internal _xdgOpenVerified trusts its input.
+function xdgOpen(rawPath, context) {
+  var real = verifyPath(rawPath);
+  if (!real) {
+    console.warn('[Cowork] ' + (context || 'xdgOpen') + ' BLOCKED:', rawPath);
+    return;
+  }
+  _xdgOpenVerified(real);
+}
+
+function _xdgOpenVerified(real) {
+  try { if (fs.statSync(real).isDirectory()) {
+    var child = execFile('xdg-open', [real], { stdio: 'ignore' });
     child.unref();
     return;
   }} catch (_) {}
-  const mime = getMimeType(filePath);
-  const desktop = getDesktopFileForMime(mime);
+  var mime = getMimeType(real);
+  var desktop = getDesktopFileForMime(mime);
   if (isTerminalApp(desktop)) {
-    const cmd = getExecFromDesktop(desktop);
+    var cmd = getExecFromDesktop(desktop);
     if (cmd) {
-      // Resolve which terminal emulator to use (cached after first lookup)
-      const term = resolveTerminal();
+      var term = resolveTerminal();
       if (term) {
-        const child = term.spawn
-          ? execFile(term.bin, [...term.spawn, cmd, filePath], { stdio: 'ignore' })
-          : execFile(term.bin, [cmd, filePath], { stdio: 'ignore' });
-        child.unref();
+        var tchild = term.spawn
+          ? execFile(term.bin, [].concat(term.spawn, [cmd, real]), { stdio: 'ignore' })
+          : execFile(term.bin, [cmd, real], { stdio: 'ignore' });
+        tchild.unref();
         return;
       }
     }
   }
-  // Non-terminal app or no terminal found: use xdg-open
-  const child = execFile('xdg-open', [filePath], { stdio: 'ignore' });
-  child.unref();
+  var ochild = execFile('xdg-open', [real], { stdio: 'ignore' });
+  ochild.unref();
 }
 
 function whichApplicationForFile(filename) {
@@ -308,48 +328,25 @@ function createOverrideRegistry(getProcessState) {
     'ClaudeVM_$_download': async () => ({ success: true }),
     'ClaudeVM_$_deleteAndReinstall': async () => ({ success: true }),
 
-    // FileSystem — proper Linux implementations.
-    // All handlers use verifyPath() which returns the canonical real path.
-    // We operate on the canonical path, not the raw input — no TOCTOU.
-    'FileSystem_$_readLocalFile': async (_event, sessionId, filePath) => {
+    // FileSystem — single front-door validation per call.
+    // readLocalFileContent and xdgOpen validate at their boundary and
+    // log every block. Handlers just decode and delegate.
+    'FileSystem_$_readLocalFile': async (_event, _sessionId, filePath) => {
       var decoded;
       try { decoded = decodeURIComponent(filePath); } catch (_) { return null; }
-      var real = verifyPath(decoded);
-      if (!real) {
-        console.warn('[Cowork] readLocalFile BLOCKED:', decoded);
-        return null;
-      }
       try {
-        return readLocalFileContent(real);
+        return readLocalFileContent(decoded, 'readLocalFile');
       } catch (e) {
-        console.error('[Cowork] readLocalFile failed:', real, e.code || e.message);
+        console.error('[Cowork] readLocalFile failed:', e.code || e.message);
         return null;
       }
     },
 
-    'FileSystem_$_openLocalFile': async (_event, sessionId, filePath, showInFolder) => {
+    'FileSystem_$_openLocalFile': async (_event, _sessionId, filePath, showInFolder) => {
       var decoded;
       try { decoded = decodeURIComponent(filePath); } catch (_) { return; }
-      var real = verifyPath(decoded);
-      if (!real) {
-        console.warn('[Cowork] openLocalFile BLOCKED:', decoded);
-        return;
-      }
-      try {
-        if (showInFolder) {
-          var parentDir = path.dirname(real);
-          var realParent = verifyPath(parentDir);
-          if (!realParent) {
-            console.warn('[Cowork] openLocalFile BLOCKED (dirname):', parentDir);
-            return;
-          }
-          xdgOpen(realParent);
-        } else {
-          xdgOpen(real);
-        }
-      } catch (e) {
-        console.error('[Cowork] openLocalFile failed:', real, e.code || e.message);
-      }
+      var target = showInFolder ? path.dirname(decoded) : decoded;
+      xdgOpen(target, showInFolder ? 'openLocalFile.parent' : 'openLocalFile');
     },
 
     'FileSystem_$_whichApplication': async (_event, filename) => {
@@ -359,20 +356,7 @@ function createOverrideRegistry(getProcessState) {
     'FileSystem_$_showInFolder': async (_event, filePath) => {
       var decoded;
       try { decoded = decodeURIComponent(filePath); } catch (_) { return; }
-      var real = verifyPath(decoded);
-      if (!real) {
-        console.warn('[Cowork] showInFolder BLOCKED:', decoded);
-        return;
-      }
-      var parentDir = path.dirname(real);
-      var realParent = verifyPath(parentDir);
-      if (!realParent) {
-        console.warn('[Cowork] showInFolder BLOCKED (dirname):', parentDir);
-        return;
-      }
-      try {
-        xdgOpen(realParent);
-      } catch (_) {}
+      xdgOpen(path.dirname(decoded), 'showInFolder');
     },
 
     'FileSystem_$_getSystemPath': async (_event, name) => {

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -188,20 +188,27 @@ function getExecFromDesktop(desktopFile) {
 
 // Terminal emulator resolution — cached after first successful lookup.
 // Checks: $TERMINAL env, xdg-terminal-exec, then common emulators.
+// Validated through the exec capability registry (system cmd prefixes).
 let _resolvedTerminal = undefined;
 function resolveTerminal() {
   if (_resolvedTerminal !== undefined) return _resolvedTerminal;
+  var registry = global.__coworkExecRegistry || null;
   // 1. Respect $TERMINAL env var (user's explicit preference)
-  const SAFE_BIN_DIRS = ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'];
   const envTerm = process.env.TERMINAL;
   if (envTerm) {
     try {
       const resolvedPath = execFileSync('which', [envTerm], { encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-      if (resolvedPath && SAFE_BIN_DIRS.some(d => resolvedPath.startsWith(d))) {
+      if (resolvedPath && registry) {
+        var cap = registry.resolve(resolvedPath, []);
+        if (cap) {
+          _resolvedTerminal = { bin: resolvedPath, spawn: ['-e'] };
+          return _resolvedTerminal;
+        }
+      } else if (resolvedPath && resolvedPath.startsWith('/usr/')) {
         _resolvedTerminal = { bin: resolvedPath, spawn: ['-e'] };
         return _resolvedTerminal;
       }
-      console.warn('[Cowork] $TERMINAL resolved outside system dirs, ignoring:', resolvedPath);
+      console.warn('[Cowork] $TERMINAL not in capability registry, ignoring:', resolvedPath);
     } catch (_) {}
   }
   // 2. xdg-terminal-exec (proposed XDG Default Terminal Spec)
@@ -216,7 +223,6 @@ function resolveTerminal() {
     'gnome-terminal', 'konsole', 'xfce4-terminal', 'mate-terminal',
     'tilix', 'lxterminal', 'terminology', 'sakura', 'xterm',
   ];
-  // gnome-terminal/konsole use '--' instead of '-e' for command separation
   const dashDashTerminals = new Set(['gnome-terminal', 'konsole']);
   for (const t of terminals) {
     try {

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -30,7 +30,11 @@ const _verbose = process.env.CLAUDE_COWORK_VERBOSE === '1';
 function vlog(msg) { if (_verbose) console.log(msg); }
 
 const _homeDir = require('os').homedir();
-const _allowedFsRoots = [_homeDir, '/tmp'];
+// User-scoped tmpdir: os.tmpdir() is patched by frame-fix-wrapper.js to return
+// a private dir under ~/.config/Claude (mode 0700). We use that instead of
+// the world-writable /tmp to keep the trust boundary within user-owned paths.
+const _userTmpDir = require('os').tmpdir();
+const _allowedFsRoots = [_homeDir, _userTmpDir];
 
 // Lazy-initialized spaces store — uses global.__coworkDirs set by frame-fix-wrapper.js
 let _spacesStore = null;

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -29,25 +29,52 @@ const { createSpacesStore } = require('./spaces_store.js');
 const _verbose = process.env.CLAUDE_COWORK_VERBOSE === '1';
 function vlog(msg) { if (_verbose) console.log(msg); }
 
-// Security boundary: homedir from /etc/passwd (set by frame-fix-wrapper.js),
-// NOT from $HOME env var. Falls back to os.userInfo().homedir if the global
-// isn't set yet (e.g. during tests).
-const _homeDir = global.__coworkPasswdHomedir || require('os').userInfo().homedir;
-// User-scoped tmpdir: os.tmpdir() is patched by frame-fix-wrapper.js to return
-// a private dir under ~/.config/Claude (mode 0700). We read it lazily because
-// this module loads before the patch runs.
-let _allowedFsRoots = null;
-function getAllowedFsRoots() {
-  if (!_allowedFsRoots) _allowedFsRoots = [_homeDir, require('os').tmpdir()];
-  return _allowedFsRoots;
+// Security boundary: homedir resolved to canonical form at load time.
+// Uses passwd-based homedir (not $HOME), then realpathSync to defeat
+// symlinked home directories.
+var _rawHomeDir = global.__coworkPasswdHomedir || require('os').userInfo().homedir;
+var _realHomeDir;
+try { _realHomeDir = fs.realpathSync(_rawHomeDir); } catch (_) { _realHomeDir = _rawHomeDir; }
+
+// Only the user's home directory is an allowed root. No /tmp, no
+// system dirs, no world-writable paths.
+var _allowedFsRoots = [_realHomeDir];
+
+// Validate and resolve a path in one pass. No normalization, no
+// transformation. The input must be a clean absolute path as-given.
+// Returns the canonical real path if valid, null if anything is wrong.
+function verifyPath(rawPath) {
+  if (typeof rawPath !== 'string' || rawPath.length === 0) return null;
+  if (rawPath.charCodeAt(0) !== 47) return null;
+  if (rawPath.length > 1 && rawPath.charCodeAt(rawPath.length - 1) === 47) return null;
+  if (rawPath.indexOf('\0') >= 0) return null;
+  var segments = rawPath.split('/');
+  for (var i = 1; i < segments.length; i++) {
+    if (segments[i] === '' || segments[i] === '.' || segments[i] === '..') return null;
+  }
+  var real;
+  try {
+    real = fs.realpathSync(rawPath);
+  } catch (_) {
+    return null;
+  }
+  if (!_allowedFsRoots.some(function(root) {
+    return real === root || real.startsWith(root + '/');
+  })) {
+    return null;
+  }
+  return real;
 }
 
-// Lazy-initialized spaces store — uses global.__coworkDirs set by frame-fix-wrapper.js
+function isPathWithinAllowedRoots(filePath) {
+  return verifyPath(filePath) !== null;
+}
+
 let _spacesStore = null;
 function getSpacesStore() {
   if (!_spacesStore) {
     const dirs = global.__coworkDirs;
-    const localAgentRoot = dirs ? dirs.claudeLocalAgentRoot : path.join(_homeDir, '.config', 'Claude', 'local-agent-mode-sessions');
+    const localAgentRoot = dirs ? dirs.claudeLocalAgentRoot : path.join(_realHomeDir, '.config', 'Claude', 'local-agent-mode-sessions');
     _spacesStore = createSpacesStore({ localAgentRoot, isPathAllowed: isPathWithinAllowedRoots, trace: vlog });
   }
   return _spacesStore;
@@ -78,40 +105,6 @@ function createSpacesOverrides() {
     'CoworkSpaces_$_summarizeSpace': async (event, spaceId) => store.summarizeSpace(event, spaceId),
     'CoworkSpaces_$_onSpaceEvent': async (event, callback) => store.onSpaceEvent(event, callback),
   };
-}
-
-function isPathWithinAllowedRoots(filePath) {
-  if (typeof filePath !== 'string' || !path.isAbsolute(filePath)) {
-    return false;
-  }
-  const normalized = path.normalize(filePath);
-  let resolved;
-  try {
-    resolved = fs.realpathSync(normalized);
-  } catch (_) {
-    // File doesn't exist yet. Walk up to the nearest existing ancestor and
-    // resolve symlinks THERE, then reattach the non-existent suffix.
-    // Without this, a symlink at an intermediate component (e.g.
-    // ~/spaces/SPACEID/escape -> /) would pass the prefix check via
-    // path.normalize (which ignores symlinks) and escape on the actual
-    // filesystem operation.
-    let current = path.dirname(normalized);
-    let tail = path.basename(normalized);
-    resolved = null;
-    while (current !== path.dirname(current)) {
-      try {
-        resolved = path.join(fs.realpathSync(current), tail);
-        break;
-      } catch (_) {
-        tail = path.join(path.basename(current), tail);
-        current = path.dirname(current);
-      }
-    }
-    if (!resolved) resolved = normalized;
-  }
-  return getAllowedFsRoots().some(root =>
-    resolved === root || resolved.startsWith(root + path.sep)
-  );
 }
 
 function getMimeType(filePath) {
@@ -151,7 +144,7 @@ function readLocalFileContent(filePath) {
 const XDG_APP_DIRS = [
   '/usr/share/applications',
   '/usr/local/share/applications',
-  path.join(require('os').homedir(), '.local', 'share', 'applications'),
+  path.join(_realHomeDir, '.local', 'share', 'applications'),
 ];
 
 function readDesktopFile(desktopFile) {
@@ -315,48 +308,47 @@ function createOverrideRegistry(getProcessState) {
     'ClaudeVM_$_download': async () => ({ success: true }),
     'ClaudeVM_$_deleteAndReinstall': async () => ({ success: true }),
 
-    // FileSystem — proper Linux implementations
+    // FileSystem — proper Linux implementations.
+    // All handlers use verifyPath() which returns the canonical real path.
+    // We operate on the canonical path, not the raw input — no TOCTOU.
     'FileSystem_$_readLocalFile': async (_event, sessionId, filePath) => {
-      let decoded;
-      try {
-        decoded = decodeURIComponent(filePath);
-      } catch (_e) {
-        return null;
-      }
-      if (!path.isAbsolute(decoded)) return null;
-      if (!isPathWithinAllowedRoots(decoded)) {
-        console.warn('[Cowork] readLocalFile BLOCKED (outside allowed roots):', decoded);
+      var decoded;
+      try { decoded = decodeURIComponent(filePath); } catch (_) { return null; }
+      var real = verifyPath(decoded);
+      if (!real) {
+        console.warn('[Cowork] readLocalFile BLOCKED:', decoded);
         return null;
       }
       try {
-        return readLocalFileContent(decoded);
+        return readLocalFileContent(real);
       } catch (e) {
-        console.error('[Cowork] readLocalFile failed:', decoded, e.code || e.message);
+        console.error('[Cowork] readLocalFile failed:', real, e.code || e.message);
         return null;
       }
     },
 
     'FileSystem_$_openLocalFile': async (_event, sessionId, filePath, showInFolder) => {
-      let decoded;
-      try {
-        decoded = decodeURIComponent(filePath);
-      } catch (_e) {
-        return;
-      }
-      vlog('[Cowork] openLocalFile: ' + decoded + ' showInFolder: ' + showInFolder);
-      if (!path.isAbsolute(decoded)) return;
-      if (!isPathWithinAllowedRoots(decoded)) {
-        console.warn('[Cowork] openLocalFile BLOCKED (outside allowed roots):', decoded);
+      var decoded;
+      try { decoded = decodeURIComponent(filePath); } catch (_) { return; }
+      var real = verifyPath(decoded);
+      if (!real) {
+        console.warn('[Cowork] openLocalFile BLOCKED:', decoded);
         return;
       }
       try {
         if (showInFolder) {
-          xdgOpen(path.dirname(decoded));
+          var parentDir = path.dirname(real);
+          var realParent = verifyPath(parentDir);
+          if (!realParent) {
+            console.warn('[Cowork] openLocalFile BLOCKED (dirname):', parentDir);
+            return;
+          }
+          xdgOpen(realParent);
         } else {
-          xdgOpen(decoded);
+          xdgOpen(real);
         }
       } catch (e) {
-        console.error('[Cowork] openLocalFile failed:', decoded, e.code || e.message);
+        console.error('[Cowork] openLocalFile failed:', real, e.code || e.message);
       }
     },
 
@@ -365,22 +357,21 @@ function createOverrideRegistry(getProcessState) {
     },
 
     'FileSystem_$_showInFolder': async (_event, filePath) => {
-      let decoded;
-      try {
-        decoded = decodeURIComponent(filePath);
-      } catch (_e) {
+      var decoded;
+      try { decoded = decodeURIComponent(filePath); } catch (_) { return; }
+      var real = verifyPath(decoded);
+      if (!real) {
+        console.warn('[Cowork] showInFolder BLOCKED:', decoded);
         return;
       }
-      vlog('[Cowork] showInFolder: ' + decoded);
-      if (!path.isAbsolute(decoded)) return;
-      if (!isPathWithinAllowedRoots(decoded)) {
-        console.warn('[Cowork] showInFolder BLOCKED (outside allowed roots):', decoded);
+      var parentDir = path.dirname(real);
+      var realParent = verifyPath(parentDir);
+      if (!realParent) {
+        console.warn('[Cowork] showInFolder BLOCKED (dirname):', parentDir);
         return;
       }
       try {
-        // D-Bus FileManager1 isn't available on Hyprland/wlroots compositors.
-        // Open the parent directory with xdg-open instead.
-        xdgOpen(path.dirname(decoded));
+        xdgOpen(realParent);
       } catch (_) {}
     },
 

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -146,6 +146,7 @@ const XDG_APP_DIRS = [
 
 function readDesktopFile(desktopFile) {
   if (!desktopFile) return null;
+  if (path.basename(desktopFile) !== desktopFile) return null;
   for (const dir of XDG_APP_DIRS) {
     try {
       return fs.readFileSync(path.join(dir, desktopFile), 'utf-8');

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -46,15 +46,21 @@ var _allowedFsRoots = [_realHomeDir];
 function verifyPath(rawPath) {
   if (typeof rawPath !== 'string' || rawPath.length === 0) return null;
   if (rawPath.charCodeAt(0) !== 47) return null;
-  if (rawPath.length > 1 && rawPath.charCodeAt(rawPath.length - 1) === 47) return null;
   if (rawPath.indexOf('\0') >= 0) return null;
-  var segments = rawPath.split('/');
+  // Strip trailing slash for normalization (legitimate directory paths
+  // often arrive with one). Empty result means input was just "/" — reject.
+  var clean = rawPath;
+  while (clean.length > 1 && clean.charCodeAt(clean.length - 1) === 47) {
+    clean = clean.slice(0, -1);
+  }
+  if (clean.length <= 1) return null;
+  var segments = clean.split('/');
   for (var i = 1; i < segments.length; i++) {
     if (segments[i] === '' || segments[i] === '.' || segments[i] === '..') return null;
   }
   var real;
   try {
-    real = fs.realpathSync(rawPath);
+    real = fs.realpathSync(clean);
   } catch (_) {
     return null;
   }
@@ -345,8 +351,20 @@ function createOverrideRegistry(getProcessState) {
     'FileSystem_$_openLocalFile': async (_event, _sessionId, filePath, showInFolder) => {
       var decoded;
       try { decoded = decodeURIComponent(filePath); } catch (_) { return; }
-      var target = showInFolder ? path.dirname(decoded) : decoded;
-      xdgOpen(target, showInFolder ? 'openLocalFile.parent' : 'openLocalFile');
+      if (showInFolder) {
+        // Try the parent directory; if that's outside allowed roots
+        // (e.g. file IS the home dir), fall back to opening the file itself
+        // so users can reveal-in-finder their home.
+        var parent = path.dirname(decoded);
+        var parentReal = verifyPath(parent);
+        if (parentReal) {
+          xdgOpen(parent, 'openLocalFile.parent');
+        } else {
+          xdgOpen(decoded, 'openLocalFile.fallback');
+        }
+      } else {
+        xdgOpen(decoded, 'openLocalFile');
+      }
     },
 
     'FileSystem_$_whichApplication': async (_event, filename) => {

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -71,17 +71,33 @@ function createSpacesOverrides() {
 }
 
 function isPathWithinAllowedRoots(filePath) {
-  // Reject non-absolute up front: path.resolve would fall back to process.cwd()
-  // and make the policy depend on runtime working directory.
   if (typeof filePath !== 'string' || !path.isAbsolute(filePath)) {
     return false;
   }
+  const normalized = path.normalize(filePath);
   let resolved;
   try {
-    resolved = fs.realpathSync(filePath);
+    resolved = fs.realpathSync(normalized);
   } catch (_) {
-    // File may not exist yet (for open/show); the input is already absolute
-    resolved = path.normalize(filePath);
+    // File doesn't exist yet. Walk up to the nearest existing ancestor and
+    // resolve symlinks THERE, then reattach the non-existent suffix.
+    // Without this, a symlink at an intermediate component (e.g.
+    // ~/spaces/SPACEID/escape -> /) would pass the prefix check via
+    // path.normalize (which ignores symlinks) and escape on the actual
+    // filesystem operation.
+    let current = path.dirname(normalized);
+    let tail = path.basename(normalized);
+    resolved = null;
+    while (current !== path.dirname(current)) {
+      try {
+        resolved = path.join(fs.realpathSync(current), tail);
+        break;
+      } catch (_) {
+        tail = path.join(path.basename(current), tail);
+        current = path.dirname(current);
+      }
+    }
+    if (!resolved) resolved = normalized;
   }
   return _allowedFsRoots.some(root =>
     resolved === root || resolved.startsWith(root + path.sep)

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -20,6 +20,7 @@ const {
   COMPUTER_USE_TCC_GRANTED,
   COMPUTER_USE_TCC_REQUEST_GRANTED,
 } = require('./linux_ipc_stubs.js');
+const { createSpacesStore } = require('./spaces_store.js');
 
 // -- Helpers --
 
@@ -30,6 +31,44 @@ function vlog(msg) { if (_verbose) console.log(msg); }
 
 const _homeDir = require('os').homedir();
 const _allowedFsRoots = [_homeDir, '/tmp'];
+
+// Lazy-initialized spaces store — uses global.__coworkDirs set by frame-fix-wrapper.js
+let _spacesStore = null;
+function getSpacesStore() {
+  if (!_spacesStore) {
+    const dirs = global.__coworkDirs;
+    const localAgentRoot = dirs ? dirs.claudeLocalAgentRoot : path.join(_homeDir, '.config', 'Claude', 'local-agent-mode-sessions');
+    _spacesStore = createSpacesStore({ localAgentRoot, trace: vlog });
+  }
+  return _spacesStore;
+}
+
+function createSpacesOverrides() {
+  const store = getSpacesStore();
+  return {
+    'CoworkSpaces_$_getAllSpaces': async (event) => store.getAllSpaces(),
+    'CoworkSpaces_$_getSpace': async (event, spaceId) => store.getSpace(event, spaceId),
+    'CoworkSpaces_$_createSpace': async (event, spaceData) => store.createSpace(event, spaceData),
+    'CoworkSpaces_$_updateSpace': async (event, spaceId, updates) => store.updateSpace(event, spaceId, updates),
+    'CoworkSpaces_$_deleteSpace': async (event, spaceId) => store.deleteSpace(event, spaceId),
+    'CoworkSpaces_$_addFolderToSpace': async (event, spaceId, folderPath) => store.addFolderToSpace(event, spaceId, folderPath),
+    'CoworkSpaces_$_removeFolderFromSpace': async (event, spaceId, folderPath) => store.removeFolderFromSpace(event, spaceId, folderPath),
+    'CoworkSpaces_$_addProjectToSpace': async (event, spaceId, project) => store.addProjectToSpace(event, spaceId, project),
+    'CoworkSpaces_$_removeProjectFromSpace': async (event, spaceId, projectId) => store.removeProjectFromSpace(event, spaceId, projectId),
+    'CoworkSpaces_$_addLinkToSpace': async (event, spaceId, link) => store.addLinkToSpace(event, spaceId, link),
+    'CoworkSpaces_$_removeLinkFromSpace': async (event, spaceId, linkId) => store.removeLinkFromSpace(event, spaceId, linkId),
+    'CoworkSpaces_$_getAutoMemoryDir': async (event, spaceId) => store.getAutoMemoryDir(event, spaceId),
+    'CoworkSpaces_$_listFolderContents': async (event, folderPath) => store.listFolderContents(event, folderPath),
+    'CoworkSpaces_$_readFileContents': async (event, filePath) => store.readFileContents(event, filePath),
+    'CoworkSpaces_$_openFile': async (event, filePath) => store.openFile(event, filePath),
+    'CoworkSpaces_$_copyFilesToSpaceFolder': async (event, spaceId, files) => store.copyFilesToSpaceFolder(event, spaceId, files),
+    'CoworkSpaces_$_createSpaceFolder': async (event, spaceId, folderName) => store.createSpaceFolder(event, spaceId, folderName),
+    'CoworkSpaces_$_classifySessions': async (event, sessions) => store.classifySessions(event, sessions),
+    'CoworkSpaces_$_setAutoDescription': async (event, spaceId, description) => store.setAutoDescription(event, spaceId, description),
+    'CoworkSpaces_$_summarizeSpace': async (event, spaceId) => store.summarizeSpace(event, spaceId),
+    'CoworkSpaces_$_onSpaceEvent': async (event, callback) => store.onSpaceEvent(event, callback),
+  };
+}
 
 function isPathWithinAllowedRoots(filePath) {
   // Reject non-absolute up front: path.resolve would fall back to process.cwd()
@@ -371,8 +410,8 @@ function createOverrideRegistry(getProcessState) {
       try { menu.popup({ window: win || undefined }); } catch (_) {}
     },
 
-    // CoworkSpaces — not implemented on Linux
-    'CoworkSpaces_$_getAllSpaces': async () => ([]),
+    // CoworkSpaces — file-backed implementation for Linux
+    ...createSpacesOverrides(),
 
     // Startup — Linux has no macOS login items; report disabled
     'Startup_$_isStartupOnLoginEnabled': async () => false,
@@ -525,7 +564,30 @@ const PROACTIVE_ONLY_SUFFIXES = new Set([
   'ComputerUseTcc_$_openSystemSettings',
   'ComputerUseTcc_$_getCurrentSessionGrants',
   'ComputerUseTcc_$_revokeGrant',
+  // CoworkSpaces — proactive because the asar's native handler registration
+  // depends on account IPC from the renderer, which often never arrives on Linux.
+  // Without proactive registration, getAllSpaces has no handler and fails silently.
   'CoworkSpaces_$_getAllSpaces',
+  'CoworkSpaces_$_getSpace',
+  'CoworkSpaces_$_createSpace',
+  'CoworkSpaces_$_updateSpace',
+  'CoworkSpaces_$_deleteSpace',
+  'CoworkSpaces_$_addFolderToSpace',
+  'CoworkSpaces_$_removeFolderFromSpace',
+  'CoworkSpaces_$_addProjectToSpace',
+  'CoworkSpaces_$_removeProjectFromSpace',
+  'CoworkSpaces_$_addLinkToSpace',
+  'CoworkSpaces_$_removeLinkFromSpace',
+  'CoworkSpaces_$_getAutoMemoryDir',
+  'CoworkSpaces_$_listFolderContents',
+  'CoworkSpaces_$_readFileContents',
+  'CoworkSpaces_$_openFile',
+  'CoworkSpaces_$_copyFilesToSpaceFolder',
+  'CoworkSpaces_$_createSpaceFolder',
+  'CoworkSpaces_$_classifySessions',
+  'CoworkSpaces_$_setAutoDescription',
+  'CoworkSpaces_$_summarizeSpace',
+  'CoworkSpaces_$_onSpaceEvent',
   // Startup — Linux has no macOS login items. The asar's handler calls
   // app.getLoginItemSettings() which crashes on Linux. The asar registers
   // these on webContents.ipc.handle() which our patch intercepts, but
@@ -565,7 +627,7 @@ function proactivelyRegisterOverrides(ipcMainHandle, ipcMainRemoveHandler, regis
       }
     }
   }
-  vlog('[Cowork] Proactively registered ' + _proactiveChannels.size + ' fallback handlers on ipcMain for UUID ' + uuid);
+  console.log('[Cowork] Proactively registered ' + _proactiveChannels.size + ' fallback handlers on ipcMain for UUID ' + uuid);
   return _proactiveChannels;
 }
 

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -76,14 +76,15 @@ function isPathWithinAllowedRoots(filePath) {
   return verifyPath(filePath) !== null;
 }
 
-let _spacesStore = null;
 function getSpacesStore() {
-  if (!_spacesStore) {
-    const dirs = global.__coworkDirs;
-    const localAgentRoot = dirs ? dirs.claudeLocalAgentRoot : path.join(_realHomeDir, '.config', 'Claude', 'local-agent-mode-sessions');
-    _spacesStore = createSpacesStore({ localAgentRoot, isPathAllowed: isPathWithinAllowedRoots, trace: vlog });
-  }
-  return _spacesStore;
+  // Reuse the early-registered store from frame-fix-wrapper if it exists.
+  // Two separate instances would have separate rate-limit state and could
+  // race on the spaces.json atomic rename — single global instance avoids both.
+  if (global.__coworkSpacesStore) return global.__coworkSpacesStore;
+  const dirs = global.__coworkDirs;
+  const localAgentRoot = dirs ? dirs.claudeLocalAgentRoot : path.join(_realHomeDir, '.config', 'Claude', 'local-agent-mode-sessions');
+  global.__coworkSpacesStore = createSpacesStore({ localAgentRoot, isPathAllowed: isPathWithinAllowedRoots, trace: vlog });
+  return global.__coworkSpacesStore;
 }
 
 function createSpacesOverrides() {
@@ -201,37 +202,57 @@ function getExecFromDesktop(desktopFile) {
 
 
 // Terminal emulator resolution — cached after first successful lookup.
-// Checks: $TERMINAL env, xdg-terminal-exec, then common emulators.
-// Validated through the exec capability registry (system cmd prefixes).
+// EVERY path goes through validateBinary() so PATH-hijacking attacks
+// (malicious 'kitty' on $PATH) are blocked the same way $TERMINAL is.
 let _resolvedTerminal = undefined;
+
+const _TERMINAL_SAFE_DIRS = ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'];
+
+function validateTerminalBinary(binName) {
+  // Resolve the binary via `which` and confirm it lives in a system dir
+  // (or is accepted by the exec capability registry). Returns the
+  // resolved path or null.
+  var resolvedPath;
+  try {
+    resolvedPath = execFileSync('which', [binName], { encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  } catch (_) {
+    return null;
+  }
+  if (!resolvedPath) return null;
+  var registry = global.__coworkExecRegistry || null;
+  if (registry) {
+    var cap = registry.resolve(resolvedPath, []);
+    if (cap && (cap.capabilityId === 'system-cmd' || (typeof cap.capabilityId === 'string' && cap.capabilityId.indexOf('system-') === 0))) {
+      return resolvedPath;
+    }
+    return null;
+  }
+  // Registry not available — fall back to system dir check.
+  if (_TERMINAL_SAFE_DIRS.some(function(d) { return resolvedPath.startsWith(d); })) {
+    return resolvedPath;
+  }
+  return null;
+}
+
 function resolveTerminal() {
   if (_resolvedTerminal !== undefined) return _resolvedTerminal;
-  var registry = global.__coworkExecRegistry || null;
-  // 1. Respect $TERMINAL env var (user's explicit preference)
+  // 1. $TERMINAL env var
   const envTerm = process.env.TERMINAL;
   if (envTerm) {
-    try {
-      const resolvedPath = execFileSync('which', [envTerm], { encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-      if (resolvedPath && registry) {
-        var cap = registry.resolve(resolvedPath, []);
-        if (cap) {
-          _resolvedTerminal = { bin: resolvedPath, spawn: ['-e'] };
-          return _resolvedTerminal;
-        }
-      } else if (resolvedPath && ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'].some(d => resolvedPath.startsWith(d))) {
-        _resolvedTerminal = { bin: resolvedPath, spawn: ['-e'] };
-        return _resolvedTerminal;
-      }
-      console.warn('[Cowork] $TERMINAL not in capability registry, ignoring:', resolvedPath);
-    } catch (_) {}
+    var envResolved = validateTerminalBinary(envTerm);
+    if (envResolved) {
+      _resolvedTerminal = { bin: envResolved, spawn: ['-e'] };
+      return _resolvedTerminal;
+    }
+    console.warn('[Cowork] $TERMINAL not in safe dirs / registry, ignoring:', envTerm);
   }
-  // 2. xdg-terminal-exec (proposed XDG Default Terminal Spec)
-  try {
-    execFileSync('which', ['xdg-terminal-exec'], { stdio: 'ignore' });
-    _resolvedTerminal = { bin: 'xdg-terminal-exec', spawn: null };
+  // 2. xdg-terminal-exec
+  var xdgResolved = validateTerminalBinary('xdg-terminal-exec');
+  if (xdgResolved) {
+    _resolvedTerminal = { bin: xdgResolved, spawn: null };
     return _resolvedTerminal;
-  } catch (_) {}
-  // 3. Common terminal emulators (GPU-accelerated first, then traditional)
+  }
+  // 3. Common terminal emulators
   const terminals = [
     'kitty', 'ghostty', 'alacritty', 'foot', 'wezterm',
     'gnome-terminal', 'konsole', 'xfce4-terminal', 'mate-terminal',
@@ -239,11 +260,11 @@ function resolveTerminal() {
   ];
   const dashDashTerminals = new Set(['gnome-terminal', 'konsole']);
   for (const t of terminals) {
-    try {
-      execFileSync('which', [t], { stdio: 'ignore' });
-      _resolvedTerminal = { bin: t, spawn: dashDashTerminals.has(t) ? ['--'] : ['-e'] };
+    var resolved = validateTerminalBinary(t);
+    if (resolved) {
+      _resolvedTerminal = { bin: resolved, spawn: dashDashTerminals.has(t) ? ['--'] : ['-e'] };
       return _resolvedTerminal;
-    } catch (_) {}
+    }
   }
   _resolvedTerminal = null;
   return null;

--- a/stubs/cowork/ipc_tap.js
+++ b/stubs/cowork/ipc_tap.js
@@ -35,7 +35,7 @@ function defaultLogDir() {
   const os = require('os');
   const path = require('path');
   const xdgStateHome = process.env.XDG_STATE_HOME ||
-    path.join(os.homedir(), '.local', 'state');
+    path.join(global.__coworkPasswdHomedir || os.userInfo().homedir, '.local', 'state');
   return path.join(xdgStateHome, 'claude-cowork', 'logs');
 }
 

--- a/stubs/cowork/process_manager.js
+++ b/stubs/cowork/process_manager.js
@@ -5,6 +5,98 @@ const { classifyEnvEntry } = require('./credential_classifier.js');
 const DEFAULT_STDIO = ['pipe', 'pipe', 'pipe'];
 
 // ============================================================================
+// BUBBLEWRAP SANDBOX (opt-in)
+// ============================================================================
+// Off by default. Enable with CLAUDE_COWORK_SANDBOX=1.
+// Disable explicitly with CLAUDE_COWORK_NO_SANDBOX=1 (takes precedence).
+//
+// Sandbox profile (intentionally conservative):
+//   - Read-only system: /usr, /lib, /lib64, /bin, /sbin, /etc
+//   - Private /tmp (tmpfs)
+//   - Private /proc, /dev
+//   - Network: SHARED (CLI needs API + MCP HTTP/HTTPS access)
+//   - Workspace: rw-bound at the cwd (the project the user opened)
+//   - User config dir: ro-bound at ~/.claude AND ~/.config/Claude
+//     so the CLI can read auth tokens and write session state
+//   - $HOME is NOT bound — that's the security boundary the dead-code
+//     version got wrong. ~/.ssh, ~/.aws, ~/.gnupg, browser cookies
+//     stay outside the sandbox.
+//   - --die-with-parent: sandbox dies if the parent (Electron) exits
+//   - --unshare-pid + --unshare-ipc: can't see or signal host processes
+
+var _bwrapAvailable;
+function isBwrapAvailable() {
+  if (_bwrapAvailable === undefined) {
+    try {
+      require('child_process').execFileSync('which', ['bwrap'], { stdio: 'ignore' });
+      _bwrapAvailable = true;
+    } catch (_) {
+      _bwrapAvailable = false;
+    }
+  }
+  return _bwrapAvailable;
+}
+
+function shouldUseSandbox() {
+  if (process.env.CLAUDE_COWORK_NO_SANDBOX === '1') return false;
+  if (process.env.CLAUDE_COWORK_SANDBOX !== '1') return false;
+  return isBwrapAvailable();
+}
+
+function wrapWithBwrap(command, args, cwd) {
+  if (!shouldUseSandbox()) return null;
+  if (typeof command !== 'string' || command.length === 0) return null;
+  if (!Array.isArray(args)) args = [];
+
+  var bwrapArgs = [
+    '--unshare-pid',
+    '--unshare-ipc',
+    '--die-with-parent',
+    '--clearenv',
+    '--proc', '/proc',
+    '--dev', '/dev',
+    '--tmpfs', '/tmp',
+  ];
+  // Read-only system dirs (only bind if they exist on the host).
+  ['/usr', '/etc', '/lib', '/lib64'].forEach(function(p) {
+    try { fs.statSync(p); bwrapArgs.push('--ro-bind', p, p); } catch (_) {}
+  });
+  // /bin and /sbin are symlinks to /usr/bin and /usr/sbin on modern distros.
+  try { fs.statSync('/bin'); bwrapArgs.push('--symlink', 'usr/bin', '/bin'); } catch (_) {}
+  try { fs.statSync('/sbin'); bwrapArgs.push('--symlink', 'usr/sbin', '/sbin'); } catch (_) {}
+
+  // Workspace: rw-bind only the project cwd, not $HOME.
+  if (typeof cwd === 'string' && path.isAbsolute(cwd)) {
+    bwrapArgs.push('--bind', cwd, cwd);
+  }
+
+  // ~/.claude (CLI config + auth) and ~/.config/Claude (Cowork state)
+  // are ro-bound so the CLI can read tokens but not modify them through
+  // a compromise. Reads only; writes happen through specific paths the
+  // CLI manages on the host side outside the sandbox.
+  var home;
+  try { home = require('os').userInfo().homedir; } catch (_) { home = null; }
+  if (home && path.isAbsolute(home)) {
+    var claudeConfig = path.join(home, '.claude');
+    try {
+      fs.statSync(claudeConfig);
+      bwrapArgs.push('--ro-bind', claudeConfig, claudeConfig);
+    } catch (_) {}
+    var configDir = path.join(home, '.config', 'Claude');
+    try {
+      fs.statSync(configDir);
+      bwrapArgs.push('--ro-bind', configDir, configDir);
+    } catch (_) {}
+  }
+
+  bwrapArgs.push('--');
+  bwrapArgs.push(command);
+  for (var i = 0; i < args.length; i++) bwrapArgs.push(args[i]);
+
+  return { command: 'bwrap', args: bwrapArgs };
+}
+
+// ============================================================================
 // SESSION PATH DERIVATION
 // ============================================================================
 // These functions derive session-related paths from the CLAUDE_CONFIG_DIR
@@ -376,4 +468,7 @@ module.exports = {
   deriveSessionDirectory,
   deriveSessionMetadataPath,
   resolveHostCwdPath,
+  wrapWithBwrap,
+  isBwrapAvailable,
+  shouldUseSandbox,
 };

--- a/stubs/cowork/process_manager.js
+++ b/stubs/cowork/process_manager.js
@@ -4,6 +4,43 @@ const { classifyEnvEntry } = require('./credential_classifier.js');
 
 const DEFAULT_STDIO = ['pipe', 'pipe', 'pipe'];
 
+const _bwrapAvailable = (() => {
+  try {
+    require('child_process').execFileSync('which', ['bwrap'], { stdio: 'ignore' });
+    return true;
+  } catch (_) {
+    return false;
+  }
+})();
+
+function wrapWithBwrap(command, args, cwd) {
+  if (process.env.CLAUDE_COWORK_NO_SANDBOX === '1') return null;
+  if (!_bwrapAvailable) return null;
+  var bwrapArgs = [
+    '--unshare-pid',
+    '--unshare-ipc',
+    '--die-with-parent',
+    '--ro-bind', '/usr', '/usr',
+    '--ro-bind', '/etc', '/etc',
+    '--tmpfs', '/tmp',
+    '--proc', '/proc',
+    '--dev', '/dev',
+  ];
+  try { fs.statSync('/lib'); bwrapArgs.push('--ro-bind', '/lib', '/lib'); } catch (_) {}
+  try { fs.statSync('/lib64'); bwrapArgs.push('--ro-bind', '/lib64', '/lib64'); } catch (_) {}
+  try { fs.statSync('/bin'); bwrapArgs.push('--symlink', 'usr/bin', '/bin'); } catch (_) {}
+  try { fs.statSync('/sbin'); bwrapArgs.push('--symlink', 'usr/sbin', '/sbin'); } catch (_) {}
+  if (cwd) {
+    bwrapArgs.push('--bind', cwd, cwd);
+  }
+  var home = require('os').userInfo().homedir;
+  bwrapArgs.push('--bind', home, home);
+  bwrapArgs.push('--pass-fd', '3');
+  bwrapArgs.push('--', command);
+  bwrapArgs.push.apply(bwrapArgs, args);
+  return { command: 'bwrap', args: bwrapArgs };
+}
+
 // ============================================================================
 // SESSION PATH DERIVATION
 // ============================================================================
@@ -372,6 +409,7 @@ function createProcessManager(deps) {
 module.exports = {
   DEFAULT_STDIO,
   ProcessManager,
+  wrapWithBwrap,
   createProcessManager,
   deriveSessionDirectory,
   deriveSessionMetadataPath,

--- a/stubs/cowork/process_manager.js
+++ b/stubs/cowork/process_manager.js
@@ -4,47 +4,6 @@ const { classifyEnvEntry } = require('./credential_classifier.js');
 
 const DEFAULT_STDIO = ['pipe', 'pipe', 'pipe'];
 
-var _bwrapAvailable;
-function isBwrapAvailable() {
-  if (_bwrapAvailable === undefined) {
-    try {
-      require('child_process').execFileSync('which', ['bwrap'], { stdio: 'ignore' });
-      _bwrapAvailable = true;
-    } catch (_) {
-      _bwrapAvailable = false;
-    }
-  }
-  return _bwrapAvailable;
-}
-
-function wrapWithBwrap(command, args, cwd) {
-  if (process.env.CLAUDE_COWORK_NO_SANDBOX === '1') return null;
-  if (!isBwrapAvailable()) return null;
-  var bwrapArgs = [
-    '--unshare-pid',
-    '--unshare-ipc',
-    '--die-with-parent',
-    '--ro-bind', '/usr', '/usr',
-    '--ro-bind', '/etc', '/etc',
-    '--tmpfs', '/tmp',
-    '--proc', '/proc',
-    '--dev', '/dev',
-  ];
-  try { fs.statSync('/lib'); bwrapArgs.push('--ro-bind', '/lib', '/lib'); } catch (_) {}
-  try { fs.statSync('/lib64'); bwrapArgs.push('--ro-bind', '/lib64', '/lib64'); } catch (_) {}
-  try { fs.statSync('/bin'); bwrapArgs.push('--symlink', 'usr/bin', '/bin'); } catch (_) {}
-  try { fs.statSync('/sbin'); bwrapArgs.push('--symlink', 'usr/sbin', '/sbin'); } catch (_) {}
-  if (cwd) {
-    bwrapArgs.push('--bind', cwd, cwd);
-  }
-  var home = require('os').userInfo().homedir;
-  bwrapArgs.push('--bind', home, home);
-  bwrapArgs.push('--pass-fd', '3');
-  bwrapArgs.push('--', command);
-  bwrapArgs.push.apply(bwrapArgs, args);
-  return { command: 'bwrap', args: bwrapArgs };
-}
-
 // ============================================================================
 // SESSION PATH DERIVATION
 // ============================================================================
@@ -413,7 +372,6 @@ function createProcessManager(deps) {
 module.exports = {
   DEFAULT_STDIO,
   ProcessManager,
-  wrapWithBwrap,
   createProcessManager,
   deriveSessionDirectory,
   deriveSessionMetadataPath,

--- a/stubs/cowork/process_manager.js
+++ b/stubs/cowork/process_manager.js
@@ -4,18 +4,22 @@ const { classifyEnvEntry } = require('./credential_classifier.js');
 
 const DEFAULT_STDIO = ['pipe', 'pipe', 'pipe'];
 
-const _bwrapAvailable = (() => {
-  try {
-    require('child_process').execFileSync('which', ['bwrap'], { stdio: 'ignore' });
-    return true;
-  } catch (_) {
-    return false;
+var _bwrapAvailable;
+function isBwrapAvailable() {
+  if (_bwrapAvailable === undefined) {
+    try {
+      require('child_process').execFileSync('which', ['bwrap'], { stdio: 'ignore' });
+      _bwrapAvailable = true;
+    } catch (_) {
+      _bwrapAvailable = false;
+    }
   }
-})();
+  return _bwrapAvailable;
+}
 
 function wrapWithBwrap(command, args, cwd) {
   if (process.env.CLAUDE_COWORK_NO_SANDBOX === '1') return null;
-  if (!_bwrapAvailable) return null;
+  if (!isBwrapAvailable()) return null;
   var bwrapArgs = [
     '--unshare-pid',
     '--unshare-ipc',

--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -533,21 +533,8 @@ class SessionOrchestrator {
       return mountResult;
     }
 
-    // Step 2: Define allowed binary paths for security
-    const home = os.homedir();
-    const allowedVmPrefixes = Array.isArray(claudeVmRoots) && claudeVmRoots.length > 0
-      ? claudeVmRoots.map((vmRoot) => path.resolve(vmRoot) + path.sep)
-      : [path.join(appSupportRoot, 'claude-code-vm') + path.sep];
-    const allowedPrefixes = [
-      ...allowedVmPrefixes,
-      path.join(home, '.local/bin/'),
-      path.join(home, '.local/share/claude/'),
-      path.join(home, '.npm-global/bin/'),
-      '/usr/local/bin/',
-      '/usr/bin/',
-    ];
-
-    // Step 3: Resolve command to host binary path
+    // Step 2: Resolve command via capability registry
+    const execRegistry = this._deps.execRegistry || global.__coworkExecRegistry;
     const normalizedCommand = (typeof command === 'string' || command instanceof String)
       ? String(command).trim()
       : '';
@@ -559,14 +546,23 @@ class SessionOrchestrator {
       normalizedCommand === 'claude' ||
       commandBasename === 'claude'
     ) {
-      hostCommand = resolveClaudeBinaryPath();
+      const cap = execRegistry
+        ? execRegistry.resolveCapability('claude-cli')
+        : null;
+      hostCommand = cap ? cap.exec : resolveClaudeBinaryPath();
       trace('Translated command: ' + normalizedCommand + ' -> ' + hostCommand);
-      } else if (
+    } else if (
       normalizedCommand === 'bash' ||
       commandBasename === 'bash'
     ) {
-      const bashCandidates = ['/usr/bin/bash', '/bin/bash'];
-      hostCommand = bashCandidates.find((c) => fs.existsSync(c));
+      const cap = execRegistry
+        ? execRegistry.resolveCapability('system-bash')
+        : null;
+      if (cap) {
+        hostCommand = cap.exec;
+      } else {
+        hostCommand = ['/usr/bin/bash', '/bin/bash'].find((c) => fs.existsSync(c));
+      }
       if (!hostCommand) {
         trace('bash requested but not found on host');
         if (typeof onError === 'function') {
@@ -575,31 +571,34 @@ class SessionOrchestrator {
         return { success: false, error: 'bash not found' };
       }
       trace('Translated bash command: ' + normalizedCommand + ' -> ' + hostCommand);
-    } else if (allowedPrefixes.some((prefix) => normalizedCommand.startsWith(prefix))) {
-      if (fs.existsSync(normalizedCommand)) {
-        hostCommand = normalizedCommand;
-        trace('Command is an allowed absolute path: ' + normalizedCommand);
+    } else if (execRegistry) {
+      const resolved = execRegistry.resolve(normalizedCommand, args);
+      if (resolved) {
+        hostCommand = resolved.cmd;
+        trace('Command resolved via capability "' + resolved.capabilityId + '": ' + normalizedCommand);
       } else {
-        hostCommand = resolveClaudeBinaryPath();
-        trace('Allowed absolute path missing, resolved: ' + normalizedCommand + ' -> ' + hostCommand);
+        trace('Unexpected command blocked: "' + String(command) + '" (type=' + typeof command + ')');
+        if (typeof onError === 'function') {
+          onError(processId, 'Unexpected command: ' + String(command), '');
+        }
+        return { success: false, error: 'Unexpected command' };
       }
     } else {
-      trace('Unexpected command blocked: "' + String(command) + '" (type=' + typeof command + ')');
-      if (typeof onError === 'function') {
-        onError(processId, 'Unexpected command: ' + String(command), '');
+      const home = os.homedir();
+      const fallbackPrefixes = [
+        path.join(home, '.local/bin/'),
+        path.join(home, '.local/share/claude/'),
+        path.join(home, '.npm-global/bin/'),
+        '/usr/local/bin/',
+        '/usr/bin/',
+      ];
+      if (normalizedCommand && fallbackPrefixes.some((p) => normalizedCommand.startsWith(p)) && fs.existsSync(normalizedCommand)) {
+        hostCommand = normalizedCommand;
+        trace('No exec registry, allowed absolute path: ' + normalizedCommand);
+      } else {
+        hostCommand = resolveClaudeBinaryPath();
+        trace('No exec registry, falling back to claude binary: ' + hostCommand);
       }
-      return { success: false, error: 'Unexpected command' };
-    }
-
-    // Security check: Ensure resolved command is in allowed directories
-    const commandIsAllowed = hostCommand === 'claude' ||
-      allowedPrefixes.some((prefix) => hostCommand.startsWith(prefix));
-    if (!commandIsAllowed) {
-      trace('Command outside allowed directories: ' + hostCommand);
-      if (typeof onError === 'function') {
-        onError(processId, 'Invalid binary path', '');
-      }
-      return { success: false, error: 'Invalid binary path' };
     }
 
     // Step 4: Translate VM paths in arguments to host paths

--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -585,9 +585,15 @@ class SessionOrchestrator {
       }
     } else {
       var passwdHome = global.__coworkPasswdHomedir || os.userInfo().homedir;
+      // Only build VM prefixes if appSupportRoot or claudeVmRoots is provided.
+      // Without an absolute base, path.join('', 'claude-code-vm') would yield
+      // a relative prefix that any relative command starting with that string
+      // could match (passing fs.existsSync via process.cwd() resolution).
       const vmPrefixes = Array.isArray(claudeVmRoots) && claudeVmRoots.length > 0
         ? claudeVmRoots.map((r) => path.resolve(r) + path.sep)
-        : [path.join(appSupportRoot || '', 'claude-code-vm') + path.sep];
+        : (appSupportRoot && path.isAbsolute(appSupportRoot)
+            ? [path.join(appSupportRoot, 'claude-code-vm') + path.sep]
+            : []);
       const fallbackPrefixes = [
         ...vmPrefixes,
         path.join(passwdHome, '.local/bin/'),

--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -584,11 +584,16 @@ class SessionOrchestrator {
         return { success: false, error: 'Unexpected command' };
       }
     } else {
-      const home = os.homedir();
+      var passwdHome = global.__coworkPasswdHomedir || os.userInfo().homedir;
+      const vmPrefixes = Array.isArray(claudeVmRoots) && claudeVmRoots.length > 0
+        ? claudeVmRoots.map((r) => path.resolve(r) + path.sep)
+        : [path.join(appSupportRoot || '', 'claude-code-vm') + path.sep];
       const fallbackPrefixes = [
-        path.join(home, '.local/bin/'),
-        path.join(home, '.local/share/claude/'),
-        path.join(home, '.npm-global/bin/'),
+        ...vmPrefixes,
+        path.join(passwdHome, '.local/bin/'),
+        path.join(passwdHome, '.local/share/claude/'),
+        path.join(passwdHome, '.npm-global/bin/'),
+        path.join(os.homedir(), '.local/bin/'),
         '/usr/local/bin/',
         '/usr/bin/',
       ];
@@ -596,8 +601,11 @@ class SessionOrchestrator {
         hostCommand = normalizedCommand;
         trace('No exec registry, allowed absolute path: ' + normalizedCommand);
       } else {
-        hostCommand = resolveClaudeBinaryPath();
-        trace('No exec registry, falling back to claude binary: ' + hostCommand);
+        trace('Unexpected command blocked (no registry): "' + String(command) + '"');
+        if (typeof onError === 'function') {
+          onError(processId, 'Unexpected command: ' + String(command), '');
+        }
+        return { success: false, error: 'Unexpected command' };
       }
     }
 

--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -484,9 +484,31 @@ class SessionOrchestrator {
       args,
       envVars,
       additionalMounts,
-      sharedCwdPath,
+      sharedCwdPath: rawSharedCwdPath,
       onError,
     } = context || {};
+
+    // Fix: asar passes sharedCwdPath=false (boolean) instead of a path string.
+    // When falsy, recover from session metadata's userSelectedFolders so the CLI
+    // gets the correct cwd and project key persists across restarts.
+    const trace = this._deps.trace || (() => {});
+    let sharedCwdPath = rawSharedCwdPath;
+    if (!sharedCwdPath || typeof sharedCwdPath !== 'string') {
+      const sessionStore = this._deps.sessionStore;
+      if (sessionStore) {
+        const activeInfo = sessionStore.getActiveSessionInfo();
+        if (activeInfo && activeInfo.preferredRoot) {
+          sharedCwdPath = activeInfo.preferredRoot;
+          trace('[cwd-fix] Recovered sharedCwdPath from active session: ' + sharedCwdPath);
+        } else if (typeof processId === 'string' && processId.startsWith('local_')) {
+          const sessionInfo = sessionStore.getSessionInfo(processId);
+          if (sessionInfo && sessionInfo.preferredRoot) {
+            sharedCwdPath = sessionInfo.preferredRoot;
+            trace('[cwd-fix] Recovered sharedCwdPath from session metadata: ' + sharedCwdPath);
+          }
+        }
+      }
+    }
     const {
       appSupportRoot,
       canonicalizePathForHostAccess,
@@ -494,7 +516,6 @@ class SessionOrchestrator {
       claudeVmRoots,
       resolveClaudeBinaryPath,
       sessionsBase,
-      trace = () => {},
       translateVmPathStrict,
     } = this._deps;
 
@@ -607,6 +628,16 @@ class SessionOrchestrator {
       filteredArgs.push(hostArgs[index]);
     }
     hostArgs = filteredArgs;
+
+    // Step 5b: Remap unsupported CLI flags
+    // Claude Desktop may pass --effort xhigh, but the SDK binary only supports
+    // low/medium/high/max. Remap xhigh -> max to prevent exit code 1.
+    for (let i = 0; i < hostArgs.length; i += 1) {
+      if (hostArgs[i] === '--effort' && i + 1 < hostArgs.length && hostArgs[i + 1] === 'xhigh') {
+        trace('Remapped --effort xhigh -> max');
+        hostArgs[i + 1] = 'max';
+      }
+    }
 
     // Step 6: Ensure sessions base directory exists
     try {

--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -378,7 +378,7 @@ function readRemoteSessionIdFromBridgeState(deps) {
   } = deps || {};
 
   const defaultBridgePath = path.join(
-    process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+    process.env.XDG_CONFIG_HOME || path.join(global.__coworkPasswdHomedir || os.userInfo().homedir, '.config'),
     'Claude', 'bridge-state.json'
   );
   const filePath = typeof bridgeStatePath === 'string' && bridgeStatePath.trim()
@@ -593,7 +593,7 @@ class SessionOrchestrator {
         path.join(passwdHome, '.local/bin/'),
         path.join(passwdHome, '.local/share/claude/'),
         path.join(passwdHome, '.npm-global/bin/'),
-        path.join(os.homedir(), '.local/bin/'),
+        path.join(os.userInfo().homedir, '.local/bin/'),
         '/usr/local/bin/',
         '/usr/bin/',
       ];
@@ -1825,7 +1825,7 @@ function transformSdkMessages(messages, sessionIdOverride) {
 }
 
 // Global Claude Code config directory (skills, commands, settings, etc.)
-const GLOBAL_CLAUDE_DIR = path.join(os.homedir(), '.claude');
+const GLOBAL_CLAUDE_DIR = path.join(global.__coworkPasswdHomedir || os.userInfo().homedir, '.claude');
 
 /**
  * Symlink global Claude Code config into a session's CLAUDE_CONFIG_DIR.

--- a/stubs/cowork/session_store.js
+++ b/stubs/cowork/session_store.js
@@ -76,7 +76,7 @@ function isDesktopRuntimePath(targetPath) {
     return false;
   }
 
-  const homeDir = os.homedir();
+  const homeDir = global.__coworkPasswdHomedir || os.userInfo().homedir;
   const xdgDataHome = typeof process.env.XDG_DATA_HOME === 'string' && process.env.XDG_DATA_HOME.trim()
     ? path.resolve(process.env.XDG_DATA_HOME)
     : path.join(homeDir, '.local', 'share');

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -14,14 +14,38 @@ const { randomUUID } = require('crypto');
 function createSpacesStore(options) {
   const { localAgentRoot, isPathAllowed, trace = () => {} } = options || {};
 
-  // Path validation gate for folder registration (addFolderToSpace).
-  // Uses the caller's isPathWithinAllowedRoots() which checks [homedir, /tmp].
+  // Rate limiter for write operations. A compromised renderer can't exhaust
+  // disk by spamming createSpace/updateSpace/etc.
+  const _writeTimestamps = [];
+  const WRITE_RATE_LIMIT = 30;       // max writes
+  const WRITE_RATE_WINDOW_MS = 60000; // per minute
+  function checkWriteRate() {
+    const now = Date.now();
+    while (_writeTimestamps.length > 0 && _writeTimestamps[0] < now - WRITE_RATE_WINDOW_MS) {
+      _writeTimestamps.shift();
+    }
+    if (_writeTimestamps.length >= WRITE_RATE_LIMIT) {
+      trace('[spaces] Write rate limit exceeded (' + WRITE_RATE_LIMIT + '/min)');
+      return false;
+    }
+    _writeTimestamps.push(now);
+    return true;
+  }
+
+  // Path validation for folder registration (addFolderToSpace).
+  // Stricter than the general FileSystem allowlist: homedir only, no /tmp.
+  // /tmp is world-writable — another user could swap contents between
+  // registration and read, violating the trust boundary.
   function requireAllowedPath(p) {
     if (typeof p !== 'string' || !path.isAbsolute(p)) return false;
-    if (typeof isPathAllowed === 'function') return isPathAllowed(p);
+    if (typeof isPathAllowed === 'function') {
+      if (!isPathAllowed(p)) return false;
+    }
+    // Always enforce: no /tmp for space folder registration
+    const normalized = path.normalize(p);
+    if (normalized === '/tmp' || normalized.startsWith('/tmp/')) return false;
     const home = require('os').homedir();
-    const resolved = path.normalize(p);
-    return resolved === home || resolved.startsWith(home + path.sep);
+    return normalized === home || normalized.startsWith(home + path.sep);
   }
 
   // Resolve a path through realpathSync, defeating symlinks.
@@ -69,18 +93,21 @@ function createSpacesStore(options) {
 
   // Read-path validation: the file MUST exist (so realpathSync can resolve it)
   // AND its resolved path must fall within a folder registered in spaces.json.
-  // The folder list is the allowlist — read from disk each time so the renderer
-  // can't influence it. Both sides are resolved via realpathSync to prevent
-  // symlink-based escapes.
+  //
+  // The registered folder paths are ALREADY resolved (addFolderToSpace stores
+  // the realpathSync'd result). We do NOT re-resolve them here — re-resolving
+  // would follow any symlinks placed at that path AFTER registration, reopening
+  // the symlink-swap attack. The comparison is:
+  //   resolved(requested) vs stored-as-is(registered)
   function isWithinRegisteredFolder(filePath) {
     const resolved = resolvePath(filePath);
     if (!resolved) return false;
     const spaces = readSpaces();
     for (const space of spaces) {
       for (const folder of (space.folders || [])) {
-        const folderResolved = resolvePath(folder.path);
-        if (!folderResolved) continue;
-        if (resolved === folderResolved || resolved.startsWith(folderResolved + path.sep)) {
+        const registeredPath = folder.path;
+        if (typeof registeredPath !== 'string') continue;
+        if (resolved === registeredPath || resolved.startsWith(registeredPath + path.sep)) {
           return true;
         }
       }
@@ -138,6 +165,7 @@ function createSpacesStore(options) {
   }
 
   function writeSpaces(spaces) {
+    if (!checkWriteRate()) return false;
     const p = discoverSpacesPath();
     if (!p) {
       trace('[spaces] Cannot write — no path discovered');
@@ -414,16 +442,31 @@ function createSpacesStore(options) {
   }
 
   function classifySessions(_event, sessions) {
-    // Classify which sessions belong to which spaces based on userSelectedFolders
+    if (!Array.isArray(sessions)) return {};
     const spaces = readSpaces();
     const result = {};
-    for (const session of (sessions || [])) {
-      const folders = session.userSelectedFolders || [];
+    for (const session of sessions) {
+      if (!session || typeof session !== 'object') continue;
+      const rawFolders = session.userSelectedFolders;
+      if (!Array.isArray(rawFolders)) continue;
+      // Resolve session folder paths so renderer can't fake containment
+      // with unresolved symlink paths. Skip non-existent paths.
+      const resolvedFolders = [];
+      for (const f of rawFolders) {
+        if (typeof f !== 'string') continue;
+        const r = resolvePath(f);
+        if (r) resolvedFolders.push(r);
+      }
+      if (resolvedFolders.length === 0) continue;
       for (const space of spaces) {
         for (const sf of (space.folders || [])) {
-          if (folders.some(f => f === sf.path || f.startsWith(sf.path + '/'))) {
+          // sf.path is already resolved (stored at registration time)
+          const registeredPath = sf.path;
+          if (typeof registeredPath !== 'string') continue;
+          if (resolvedFolders.some(f => f === registeredPath || f.startsWith(registeredPath + path.sep))) {
             if (!result[space.id]) result[space.id] = [];
-            result[space.id].push(session.sessionId || session.id);
+            const sid = sanitizeString(session.sessionId || session.id, 256);
+            if (sid) result[space.id].push(sid);
             break;
           }
         }

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -35,6 +35,38 @@ function createSpacesStore(options) {
     }
   }
 
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  function isValidUUID(s) {
+    return typeof s === 'string' && UUID_RE.test(s);
+  }
+
+  // Sanitize a value from the renderer to a plain string (max 10KB).
+  // Rejects objects, arrays, and excessively large strings.
+  function sanitizeString(v, maxLen) {
+    if (typeof v !== 'string') return null;
+    if (v.length > (maxLen || 10240)) return null;
+    return v;
+  }
+
+  // Sanitize an object from the renderer: allow only plain key-value pairs
+  // with string/number/boolean/null values. Rejects nested objects, arrays,
+  // prototype-polluting keys, and enforces max depth of 1 + max size.
+  function sanitizeObject(obj, maxKeys) {
+    if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) return null;
+    const clean = {};
+    const keys = Object.keys(obj);
+    if (keys.length > (maxKeys || 50)) return null;
+    for (const k of keys) {
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+      const v = obj[k];
+      if (v === null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+        if (typeof v === 'string' && v.length > 10240) continue;
+        clean[k] = v;
+      }
+    }
+    return clean;
+  }
+
   // Read-path validation: the file MUST exist (so realpathSync can resolve it)
   // AND its resolved path must fall within a folder registered in spaces.json.
   // The folder list is the allowlist — read from disk each time so the renderer
@@ -116,7 +148,11 @@ function createSpacesStore(options) {
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
-      fs.writeFileSync(p, JSON.stringify({ spaces }, null, 4) + '\n', 'utf8');
+      // Atomic write: write to temp file then rename. Prevents partial
+      // writes from corrupting spaces.json on crash or concurrent access.
+      const tmp = p + '.tmp.' + process.pid;
+      fs.writeFileSync(tmp, JSON.stringify({ spaces }, null, 4) + '\n', 'utf8');
+      fs.renameSync(tmp, p);
       return true;
     } catch (e) {
       trace('[spaces] Write error: ' + e.message);
@@ -139,20 +175,22 @@ function createSpacesStore(options) {
   }
 
   function createSpace(_event, spaceData) {
+    if (!spaceData || typeof spaceData !== 'object') return null;
     const spaces = readSpaces();
     const now = Date.now();
     const newSpace = {
       id: randomUUID(),
-      name: spaceData.name || 'Untitled',
-      folders: Array.isArray(spaceData.folders) ? spaceData.folders : [],
-      projects: Array.isArray(spaceData.projects) ? spaceData.projects : [],
-      links: Array.isArray(spaceData.links) ? spaceData.links : [],
-      origin: spaceData.origin || 'user',
+      name: sanitizeString(spaceData.name, 512) || 'Untitled',
+      folders: [],
+      projects: [],
+      links: [],
+      origin: sanitizeString(spaceData.origin, 64) || 'user',
       createdAt: now,
       updatedAt: now,
     };
-    if (spaceData.instructions) {
-      newSpace.instructions = spaceData.instructions;
+    const instr = sanitizeString(spaceData.instructions, 65536);
+    if (instr) {
+      newSpace.instructions = instr;
     }
     spaces.push(newSpace);
     writeSpaces(spaces);
@@ -161,14 +199,21 @@ function createSpacesStore(options) {
   }
 
   function updateSpace(_event, spaceId, updates) {
+    if (!updates || typeof updates !== 'object' || Array.isArray(updates)) return null;
     const spaces = readSpaces();
     const index = spaces.findIndex(s => s.id === spaceId);
     if (index === -1) {
       trace('[spaces] updateSpace: not found ' + spaceId);
       return null;
     }
-    const updated = { ...spaces[index], ...updates, updatedAt: Date.now() };
-    // Don't allow overwriting id or createdAt
+    // Allowlist: only permit known scalar fields to be updated.
+    // Structured fields (folders, projects, links) have their own add/remove handlers.
+    const allowed = {};
+    if ('name' in updates) allowed.name = sanitizeString(updates.name, 512);
+    if ('instructions' in updates) allowed.instructions = sanitizeString(updates.instructions, 65536);
+    if ('origin' in updates) allowed.origin = sanitizeString(updates.origin, 64);
+    if ('autoDescription' in updates) allowed.autoDescription = sanitizeString(updates.autoDescription, 65536);
+    const updated = { ...spaces[index], ...allowed, updatedAt: Date.now() };
     updated.id = spaces[index].id;
     updated.createdAt = spaces[index].createdAt;
     spaces[index] = updated;
@@ -193,13 +238,23 @@ function createSpacesStore(options) {
       trace('[spaces] addFolderToSpace BLOCKED (outside allowed roots): ' + folderPath);
       return null;
     }
+    // Store the RESOLVED path so symlink swaps after registration
+    // can't redirect reads to unintended locations.
+    const resolved = resolvePath(folderPath);
+    if (!resolved) {
+      trace('[spaces] addFolderToSpace BLOCKED (path does not exist): ' + folderPath);
+      return null;
+    }
+    if (!requireAllowedPath(resolved)) {
+      trace('[spaces] addFolderToSpace BLOCKED (resolved path outside allowed roots): ' + resolved);
+      return null;
+    }
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space) return null;
     if (!Array.isArray(space.folders)) space.folders = [];
-    // Avoid duplicates
-    if (!space.folders.some(f => f.path === folderPath)) {
-      space.folders.push({ path: folderPath });
+    if (!space.folders.some(f => f.path === resolved)) {
+      space.folders.push({ path: resolved });
     }
     space.updatedAt = Date.now();
     writeSpaces(spaces);
@@ -217,11 +272,13 @@ function createSpacesStore(options) {
   }
 
   function addProjectToSpace(_event, spaceId, project) {
+    const sanitized = sanitizeObject(project, 20);
+    if (!sanitized) return null;
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space) return null;
     if (!Array.isArray(space.projects)) space.projects = [];
-    space.projects.push(project);
+    space.projects.push(sanitized);
     space.updatedAt = Date.now();
     writeSpaces(spaces);
     return space;
@@ -238,11 +295,13 @@ function createSpacesStore(options) {
   }
 
   function addLinkToSpace(_event, spaceId, link) {
+    const sanitized = sanitizeObject(link, 20);
+    if (!sanitized) return null;
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space) return null;
     if (!Array.isArray(space.links)) space.links = [];
-    space.links.push(link);
+    space.links.push(sanitized);
     space.updatedAt = Date.now();
     writeSpaces(spaces);
     return space;
@@ -332,7 +391,7 @@ function createSpacesStore(options) {
       trace('[spaces] createSpaceFolder BLOCKED (invalid name): ' + folderName);
       return null;
     }
-    if (typeof spaceId !== 'string' || !/^[0-9a-f-]+$/i.test(spaceId)) {
+    if (!isValidUUID(spaceId)) {
       trace('[spaces] createSpaceFolder BLOCKED (invalid spaceId): ' + spaceId);
       return null;
     }

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -14,15 +14,46 @@ const { randomUUID } = require('crypto');
 function createSpacesStore(options) {
   const { localAgentRoot, isPathAllowed, trace = () => {} } = options || {};
 
-  // Path validation gate — reuses the caller's isPathWithinAllowedRoots().
-  // Every function that touches user-supplied paths MUST call this.
+  // Path validation gate for folder registration (addFolderToSpace).
+  // Uses the caller's isPathWithinAllowedRoots() which checks [homedir, /tmp].
   function requireAllowedPath(p) {
     if (typeof p !== 'string' || !path.isAbsolute(p)) return false;
     if (typeof isPathAllowed === 'function') return isPathAllowed(p);
-    // Fallback: restrict to homedir if no validator was injected
     const home = require('os').homedir();
     const resolved = path.normalize(p);
     return resolved === home || resolved.startsWith(home + path.sep);
+  }
+
+  // Resolve a path through realpathSync, defeating symlinks.
+  // Returns null if the path doesn't exist (can't be resolved = can't be read).
+  function resolvePath(p) {
+    if (typeof p !== 'string' || !path.isAbsolute(p)) return null;
+    try {
+      return fs.realpathSync(p);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // Read-path validation: the file MUST exist (so realpathSync can resolve it)
+  // AND its resolved path must fall within a folder registered in spaces.json.
+  // The folder list is the allowlist — read from disk each time so the renderer
+  // can't influence it. Both sides are resolved via realpathSync to prevent
+  // symlink-based escapes.
+  function isWithinRegisteredFolder(filePath) {
+    const resolved = resolvePath(filePath);
+    if (!resolved) return false;
+    const spaces = readSpaces();
+    for (const space of spaces) {
+      for (const folder of (space.folders || [])) {
+        const folderResolved = resolvePath(folder.path);
+        if (!folderResolved) continue;
+        if (resolved === folderResolved || resolved.startsWith(folderResolved + path.sep)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   // Discover the spaces.json path by walking localAgentRoot/<accountId>/<orgId>/
@@ -228,10 +259,12 @@ function createSpacesStore(options) {
   }
 
   function getAutoMemoryDir(_event, spaceId) {
-    // Return the memory directory for the space
+    if (typeof spaceId !== 'string' || !/^[0-9a-f-]+$/i.test(spaceId)) return null;
     const p = discoverSpacesPath();
     if (!p) return null;
     const spacesDir = path.join(path.dirname(p), 'spaces', spaceId, 'memory');
+    const normalized = path.normalize(spacesDir);
+    if (!normalized.startsWith(localAgentRoot + path.sep)) return null;
     try {
       if (!fs.existsSync(spacesDir)) {
         fs.mkdirSync(spacesDir, { recursive: true });
@@ -241,15 +274,16 @@ function createSpacesStore(options) {
   }
 
   function listFolderContents(_event, folderPath) {
-    if (!requireAllowedPath(folderPath)) {
-      trace('[spaces] listFolderContents BLOCKED (outside allowed roots): ' + folderPath);
+    if (!isWithinRegisteredFolder(folderPath)) {
+      trace('[spaces] listFolderContents BLOCKED (not in any registered folder): ' + folderPath);
       return [];
     }
+    const resolved = resolvePath(folderPath);
     try {
-      const entries = fs.readdirSync(folderPath, { withFileTypes: true });
+      const entries = fs.readdirSync(resolved, { withFileTypes: true });
       return entries.map(e => ({
         name: e.name,
-        path: path.join(folderPath, e.name),
+        path: path.join(resolved, e.name),
         isDirectory: e.isDirectory(),
         isFile: e.isFile(),
       }));
@@ -259,25 +293,27 @@ function createSpacesStore(options) {
   }
 
   function readFileContents(_event, filePath) {
-    if (!requireAllowedPath(filePath)) {
-      trace('[spaces] readFileContents BLOCKED (outside allowed roots): ' + filePath);
+    if (!isWithinRegisteredFolder(filePath)) {
+      trace('[spaces] readFileContents BLOCKED (not in any registered folder): ' + filePath);
       return null;
     }
+    const resolved = resolvePath(filePath);
     try {
-      return fs.readFileSync(filePath, 'utf8');
+      return fs.readFileSync(resolved, 'utf8');
     } catch (_) {
       return null;
     }
   }
 
   function openFile(_event, filePath) {
-    if (!requireAllowedPath(filePath)) {
-      trace('[spaces] openFile BLOCKED (outside allowed roots): ' + filePath);
+    if (!isWithinRegisteredFolder(filePath)) {
+      trace('[spaces] openFile BLOCKED (not in any registered folder): ' + filePath);
       return false;
     }
+    const resolved = resolvePath(filePath);
     try {
       const { execFile } = require('child_process');
-      execFile('xdg-open', [filePath], { timeout: 5000 });
+      execFile('xdg-open', [resolved], { timeout: 5000 });
     } catch (_) {}
     return true;
   }
@@ -289,15 +325,24 @@ function createSpacesStore(options) {
   }
 
   function createSpaceFolder(_event, spaceId, folderName) {
-    if (typeof folderName !== 'string' || /\.\.[\\/]/.test(folderName) || path.isAbsolute(folderName)) {
-      trace('[spaces] createSpaceFolder BLOCKED (path traversal): ' + folderName);
+    // Internal operation: only allows simple basenames, no path separators
+    // or traversal. Output is always under localAgentRoot.
+    if (typeof folderName !== 'string' || folderName.length === 0 || folderName.length > 255) return null;
+    if (/[/\\]/.test(folderName) || folderName === '.' || folderName === '..') {
+      trace('[spaces] createSpaceFolder BLOCKED (invalid name): ' + folderName);
+      return null;
+    }
+    if (typeof spaceId !== 'string' || !/^[0-9a-f-]+$/i.test(spaceId)) {
+      trace('[spaces] createSpaceFolder BLOCKED (invalid spaceId): ' + spaceId);
       return null;
     }
     const p = discoverSpacesPath();
     if (!p) return null;
     const spaceFolderPath = path.join(path.dirname(p), 'spaces', spaceId, folderName);
-    if (!requireAllowedPath(spaceFolderPath)) {
-      trace('[spaces] createSpaceFolder BLOCKED (outside allowed roots): ' + spaceFolderPath);
+    // Verify the constructed path is still under localAgentRoot
+    const normalized = path.normalize(spaceFolderPath);
+    if (!normalized.startsWith(localAgentRoot + path.sep)) {
+      trace('[spaces] createSpaceFolder BLOCKED (escaped localAgentRoot): ' + normalized);
       return null;
     }
     try {

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -480,7 +480,9 @@ function createSpacesStore(options) {
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space) return null;
-    space.autoDescription = description;
+    var sanitized = sanitizeString(description, 65536);
+    if (sanitized === null) return null;
+    space.autoDescription = sanitized;
     space.updatedAt = Date.now();
     writeSpaces(spaces);
     return space;

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -11,6 +11,14 @@ const fs = require('fs');
 const path = require('path');
 const { randomUUID } = require('crypto');
 
+// Hard caps to prevent unbounded growth of spaces.json. Even with rate
+// limits a malicious renderer could grow the file to GB scale over time.
+const MAX_SPACES_FILE_BYTES = 5 * 1024 * 1024;    // 5 MB total
+const MAX_SPACES_COUNT = 200;
+const MAX_FOLDERS_PER_SPACE = 100;
+const MAX_PROJECTS_PER_SPACE = 500;
+const MAX_LINKS_PER_SPACE = 500;
+
 function createSpacesStore(options) {
   const { localAgentRoot, isPathAllowed, trace = () => {} } = options || {};
 
@@ -195,10 +203,36 @@ function createSpacesStore(options) {
       trace('[spaces] Write BLOCKED: previous read failed to parse — refusing to clobber existing file');
       return false;
     }
+    if (!Array.isArray(spaces)) return false;
+    // Cap total space count and per-space array sizes before serializing.
+    if (spaces.length > MAX_SPACES_COUNT) {
+      trace('[spaces] Write BLOCKED: too many spaces (' + spaces.length + ' > ' + MAX_SPACES_COUNT + ')');
+      return false;
+    }
+    for (var si = 0; si < spaces.length; si++) {
+      var s = spaces[si];
+      if (s && Array.isArray(s.folders) && s.folders.length > MAX_FOLDERS_PER_SPACE) {
+        trace('[spaces] Write BLOCKED: too many folders in space ' + s.id);
+        return false;
+      }
+      if (s && Array.isArray(s.projects) && s.projects.length > MAX_PROJECTS_PER_SPACE) {
+        trace('[spaces] Write BLOCKED: too many projects in space ' + s.id);
+        return false;
+      }
+      if (s && Array.isArray(s.links) && s.links.length > MAX_LINKS_PER_SPACE) {
+        trace('[spaces] Write BLOCKED: too many links in space ' + s.id);
+        return false;
+      }
+    }
     if (!checkWriteRate()) return false;
     const p = discoverSpacesPath();
     if (!p) {
       trace('[spaces] Cannot write — no path discovered');
+      return false;
+    }
+    const payload = JSON.stringify({ spaces }, null, 4) + '\n';
+    if (Buffer.byteLength(payload, 'utf8') > MAX_SPACES_FILE_BYTES) {
+      trace('[spaces] Write BLOCKED: payload exceeds ' + MAX_SPACES_FILE_BYTES + ' bytes');
       return false;
     }
     try {
@@ -206,10 +240,11 @@ function createSpacesStore(options) {
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
-      // Atomic write: write to temp file then rename. Prevents partial
-      // writes from corrupting spaces.json on crash or concurrent access.
-      const tmp = p + '.tmp.' + process.pid;
-      fs.writeFileSync(tmp, JSON.stringify({ spaces }, null, 4) + '\n', 'utf8');
+      // Atomic write: write to temp file then rename. Use random suffix
+      // (not just pid) so two SpacesStore instances in the same process
+      // can't collide on the temp filename.
+      const tmp = p + '.tmp.' + process.pid + '.' + Math.random().toString(36).slice(2);
+      fs.writeFileSync(tmp, payload, 'utf8');
       fs.renameSync(tmp, p);
       return true;
     } catch (e) {
@@ -278,7 +313,7 @@ function createSpacesStore(options) {
     updated.id = spaces[index].id;
     updated.createdAt = spaces[index].createdAt;
     spaces[index] = updated;
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     trace('[spaces] Updated space: ' + spaceId);
     return updated;
   }
@@ -289,7 +324,7 @@ function createSpacesStore(options) {
     if (filtered.length === spaces.length) {
       return false;
     }
-    writeSpaces(filtered);
+    if (!writeSpaces(filtered)) return false;
     trace('[spaces] Deleted space: ' + spaceId);
     return true;
   }
@@ -318,7 +353,7 @@ function createSpacesStore(options) {
       space.folders.push({ path: resolved });
     }
     space.updatedAt = Date.now();
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     return space;
   }
 
@@ -326,13 +361,10 @@ function createSpacesStore(options) {
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space || !Array.isArray(space.folders)) return null;
-    // addFolderToSpace stores the realpath, but the renderer may pass the
-    // original (display) path. Match against both the raw input and the
-    // resolved real path so removal works either way.
     const resolved = resolvePath(folderPath);
     space.folders = space.folders.filter(f => f.path !== folderPath && f.path !== resolved);
     space.updatedAt = Date.now();
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     return space;
   }
 
@@ -345,7 +377,7 @@ function createSpacesStore(options) {
     if (!Array.isArray(space.projects)) space.projects = [];
     space.projects.push(sanitized);
     space.updatedAt = Date.now();
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     return space;
   }
 
@@ -353,9 +385,10 @@ function createSpacesStore(options) {
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space || !Array.isArray(space.projects)) return null;
-    space.projects = space.projects.filter(p => (p.id || p) !== projectId);
+    // Use 'id' in p check + ?? to handle id=0, id='', etc. correctly.
+    space.projects = space.projects.filter(p => (p && 'id' in p ? p.id : p) !== projectId);
     space.updatedAt = Date.now();
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     return space;
   }
 
@@ -368,7 +401,7 @@ function createSpacesStore(options) {
     if (!Array.isArray(space.links)) space.links = [];
     space.links.push(sanitized);
     space.updatedAt = Date.now();
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     return space;
   }
 
@@ -376,9 +409,9 @@ function createSpacesStore(options) {
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space || !Array.isArray(space.links)) return null;
-    space.links = space.links.filter(l => (l.id || l) !== linkId);
+    space.links = space.links.filter(l => (l && 'id' in l ? l.id : l) !== linkId);
     space.updatedAt = Date.now();
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     return space;
   }
 
@@ -520,7 +553,7 @@ function createSpacesStore(options) {
     if (sanitized === null) return null;
     space.autoDescription = sanitized;
     space.updatedAt = Date.now();
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) return null;
     return space;
   }
 

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -44,7 +44,8 @@ function createSpacesStore(options) {
     // Always enforce: no /tmp for space folder registration
     const normalized = path.normalize(p);
     if (normalized === '/tmp' || normalized.startsWith('/tmp/')) return false;
-    const home = require('os').homedir();
+    // Homedir from /etc/passwd, not $HOME
+    const home = global.__coworkPasswdHomedir || require('os').userInfo().homedir;
     return normalized === home || normalized.startsWith(home + path.sep);
   }
 

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -92,28 +92,35 @@ function createSpacesStore(options) {
     return clean;
   }
 
-  // Read-path validation: the file MUST exist (so realpathSync can resolve it)
-  // AND its resolved path must fall within a folder registered in spaces.json.
+  // Read-path validation: resolve the path ONCE through realpathSync and
+  // return the resolved path if it falls within a registered folder. The
+  // caller MUST use the returned path for the actual operation — not the
+  // raw input. Resolving twice creates a TOCTOU window where a symlink
+  // swap between resolve and use can redirect the read.
   //
-  // The registered folder paths are ALREADY resolved (addFolderToSpace stores
-  // the realpathSync'd result). We do NOT re-resolve them here — re-resolving
-  // would follow any symlinks placed at that path AFTER registration, reopening
-  // the symlink-swap attack. The comparison is:
-  //   resolved(requested) vs stored-as-is(registered)
-  function isWithinRegisteredFolder(filePath) {
+  // The registered folder paths are ALREADY resolved (addFolderToSpace
+  // stored the realpathSync'd result). We do NOT re-resolve them here —
+  // re-resolving would follow any symlinks placed at that path AFTER
+  // registration, reopening the symlink-swap attack.
+  function resolveWithinRegisteredFolder(filePath) {
     const resolved = resolvePath(filePath);
-    if (!resolved) return false;
+    if (!resolved) return null;
     const spaces = readSpaces();
     for (const space of spaces) {
       for (const folder of (space.folders || [])) {
         const registeredPath = folder.path;
         if (typeof registeredPath !== 'string') continue;
         if (resolved === registeredPath || resolved.startsWith(registeredPath + path.sep)) {
-          return true;
+          return resolved;
         }
       }
     }
-    return false;
+    return null;
+  }
+
+  // Legacy boolean variant kept for callers that only need the predicate.
+  function isWithinRegisteredFolder(filePath) {
+    return resolveWithinRegisteredFolder(filePath) !== null;
   }
 
   // Discover the spaces.json path by walking localAgentRoot/<accountId>/<orgId>/
@@ -154,18 +161,40 @@ function createSpacesStore(options) {
     return null;
   }
 
+  // _readState tracks whether the last readSpaces() returned [] because
+  // the file genuinely was missing/empty (safe to write) vs because parsing
+  // failed (NOT safe to write — would clobber user's real data).
+  let _lastReadOk = true;
+
   function readSpaces() {
     const p = discoverSpacesPath();
-    if (!p) return [];
+    if (!p) { _lastReadOk = true; return []; }
+    let raw;
     try {
-      const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+      raw = fs.readFileSync(p, 'utf8');
+    } catch (e) {
+      // ENOENT is fine — file just doesn't exist yet.
+      _lastReadOk = (e && e.code === 'ENOENT');
+      return [];
+    }
+    try {
+      const data = JSON.parse(raw);
+      _lastReadOk = true;
       return Array.isArray(data.spaces) ? data.spaces : [];
-    } catch (_) {
+    } catch (e) {
+      // Parse failure: file exists but is corrupt. Refuse subsequent
+      // writes so we don't silently overwrite the user's broken-but-real data.
+      _lastReadOk = false;
+      trace('[spaces] PARSE FAILED, refusing writes until resolved: ' + e.message);
       return [];
     }
   }
 
   function writeSpaces(spaces) {
+    if (!_lastReadOk) {
+      trace('[spaces] Write BLOCKED: previous read failed to parse — refusing to clobber existing file');
+      return false;
+    }
     if (!checkWriteRate()) return false;
     const p = discoverSpacesPath();
     if (!p) {
@@ -222,7 +251,10 @@ function createSpacesStore(options) {
       newSpace.instructions = instr;
     }
     spaces.push(newSpace);
-    writeSpaces(spaces);
+    if (!writeSpaces(spaces)) {
+      trace('[spaces] createSpace: write failed, returning null');
+      return null;
+    }
     trace('[spaces] Created space: ' + newSpace.id + ' (' + newSpace.name + ')');
     return newSpace;
   }
@@ -294,7 +326,11 @@ function createSpacesStore(options) {
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space || !Array.isArray(space.folders)) return null;
-    space.folders = space.folders.filter(f => f.path !== folderPath);
+    // addFolderToSpace stores the realpath, but the renderer may pass the
+    // original (display) path. Match against both the raw input and the
+    // resolved real path so removal works either way.
+    const resolved = resolvePath(folderPath);
+    space.folders = space.folders.filter(f => f.path !== folderPath && f.path !== resolved);
     space.updatedAt = Date.now();
     writeSpaces(spaces);
     return space;
@@ -362,11 +398,11 @@ function createSpacesStore(options) {
   }
 
   function listFolderContents(_event, folderPath) {
-    if (!isWithinRegisteredFolder(folderPath)) {
-      trace('[spaces] listFolderContents BLOCKED (not in any registered folder): ' + folderPath);
+    const resolved = resolveWithinRegisteredFolder(folderPath);
+    if (!resolved) {
+      trace('[spaces] listFolderContents BLOCKED: ' + folderPath);
       return [];
     }
-    const resolved = resolvePath(folderPath);
     try {
       const entries = fs.readdirSync(resolved, { withFileTypes: true });
       return entries.map(e => ({
@@ -381,11 +417,11 @@ function createSpacesStore(options) {
   }
 
   function readFileContents(_event, filePath) {
-    if (!isWithinRegisteredFolder(filePath)) {
-      trace('[spaces] readFileContents BLOCKED (not in any registered folder): ' + filePath);
+    const resolved = resolveWithinRegisteredFolder(filePath);
+    if (!resolved) {
+      trace('[spaces] readFileContents BLOCKED: ' + filePath);
       return null;
     }
-    const resolved = resolvePath(filePath);
     try {
       return fs.readFileSync(resolved, 'utf8');
     } catch (_) {
@@ -394,11 +430,11 @@ function createSpacesStore(options) {
   }
 
   function openFile(_event, filePath) {
-    if (!isWithinRegisteredFolder(filePath)) {
-      trace('[spaces] openFile BLOCKED (not in any registered folder): ' + filePath);
+    const resolved = resolveWithinRegisteredFolder(filePath);
+    if (!resolved) {
+      trace('[spaces] openFile BLOCKED: ' + filePath);
       return false;
     }
-    const resolved = resolvePath(filePath);
     try {
       const { execFile } = require('child_process');
       execFile('xdg-open', [resolved], { timeout: 5000 });

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -12,7 +12,18 @@ const path = require('path');
 const { randomUUID } = require('crypto');
 
 function createSpacesStore(options) {
-  const { localAgentRoot, trace = () => {} } = options || {};
+  const { localAgentRoot, isPathAllowed, trace = () => {} } = options || {};
+
+  // Path validation gate — reuses the caller's isPathWithinAllowedRoots().
+  // Every function that touches user-supplied paths MUST call this.
+  function requireAllowedPath(p) {
+    if (typeof p !== 'string' || !path.isAbsolute(p)) return false;
+    if (typeof isPathAllowed === 'function') return isPathAllowed(p);
+    // Fallback: restrict to homedir if no validator was injected
+    const home = require('os').homedir();
+    const resolved = path.normalize(p);
+    return resolved === home || resolved.startsWith(home + path.sep);
+  }
 
   // Discover the spaces.json path by walking localAgentRoot/<accountId>/<orgId>/
   let spacesJsonPath = null;
@@ -147,6 +158,10 @@ function createSpacesStore(options) {
   }
 
   function addFolderToSpace(_event, spaceId, folderPath) {
+    if (!requireAllowedPath(folderPath)) {
+      trace('[spaces] addFolderToSpace BLOCKED (outside allowed roots): ' + folderPath);
+      return null;
+    }
     const spaces = readSpaces();
     const space = spaces.find(s => s.id === spaceId);
     if (!space) return null;
@@ -226,6 +241,10 @@ function createSpacesStore(options) {
   }
 
   function listFolderContents(_event, folderPath) {
+    if (!requireAllowedPath(folderPath)) {
+      trace('[spaces] listFolderContents BLOCKED (outside allowed roots): ' + folderPath);
+      return [];
+    }
     try {
       const entries = fs.readdirSync(folderPath, { withFileTypes: true });
       return entries.map(e => ({
@@ -240,6 +259,10 @@ function createSpacesStore(options) {
   }
 
   function readFileContents(_event, filePath) {
+    if (!requireAllowedPath(filePath)) {
+      trace('[spaces] readFileContents BLOCKED (outside allowed roots): ' + filePath);
+      return null;
+    }
     try {
       return fs.readFileSync(filePath, 'utf8');
     } catch (_) {
@@ -248,7 +271,10 @@ function createSpacesStore(options) {
   }
 
   function openFile(_event, filePath) {
-    // Best-effort open with xdg-open
+    if (!requireAllowedPath(filePath)) {
+      trace('[spaces] openFile BLOCKED (outside allowed roots): ' + filePath);
+      return false;
+    }
     try {
       const { execFile } = require('child_process');
       execFile('xdg-open', [filePath], { timeout: 5000 });
@@ -263,9 +289,17 @@ function createSpacesStore(options) {
   }
 
   function createSpaceFolder(_event, spaceId, folderName) {
+    if (typeof folderName !== 'string' || /\.\.[\\/]/.test(folderName) || path.isAbsolute(folderName)) {
+      trace('[spaces] createSpaceFolder BLOCKED (path traversal): ' + folderName);
+      return null;
+    }
     const p = discoverSpacesPath();
     if (!p) return null;
     const spaceFolderPath = path.join(path.dirname(p), 'spaces', spaceId, folderName);
+    if (!requireAllowedPath(spaceFolderPath)) {
+      trace('[spaces] createSpaceFolder BLOCKED (outside allowed roots): ' + spaceFolderPath);
+      return null;
+    }
     try {
       fs.mkdirSync(spaceFolderPath, { recursive: true });
       return spaceFolderPath;

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -1,0 +1,352 @@
+'use strict';
+
+// Spaces store — file-backed implementation of CoworkSpaces IPC handlers for Linux.
+//
+// On macOS, spaces are managed by a native Swift module. On Linux, we persist
+// them to spaces.json under the local-agent-mode-sessions directory.
+//
+// Path: <localAgentRoot>/<accountId>/<orgId>/spaces.json
+
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+
+function createSpacesStore(options) {
+  const { localAgentRoot, trace = () => {} } = options || {};
+
+  // Discover the spaces.json path by walking localAgentRoot/<accountId>/<orgId>/
+  let spacesJsonPath = null;
+
+  function discoverSpacesPath() {
+    if (spacesJsonPath) return spacesJsonPath;
+    if (!localAgentRoot || !fs.existsSync(localAgentRoot)) {
+      trace('[spaces] localAgentRoot not found: ' + localAgentRoot);
+      return null;
+    }
+
+    try {
+      const accountDirs = fs.readdirSync(localAgentRoot, { withFileTypes: true })
+        .filter(d => d.isDirectory());
+      for (const accountDir of accountDirs) {
+        const accountPath = path.join(localAgentRoot, accountDir.name);
+        const orgDirs = fs.readdirSync(accountPath, { withFileTypes: true })
+          .filter(d => d.isDirectory());
+        for (const orgDir of orgDirs) {
+          const candidate = path.join(accountPath, orgDir.name, 'spaces.json');
+          if (fs.existsSync(candidate)) {
+            spacesJsonPath = candidate;
+            trace('[spaces] Found spaces.json: ' + spacesJsonPath);
+            return spacesJsonPath;
+          }
+        }
+        // If no spaces.json yet, use first org dir
+        if (orgDirs.length > 0) {
+          spacesJsonPath = path.join(accountPath, orgDirs[0].name, 'spaces.json');
+          trace('[spaces] Will create spaces.json: ' + spacesJsonPath);
+          return spacesJsonPath;
+        }
+      }
+    } catch (e) {
+      trace('[spaces] Error discovering spaces path: ' + e.message);
+    }
+    return null;
+  }
+
+  function readSpaces() {
+    const p = discoverSpacesPath();
+    if (!p) return [];
+    try {
+      const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+      return Array.isArray(data.spaces) ? data.spaces : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  function writeSpaces(spaces) {
+    const p = discoverSpacesPath();
+    if (!p) {
+      trace('[spaces] Cannot write — no path discovered');
+      return false;
+    }
+    try {
+      const dir = path.dirname(p);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.writeFileSync(p, JSON.stringify({ spaces }, null, 4) + '\n', 'utf8');
+      return true;
+    } catch (e) {
+      trace('[spaces] Write error: ' + e.message);
+      return false;
+    }
+  }
+
+  function findSpace(spaceId) {
+    return readSpaces().find(s => s.id === spaceId) || null;
+  }
+
+  // -- IPC handlers (match CoworkSpaces_$_* contract) --
+
+  function getAllSpaces() {
+    return readSpaces();
+  }
+
+  function getSpace(_event, spaceId) {
+    return findSpace(spaceId);
+  }
+
+  function createSpace(_event, spaceData) {
+    const spaces = readSpaces();
+    const now = Date.now();
+    const newSpace = {
+      id: randomUUID(),
+      name: spaceData.name || 'Untitled',
+      folders: Array.isArray(spaceData.folders) ? spaceData.folders : [],
+      projects: Array.isArray(spaceData.projects) ? spaceData.projects : [],
+      links: Array.isArray(spaceData.links) ? spaceData.links : [],
+      origin: spaceData.origin || 'user',
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (spaceData.instructions) {
+      newSpace.instructions = spaceData.instructions;
+    }
+    spaces.push(newSpace);
+    writeSpaces(spaces);
+    trace('[spaces] Created space: ' + newSpace.id + ' (' + newSpace.name + ')');
+    return newSpace;
+  }
+
+  function updateSpace(_event, spaceId, updates) {
+    const spaces = readSpaces();
+    const index = spaces.findIndex(s => s.id === spaceId);
+    if (index === -1) {
+      trace('[spaces] updateSpace: not found ' + spaceId);
+      return null;
+    }
+    const updated = { ...spaces[index], ...updates, updatedAt: Date.now() };
+    // Don't allow overwriting id or createdAt
+    updated.id = spaces[index].id;
+    updated.createdAt = spaces[index].createdAt;
+    spaces[index] = updated;
+    writeSpaces(spaces);
+    trace('[spaces] Updated space: ' + spaceId);
+    return updated;
+  }
+
+  function deleteSpace(_event, spaceId) {
+    const spaces = readSpaces();
+    const filtered = spaces.filter(s => s.id !== spaceId);
+    if (filtered.length === spaces.length) {
+      return false;
+    }
+    writeSpaces(filtered);
+    trace('[spaces] Deleted space: ' + spaceId);
+    return true;
+  }
+
+  function addFolderToSpace(_event, spaceId, folderPath) {
+    const spaces = readSpaces();
+    const space = spaces.find(s => s.id === spaceId);
+    if (!space) return null;
+    if (!Array.isArray(space.folders)) space.folders = [];
+    // Avoid duplicates
+    if (!space.folders.some(f => f.path === folderPath)) {
+      space.folders.push({ path: folderPath });
+    }
+    space.updatedAt = Date.now();
+    writeSpaces(spaces);
+    return space;
+  }
+
+  function removeFolderFromSpace(_event, spaceId, folderPath) {
+    const spaces = readSpaces();
+    const space = spaces.find(s => s.id === spaceId);
+    if (!space || !Array.isArray(space.folders)) return null;
+    space.folders = space.folders.filter(f => f.path !== folderPath);
+    space.updatedAt = Date.now();
+    writeSpaces(spaces);
+    return space;
+  }
+
+  function addProjectToSpace(_event, spaceId, project) {
+    const spaces = readSpaces();
+    const space = spaces.find(s => s.id === spaceId);
+    if (!space) return null;
+    if (!Array.isArray(space.projects)) space.projects = [];
+    space.projects.push(project);
+    space.updatedAt = Date.now();
+    writeSpaces(spaces);
+    return space;
+  }
+
+  function removeProjectFromSpace(_event, spaceId, projectId) {
+    const spaces = readSpaces();
+    const space = spaces.find(s => s.id === spaceId);
+    if (!space || !Array.isArray(space.projects)) return null;
+    space.projects = space.projects.filter(p => (p.id || p) !== projectId);
+    space.updatedAt = Date.now();
+    writeSpaces(spaces);
+    return space;
+  }
+
+  function addLinkToSpace(_event, spaceId, link) {
+    const spaces = readSpaces();
+    const space = spaces.find(s => s.id === spaceId);
+    if (!space) return null;
+    if (!Array.isArray(space.links)) space.links = [];
+    space.links.push(link);
+    space.updatedAt = Date.now();
+    writeSpaces(spaces);
+    return space;
+  }
+
+  function removeLinkFromSpace(_event, spaceId, linkId) {
+    const spaces = readSpaces();
+    const space = spaces.find(s => s.id === spaceId);
+    if (!space || !Array.isArray(space.links)) return null;
+    space.links = space.links.filter(l => (l.id || l) !== linkId);
+    space.updatedAt = Date.now();
+    writeSpaces(spaces);
+    return space;
+  }
+
+  function getAutoMemoryDir(_event, spaceId) {
+    // Return the memory directory for the space
+    const p = discoverSpacesPath();
+    if (!p) return null;
+    const spacesDir = path.join(path.dirname(p), 'spaces', spaceId, 'memory');
+    try {
+      if (!fs.existsSync(spacesDir)) {
+        fs.mkdirSync(spacesDir, { recursive: true });
+      }
+    } catch (_) {}
+    return spacesDir;
+  }
+
+  function listFolderContents(_event, folderPath) {
+    try {
+      const entries = fs.readdirSync(folderPath, { withFileTypes: true });
+      return entries.map(e => ({
+        name: e.name,
+        path: path.join(folderPath, e.name),
+        isDirectory: e.isDirectory(),
+        isFile: e.isFile(),
+      }));
+    } catch (_) {
+      return [];
+    }
+  }
+
+  function readFileContents(_event, filePath) {
+    try {
+      return fs.readFileSync(filePath, 'utf8');
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function openFile(_event, filePath) {
+    // Best-effort open with xdg-open
+    try {
+      const { execFile } = require('child_process');
+      execFile('xdg-open', [filePath], { timeout: 5000 });
+    } catch (_) {}
+    return true;
+  }
+
+  function copyFilesToSpaceFolder(_event, spaceId, files) {
+    // No-op stub — would need implementation for drag-and-drop
+    trace('[spaces] copyFilesToSpaceFolder: stub (spaceId=' + spaceId + ')');
+    return true;
+  }
+
+  function createSpaceFolder(_event, spaceId, folderName) {
+    const p = discoverSpacesPath();
+    if (!p) return null;
+    const spaceFolderPath = path.join(path.dirname(p), 'spaces', spaceId, folderName);
+    try {
+      fs.mkdirSync(spaceFolderPath, { recursive: true });
+      return spaceFolderPath;
+    } catch (e) {
+      trace('[spaces] createSpaceFolder error: ' + e.message);
+      return null;
+    }
+  }
+
+  function classifySessions(_event, sessions) {
+    // Classify which sessions belong to which spaces based on userSelectedFolders
+    const spaces = readSpaces();
+    const result = {};
+    for (const session of (sessions || [])) {
+      const folders = session.userSelectedFolders || [];
+      for (const space of spaces) {
+        for (const sf of (space.folders || [])) {
+          if (folders.some(f => f === sf.path || f.startsWith(sf.path + '/'))) {
+            if (!result[space.id]) result[space.id] = [];
+            result[space.id].push(session.sessionId || session.id);
+            break;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  function setAutoDescription(_event, spaceId, description) {
+    const spaces = readSpaces();
+    const space = spaces.find(s => s.id === spaceId);
+    if (!space) return null;
+    space.autoDescription = description;
+    space.updatedAt = Date.now();
+    writeSpaces(spaces);
+    return space;
+  }
+
+  function summarizeSpace(_event, spaceId) {
+    const space = findSpace(spaceId);
+    if (!space) return null;
+    return {
+      id: space.id,
+      name: space.name,
+      folderCount: (space.folders || []).length,
+      projectCount: (space.projects || []).length,
+      linkCount: (space.links || []).length,
+      instructions: space.instructions || null,
+      autoDescription: space.autoDescription || null,
+    };
+  }
+
+  // Event subscription — no-op, the renderer doesn't need real-time events on Linux
+  // since we don't have native filesystem watchers wired to spaces.
+  function onSpaceEvent(_event, _callback) {
+    return { dispose: () => {} };
+  }
+
+  return {
+    getAllSpaces,
+    getSpace,
+    createSpace,
+    updateSpace,
+    deleteSpace,
+    addFolderToSpace,
+    removeFolderFromSpace,
+    addProjectToSpace,
+    removeProjectFromSpace,
+    addLinkToSpace,
+    removeLinkFromSpace,
+    getAutoMemoryDir,
+    listFolderContents,
+    readFileContents,
+    openFile,
+    copyFilesToSpaceFolder,
+    createSpaceFolder,
+    classifySessions,
+    setAutoDescription,
+    summarizeSpace,
+    onSpaceEvent,
+  };
+}
+
+module.exports = { createSpacesStore };

--- a/stubs/cowork/startup_check.js
+++ b/stubs/cowork/startup_check.js
@@ -27,6 +27,7 @@ function runStartupCheck({
   ipcOverridesRegistry = null,
   autoPermissionsCap = null,
   mountRootBound = null,
+  execCapabilityRegistry = null,
   log = console.log,
   warn = console.warn,
   writeFn = fs.appendFileSync,
@@ -65,6 +66,13 @@ function runStartupCheck({
   results.push({
     check: 'mount_bound_armed',
     ok: !!(mountRootBound && typeof mountRootBound.isMountRootTooBroad === 'function'),
+  });
+
+  // Check 4: exec capability registry is armed (frozen map replaces
+  // directory-based allowlists for command execution).
+  results.push({
+    check: 'exec_capability_registry_armed',
+    ok: !!(execCapabilityRegistry && typeof execCapabilityRegistry.resolve === 'function'),
   });
 
   const ok = results.every((r) => r.ok);

--- a/stubs/cowork/startup_check.js
+++ b/stubs/cowork/startup_check.js
@@ -19,7 +19,7 @@ const path = require('path');
 const os = require('os');
 
 function defaultLogPath() {
-  const xdgState = process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state');
+  const xdgState = process.env.XDG_STATE_HOME || path.join(global.__coworkPasswdHomedir || os.userInfo().homedir, '.local', 'state');
   return path.join(xdgState, 'claude-cowork', 'logs', 'cowork-startup.log');
 }
 

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -69,19 +69,14 @@ const path = require('path');
 const os = require('os');
 const fs = require('fs');
 
-// Verify os.homedir() is owned by the current user. HOME env var can be
-// set to a world-writable dir (e.g. /tmp/fakehome), which would shift the
-// entire trust boundary. Abort early if the homedir isn't ours.
-try {
-  const _homeStat = fs.statSync(os.homedir());
-  if (_homeStat.uid !== process.getuid()) {
-    console.error('[SECURITY] os.homedir() (' + os.homedir() + ') is not owned by uid ' + process.getuid() + ' — aborting');
-    process.exit(1);
-  }
-} catch (e) {
-  console.error('[SECURITY] Cannot verify homedir ownership:', e.message);
-  process.exit(1);
-}
+// Authoritative homedir from /etc/passwd (getpwuid_r), NOT from $HOME.
+// os.homedir() trusts the HOME env var, which can be set to any path.
+// os.userInfo().homedir reads from the system password database — the
+// user's environment can't override it. Use this for all security
+// boundaries (allowlists, path validation). Expose via global so
+// downstream modules (ipc_overrides, spaces_store) use the same source.
+const PASSWD_HOMEDIR = os.userInfo().homedir;
+global.__coworkPasswdHomedir = PASSWD_HOMEDIR;
 const {
   createAsarAdapter,
   DEFAULT_FILESYSTEM_PATH_ALIASES,
@@ -548,8 +543,7 @@ try {
 try {
   const _electron = require('electron');
   const { createSpacesStore } = require('./cowork/spaces_store.js');
-  const _homeDir = os.homedir();
-  const _earlyAllowedRoots = [_homeDir];
+  const _earlyAllowedRoots = [PASSWD_HOMEDIR];
   function _earlyIsPathAllowed(filePath) {
     if (typeof filePath !== 'string' || !path.isAbsolute(filePath)) return false;
     const normalized = path.normalize(filePath);

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -535,7 +535,7 @@ try {
   const _electron = require('electron');
   const { createSpacesStore } = require('./cowork/spaces_store.js');
   const _homeDir = os.homedir();
-  const _earlyAllowedRoots = [_homeDir, '/tmp'];
+  const _earlyAllowedRoots = [_homeDir];
   function _earlyIsPathAllowed(filePath) {
     if (typeof filePath !== 'string' || !path.isAbsolute(filePath)) return false;
     const normalized = path.normalize(filePath);

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -1124,19 +1124,50 @@ for (const sig of ['SIGTERM', 'SIGHUP', 'SIGINT']) {
 }
 
 // ============================================================
-// APP NAME — set before index.js runs so requestSingleInstanceLock() uses the
-// correct userData path (~/.config/Claude). The package.json name is @ant/desktop
-// which would produce ~/.config/@ant/desktop — wrong path, breaks single-instance.
-// The asar's index.js also calls app.setName('Claude') but only inside whenReady(),
-// which is too late for the lock. We set it here at require-time.
-// Protocol URL forwarding is handled by protocol-forwarder.js (invoked from
-// the claude-desktop launcher script for claude:// callbacks).
+// APP NAME + SINGLE-INSTANCE LOCK — must run before index.js so:
+//  1. setName('Claude') sets userData to ~/.config/Claude (otherwise it
+//     would be ~/.config/@ant/desktop from package.json name).
+//  2. requestSingleInstanceLock() is held by THIS process so the
+//     protocol-forwarder (launched via `claude-desktop %u`) can detect
+//     "main app running" and forward the URL via the second-instance event.
+//
+// The asar's index.js takes app.on('open-url', ...) under darwin spoof
+// and never calls requestSingleInstanceLock() itself — so if we don't
+// hold the lock here, the forwarder always spawns a duplicate instance.
 try {
   const { app } = require('electron');
   if (typeof app.setName === 'function') app.setName('Claude');
-  console.log('[SingleInstance] App name set to Claude — lock will use ~/.config/Claude');
+  console.log('[SingleInstance] App name set to Claude');
+
+  const gotLock = app.requestSingleInstanceLock();
+  if (!gotLock) {
+    console.log('[SingleInstance] Another instance is running, quitting');
+    app.quit();
+  } else {
+    console.log('[SingleInstance] Lock acquired');
+    app.on('second-instance', function(_event, argv) {
+      // protocol-forwarder.js forwards a claude:// URL via its argv.
+      // Find it, validate basic shape, then re-emit as open-url so the
+      // asar's URL handler (registered under darwin spoof) processes it.
+      try {
+        var url = null;
+        for (var i = 0; i < argv.length; i++) {
+          if (typeof argv[i] === 'string' && argv[i].indexOf('claude://') === 0) {
+            url = argv[i];
+            break;
+          }
+        }
+        if (url && url.length < 2048 && /^claude:\/\/[a-zA-Z0-9\-._~:/?#\[\]@!$&()*+,;=%]+$/.test(url)) {
+          console.log('[SingleInstance] forwarding URL via open-url: ' + url);
+          app.emit('open-url', { preventDefault: function() {} }, url);
+        }
+      } catch (e) {
+        console.error('[SingleInstance] second-instance handler error:', e.message);
+      }
+    });
+  }
 } catch (e) {
-  console.error('[SingleInstance] Failed to set app name:', e.message);
+  console.error('[SingleInstance] setup failed:', e.message);
 }
 
 Module.prototype.require = function(id) {

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -538,8 +538,25 @@ try {
   const _earlyAllowedRoots = [_homeDir, '/tmp'];
   function _earlyIsPathAllowed(filePath) {
     if (typeof filePath !== 'string' || !path.isAbsolute(filePath)) return false;
+    const normalized = path.normalize(filePath);
     let resolved;
-    try { resolved = fs.realpathSync(filePath); } catch (_) { resolved = path.normalize(filePath); }
+    try {
+      resolved = fs.realpathSync(normalized);
+    } catch (_) {
+      let current = path.dirname(normalized);
+      let tail = path.basename(normalized);
+      resolved = null;
+      while (current !== path.dirname(current)) {
+        try {
+          resolved = path.join(fs.realpathSync(current), tail);
+          break;
+        } catch (_) {
+          tail = path.join(path.basename(current), tail);
+          current = path.dirname(current);
+        }
+      }
+      if (!resolved) resolved = normalized;
+    }
     return _earlyAllowedRoots.some(root => resolved === root || resolved.startsWith(root + path.sep));
   }
   const _spacesStore = createSpacesStore({

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -717,52 +717,15 @@ try {
     const _cp = require('child_process');
     const _origExecFile = _cp.execFile;
     const _origSpawn = _cp.spawn;
-    const CLAUDE_SEARCH_PATHS = [
-      path.join(os.homedir(), '.local', 'bin', 'claude'),
-      path.join(os.homedir(), '.local', 'share', 'mise', 'shims', 'claude'),
-      path.join(os.homedir(), '.asdf', 'shims', 'claude'),
-      '/usr/local/bin/claude',
-      '/usr/bin/claude',
-    ];
-    // Disclaimer-unwrap allowlist. On macOS the asar wraps every spawn with
-    // Helpers/disclaimer; the spoofed-darwin Linux path activates the same
-    // wrap, so we unwrap it back to the original command. Restrict the unwrap
-    // to known-good directories so a compromised caller can't trivially
-    // smuggle in arbitrary binaries via the disclaimer args.
-    //
-    // System paths are always trusted. User-local paths cover MCP servers and
-    // CLI tools the user installs via cargo, npm-global, mise, asdf, volta,
-    // and Linux distro conventions. These are user-controlled regardless, so
-    // including them adds no privilege the caller doesn't already have.
-    const ALLOWED_CMD_DIRS = [
-      '/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/',
-      os.homedir() + '/.local/bin/',
-      os.homedir() + '/.npm-global/bin/',
-      os.homedir() + '/.cargo/bin/',
-      os.homedir() + '/go/bin/',
-      os.homedir() + '/.bun/bin/',
-      os.homedir() + '/.deno/bin/',
-      os.homedir() + '/.local/share/mise/shims/',
-      os.homedir() + '/.asdf/shims/',
-      os.homedir() + '/.volta/bin/',
-      os.homedir() + '/bin/',
-    ];
+    const { createExecCapabilityRegistry } = require('../cowork/exec_capability_registry');
+    const _execRegistry = createExecCapabilityRegistry({
+      homedir: PASSWD_HOMEDIR,
+    });
+    global.__coworkExecRegistry = _execRegistry;
 
     function _resolveDisclaimerArgs(file, args) {
       if (file !== disclaimerBin) return null;
-      if (!Array.isArray(args) || args.length === 0) return null;
-      let cmd = args[0];
-      const rest = args.slice(1);
-      if (/claude\.app\/Contents\/MacOS\/[Cc]laude$/.test(cmd)) {
-        cmd = null;
-        for (const candidate of CLAUDE_SEARCH_PATHS) {
-          try { fs.accessSync(candidate, fs.constants.X_OK); cmd = candidate; break; } catch (_) {}
-        }
-        if (!cmd) return null;
-      } else if (!ALLOWED_CMD_DIRS.some(d => cmd.startsWith(d))) {
-        return null;
-      }
-      return { cmd, rest };
+      return _execRegistry.resolveDisclaimerCommand(args);
     }
 
     _cp.execFile = function(file, args, ...rest) {

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -520,6 +520,72 @@ try {
 }
 
 // ============================================================
+// CRITICAL: Register CoworkSpaces handlers on ipcMain IMMEDIATELY
+// ============================================================
+// The asar's native SpacesStore only registers handlers after account IPC
+// from the renderer, which is unreliable on Linux. Without a handler,
+// ipcRenderer.invoke() fails silently and the Projects page stays empty.
+//
+// We register our file-backed handlers on ipcMain.handle() BEFORE any
+// webContents exists. When no webContents.ipc.handle() exists for a channel,
+// Electron falls back to ipcMain.handle(). If/when the asar's native handler
+// registers later (account init succeeds), it uses webContents.ipc.handle()
+// which takes priority over our ipcMain handler.
+try {
+  const _electron = require('electron');
+  const { createSpacesStore } = require('./cowork/spaces_store.js');
+  const _spacesStore = createSpacesStore({
+    localAgentRoot: path.join(
+      process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+      'Claude', 'local-agent-mode-sessions'
+    ),
+    trace: (msg) => console.log(msg),
+  });
+
+  const EIPC_UUID = 'c42bb833-f6f9-4563-9861-03480449cfb1';
+  const EIPC_NS = 'claude.web';
+  const prefix = `$eipc_message$_${EIPC_UUID}_$_${EIPC_NS}_$_CoworkSpaces_$_`;
+
+  const handlers = {
+    getAllSpaces: async () => _spacesStore.getAllSpaces(),
+    getSpace: async (_e, id) => _spacesStore.getSpace(_e, id),
+    createSpace: async (_e, data) => _spacesStore.createSpace(_e, data),
+    updateSpace: async (_e, id, upd) => _spacesStore.updateSpace(_e, id, upd),
+    deleteSpace: async (_e, id) => _spacesStore.deleteSpace(_e, id),
+    addFolderToSpace: async (_e, id, p) => _spacesStore.addFolderToSpace(_e, id, p),
+    removeFolderFromSpace: async (_e, id, p) => _spacesStore.removeFolderFromSpace(_e, id, p),
+    addProjectToSpace: async (_e, id, p) => _spacesStore.addProjectToSpace(_e, id, p),
+    removeProjectFromSpace: async (_e, id, p) => _spacesStore.removeProjectFromSpace(_e, id, p),
+    addLinkToSpace: async (_e, id, l) => _spacesStore.addLinkToSpace(_e, id, l),
+    removeLinkFromSpace: async (_e, id, l) => _spacesStore.removeLinkFromSpace(_e, id, l),
+    getAutoMemoryDir: async (_e, id) => _spacesStore.getAutoMemoryDir(_e, id),
+    listFolderContents: async (_e, p) => _spacesStore.listFolderContents(_e, p),
+    readFileContents: async (_e, p) => _spacesStore.readFileContents(_e, p),
+    openFile: async (_e, p) => _spacesStore.openFile(_e, p),
+    copyFilesToSpaceFolder: async (_e, id, f) => _spacesStore.copyFilesToSpaceFolder(_e, id, f),
+    createSpaceFolder: async (_e, id, n) => _spacesStore.createSpaceFolder(_e, id, n),
+    classifySessions: async (_e, s) => _spacesStore.classifySessions(_e, s),
+    setAutoDescription: async (_e, id, d) => _spacesStore.setAutoDescription(_e, id, d),
+    summarizeSpace: async (_e, id) => _spacesStore.summarizeSpace(_e, id),
+    onSpaceEvent: async () => ({ dispose: () => {} }),
+  };
+
+  let registered = 0;
+  for (const [method, handler] of Object.entries(handlers)) {
+    const channel = prefix + method;
+    try {
+      _electron.ipcMain.handle(channel, handler);
+      registered++;
+    } catch (e) {
+      // Already registered — skip
+    }
+  }
+  console.log('[Cowork] Registered ' + registered + ' CoworkSpaces handlers on ipcMain (fallback)');
+} catch (earlyRegErr) {
+  console.error('[Cowork] EARLY CoworkSpaces registration FAILED:', earlyRegErr.message, earlyRegErr.stack);
+}
+
+// ============================================================
 // 0. TMPDIR FIX - MUST BE ABSOLUTELY FIRST
 // ============================================================
 // Fix EXDEV error: App downloads VM to /tmp (tmpfs) then tries to
@@ -624,7 +690,29 @@ try {
       '/usr/local/bin/claude',
       '/usr/bin/claude',
     ];
-    const ALLOWED_CMD_DIRS = ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'];
+    // Disclaimer-unwrap allowlist. On macOS the asar wraps every spawn with
+    // Helpers/disclaimer; the spoofed-darwin Linux path activates the same
+    // wrap, so we unwrap it back to the original command. Restrict the unwrap
+    // to known-good directories so a compromised caller can't trivially
+    // smuggle in arbitrary binaries via the disclaimer args.
+    //
+    // System paths are always trusted. User-local paths cover MCP servers and
+    // CLI tools the user installs via cargo, npm-global, mise, asdf, volta,
+    // and Linux distro conventions. These are user-controlled regardless, so
+    // including them adds no privilege the caller doesn't already have.
+    const ALLOWED_CMD_DIRS = [
+      '/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/', '/opt/',
+      os.homedir() + '/.local/bin/',
+      os.homedir() + '/.npm-global/bin/',
+      os.homedir() + '/.cargo/bin/',
+      os.homedir() + '/go/bin/',
+      os.homedir() + '/.bun/bin/',
+      os.homedir() + '/.deno/bin/',
+      os.homedir() + '/.local/share/mise/shims/',
+      os.homedir() + '/.asdf/shims/',
+      os.homedir() + '/.volta/bin/',
+      os.homedir() + '/bin/',
+    ];
 
     function _resolveDisclaimerArgs(file, args) {
       if (file !== disclaimerBin) return null;
@@ -662,6 +750,121 @@ try {
 } catch (e) {
   console.error('[TMPDIR] Setup failed:', e.message);
 }
+
+// ============================================================
+// 0a. PATCH fs TO REDIRECT /sessions/ PATHS TO SESSIONS_BASE
+// ============================================================
+// The asar and our stubs use /sessions/<name>/... as the VM-internal path
+// prefix. On macOS a /sessions root symlink is created. On Linux we can't
+// always create root symlinks (immutable rootfs, no sudo). Instead, patch
+// all fs calls to rewrite /sessions/ -> SESSIONS_BASE/ transparently.
+//
+// SESSIONS_BASE is resolved lazily (DIRS is created below) so we capture
+// a getter that reads from the global set during createDirs().
+(function patchFsSessionsPaths() {
+  const VM_SESSIONS_PREFIX = '/sessions/';
+
+  function rewritePath(p) {
+    if (typeof p === 'string' && p.startsWith(VM_SESSIONS_PREFIX)) {
+      const base = (typeof SESSIONS_BASE !== 'undefined' ? SESSIONS_BASE : null)
+        || (global.__coworkDirs && global.__coworkDirs.claudeSessionsBase)
+        || require('path').join(
+            (process.env.XDG_CONFIG_HOME || require('path').join(require('os').homedir(), '.config')),
+            'Claude', 'local-agent-mode-sessions', 'sessions'
+          );
+      return base + '/' + p.slice(VM_SESSIONS_PREFIX.length);
+    }
+    return p;
+  }
+
+  function wrapFsMethod(obj, name) {
+    const orig = obj[name];
+    if (typeof orig !== 'function' || obj[name].__coworkSessionsPatched) return;
+    obj[name] = function(p, ...rest) {
+      return orig.call(this, rewritePath(p), ...rest);
+    };
+    obj[name].__coworkSessionsPatched = true;
+  }
+
+  const PATH_METHODS = [
+    'access', 'accessSync',
+    'chmod', 'chmodSync',
+    'chown', 'chownSync',
+    'copyFile', 'copyFileSync',
+    'createReadStream', 'createWriteStream',
+    'exists', 'existsSync',
+    'lchmod', 'lchmodSync',
+    'lchown', 'lchownSync',
+    'lstat', 'lstatSync',
+    'mkdir', 'mkdirSync',
+    'mkdtemp', 'mkdtempSync',
+    'open', 'openSync',
+    'opendir', 'opendirSync',
+    'readdir', 'readdirSync',
+    'readFile', 'readFileSync',
+    'readlink', 'readlinkSync',
+    'realpath', 'realpathSync',
+    'rmdir', 'rmdirSync',
+    'rm', 'rmSync',
+    'stat', 'statSync',
+    'symlink', 'symlinkSync',
+    'truncate', 'truncateSync',
+    'unlink', 'unlinkSync',
+    'utimes', 'utimesSync',
+    'watch', 'watchFile',
+    'writeFile', 'writeFileSync',
+    'appendFile', 'appendFileSync',
+  ];
+
+  for (const name of PATH_METHODS) {
+    if (typeof fs[name] === 'function') wrapFsMethod(fs, name);
+  }
+
+  const origRenameForSessions = fs.rename;
+  if (origRenameForSessions && !origRenameForSessions.__coworkSessionsRenamePatched) {
+    fs.rename = function(oldPath, newPath, cb) {
+      return origRenameForSessions.call(this, rewritePath(oldPath), rewritePath(newPath), cb);
+    };
+    fs.rename.__coworkSessionsRenamePatched = true;
+  }
+  const origRenameSyncForSessions = fs.renameSync;
+  if (origRenameSyncForSessions && !origRenameSyncForSessions.__coworkSessionsRenamePatched) {
+    fs.renameSync = function(oldPath, newPath) {
+      return origRenameSyncForSessions.call(this, rewritePath(oldPath), rewritePath(newPath));
+    };
+    fs.renameSync.__coworkSessionsRenamePatched = true;
+  }
+
+  try {
+    const fsp = require('fs/promises') || fs.promises;
+    if (fsp) {
+      const ASYNC_PATH_METHODS = [
+        'access', 'chmod', 'chown', 'copyFile', 'lchmod', 'lchown',
+        'lstat', 'mkdir', 'mkdtemp', 'open', 'opendir', 'readdir',
+        'readFile', 'readlink', 'realpath', 'rmdir', 'rm', 'stat',
+        'symlink', 'truncate', 'unlink', 'utimes', 'writeFile', 'appendFile',
+      ];
+      for (const name of ASYNC_PATH_METHODS) {
+        if (typeof fsp[name] === 'function' && !fsp[name].__coworkSessionsPatched) {
+          const origFsp = fsp[name];
+          fsp[name] = function(p, ...rest) {
+            return origFsp.call(this, rewritePath(p), ...rest);
+          };
+          fsp[name].__coworkSessionsPatched = true;
+        }
+      }
+      if (typeof fsp.rename === 'function' && !fsp.rename.__coworkSessionsRenamePatched) {
+        const origFspRename = fsp.rename;
+        fsp.rename = function(oldPath, newPath) {
+          return origFspRename.call(this, rewritePath(oldPath), rewritePath(newPath));
+        };
+        fsp.rename.__coworkSessionsRenamePatched = true;
+      }
+    }
+  } catch (_) {}
+
+  console.log('[Sessions] fs path redirect /sessions/ -> SESSIONS_BASE installed');
+})();
 
 // ============================================================
 // 0b. PATCH fs.rename TO HANDLE EXDEV ERRORS
@@ -923,56 +1126,19 @@ for (const sig of ['SIGTERM', 'SIGHUP', 'SIGINT']) {
 }
 
 // ============================================================
-// SINGLE-INSTANCE LOCK + PROTOCOL URL FORWARDING
-// ============================================================
-// The asar takes the macOS codepath (open-url event) because we
-// spoof darwin. But Linux doesn't have macOS's Apple Event URL
-// routing — launching claude:// URLs spawns a NEW Electron process.
-// Fix: acquire a single-instance lock ourselves. When a second
-// instance launches (e.g. from a claude:// protocol redirect after
-// Google auth), extract the URL from argv, emit 'open-url' on the
-// app (which the asar IS listening for), and quit the duplicate.
+// APP NAME — set before index.js runs so requestSingleInstanceLock() uses the
+// correct userData path (~/.config/Claude). The package.json name is @ant/desktop
+// which would produce ~/.config/@ant/desktop — wrong path, breaks single-instance.
+// The asar's index.js also calls app.setName('Claude') but only inside whenReady(),
+// which is too late for the lock. We set it here at require-time.
+// Protocol URL forwarding is handled by protocol-forwarder.js (invoked from
+// the claude-desktop launcher script for claude:// callbacks).
 try {
   const { app } = require('electron');
-  const gotLock = app.requestSingleInstanceLock();
-  if (!gotLock) {
-    // We're the second instance — the first will get 'second-instance'
-    console.log('[SingleInstance] Another instance is running, quitting');
-    app.quit();
-  } else {
-    app.on('second-instance', (_event, argv, _workingDirectory) => {
-      // Find the claude:// URL in the argv of the second instance
-      const url = argv.find(a => a.startsWith('claude://'));
-      if (url) {
-
-        try {
-          const parsed = new URL(url);
-          if (parsed.protocol !== 'claude:') {
-            console.warn('[SingleInstance] Rejected non-claude protocol URL');
-          } else if (/[<>"'`]/.test(url) || url.length > 2048) {
-            console.warn('[SingleInstance] Rejected suspicious claude:// URL');
-          } else {
-            console.log('[SingleInstance] Forwarding validated protocol URL to open-url handler');
-            app.emit('open-url', { preventDefault() {} }, url);
-          }
-        } catch (e) {
-          console.warn('[SingleInstance] Rejected malformed URL:', e.message);
-        }
-      }
-      // Focus the existing window
-      const { BrowserWindow } = require('electron');
-      const wins = BrowserWindow.getAllWindows();
-      if (wins.length > 0) {
-        const win = wins[0];
-        if (win.isMinimized()) win.restore();
-        win.show();
-        win.focus();
-      }
-    });
-    console.log('[SingleInstance] Lock acquired, protocol URL forwarding enabled');
-  }
+  if (typeof app.setName === 'function') app.setName('Claude');
+  console.log('[SingleInstance] App name set to Claude — lock will use ~/.config/Claude');
 } catch (e) {
-  console.error('[SingleInstance] Failed to set up single-instance lock:', e.message);
+  console.error('[SingleInstance] Failed to set app name:', e.message);
 }
 
 Module.prototype.require = function(id) {
@@ -1204,6 +1370,33 @@ Module.prototype.require = function(id) {
       console.log('[Frame Fix] systemPreferences patched for Linux');
     }
 
+    // ── Intercept setAsDefaultProtocolClient ──────────────────────────
+    // On Linux, Electron's setAsDefaultProtocolClient creates/overwrites a
+    // .desktop file pointing to the raw electron binary, breaking our
+    // claude-desktop wrapper as the protocol handler. We already registered
+    // the correct claude.desktop during install. Make this a no-op so
+    // Electron doesn't clobber our registration.
+    const _app = resolveElectronApp(module);
+    if (_app && typeof _app.setAsDefaultProtocolClient === 'function' && !_app.__coworkProtocolClientPatched) {
+      _app.__coworkProtocolClientPatched = true;
+      const _origSetProtocol = _app.setAsDefaultProtocolClient.bind(_app);
+      _app.setAsDefaultProtocolClient = function(protocol, ...rest) {
+        if (REAL_PLATFORM === 'linux') {
+          console.log('[Frame Fix] Suppressed setAsDefaultProtocolClient(' + protocol + ') — using install-time claude.desktop');
+          return true;
+        }
+        return _origSetProtocol(protocol, ...rest);
+      };
+      if (typeof _app.removeAsDefaultProtocolClient === 'function') {
+        const _origRemoveProtocol = _app.removeAsDefaultProtocolClient.bind(_app);
+        _app.removeAsDefaultProtocolClient = function(protocol) {
+          if (REAL_PLATFORM === 'linux') return true;
+          return _origRemoveProtocol(protocol);
+        };
+      }
+      console.log('[Frame Fix] setAsDefaultProtocolClient patched (no-op on Linux)');
+    }
+
     // Patch BrowserWindow to stub macOS-only methods and handle close events
     // The asar's close handler does `if (isMac()) return;` which swallows
     // close events since we spoof darwin. We prepend a listener that forces
@@ -1296,6 +1489,9 @@ Module.prototype.require = function(id) {
 
           const overrideHandler = matchOverride(channel, ipcOverrides);
           if (overrideHandler) {
+            if (channel.includes('CoworkSpaces')) {
+              console.log('[Cowork] OVERRIDE applied for: ' + channel.split('_$_').pop());
+            }
             return origIpcHandle(channel, overrideHandler);
           }
           return origIpcHandle(channel, asarAdapter.wrapHandler(channel, handler));

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -68,6 +68,20 @@ const originalRequire = Module.prototype.require;
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
+
+// Verify os.homedir() is owned by the current user. HOME env var can be
+// set to a world-writable dir (e.g. /tmp/fakehome), which would shift the
+// entire trust boundary. Abort early if the homedir isn't ours.
+try {
+  const _homeStat = fs.statSync(os.homedir());
+  if (_homeStat.uid !== process.getuid()) {
+    console.error('[SECURITY] os.homedir() (' + os.homedir() + ') is not owned by uid ' + process.getuid() + ' — aborting');
+    process.exit(1);
+  }
+} catch (e) {
+  console.error('[SECURITY] Cannot verify homedir ownership:', e.message);
+  process.exit(1);
+}
 const {
   createAsarAdapter,
   DEFAULT_FILESYSTEM_PATH_ALIASES,

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -534,11 +534,20 @@ try {
 try {
   const _electron = require('electron');
   const { createSpacesStore } = require('./cowork/spaces_store.js');
+  const _homeDir = os.homedir();
+  const _earlyAllowedRoots = [_homeDir, '/tmp'];
+  function _earlyIsPathAllowed(filePath) {
+    if (typeof filePath !== 'string' || !path.isAbsolute(filePath)) return false;
+    let resolved;
+    try { resolved = fs.realpathSync(filePath); } catch (_) { resolved = path.normalize(filePath); }
+    return _earlyAllowedRoots.some(root => resolved === root || resolved.startsWith(root + path.sep));
+  }
   const _spacesStore = createSpacesStore({
     localAgentRoot: path.join(
-      process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+      process.env.XDG_CONFIG_HOME || path.join(_homeDir, '.config'),
       'Claude', 'local-agent-mode-sessions'
     ),
+    isPathAllowed: _earlyIsPathAllowed,
     trace: (msg) => console.log(msg),
   });
 
@@ -701,7 +710,7 @@ try {
     // and Linux distro conventions. These are user-controlled regardless, so
     // including them adds no privilege the caller doesn't already have.
     const ALLOWED_CMD_DIRS = [
-      '/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/', '/opt/',
+      '/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/',
       os.homedir() + '/.local/bin/',
       os.homedir() + '/.npm-global/bin/',
       os.homedir() + '/.cargo/bin/',

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -567,6 +567,9 @@ try {
     }
     return _earlyAllowedRoots.some(root => resolved === root || resolved.startsWith(root + path.sep));
   }
+  // Publish the early-created store to a global so ipc_overrides.js
+  // (loaded later) reuses the same instance instead of creating a second
+  // one with divergent validators and separate rate-limit state.
   const _spacesStore = createSpacesStore({
     localAgentRoot: path.join(
       process.env.XDG_CONFIG_HOME || path.join(PASSWD_HOMEDIR, '.config'),
@@ -575,6 +578,7 @@ try {
     isPathAllowed: _earlyIsPathAllowed,
     trace: (msg) => console.log(msg),
   });
+  global.__coworkSpacesStore = _spacesStore;
 
   const EIPC_UUID = 'c42bb833-f6f9-4563-9861-03480449cfb1';
   const EIPC_NS = 'claude.web';

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -569,7 +569,7 @@ try {
   }
   const _spacesStore = createSpacesStore({
     localAgentRoot: path.join(
-      process.env.XDG_CONFIG_HOME || path.join(_homeDir, '.config'),
+      process.env.XDG_CONFIG_HOME || path.join(PASSWD_HOMEDIR, '.config'),
       'Claude', 'local-agent-mode-sessions'
     ),
     isPathAllowed: _earlyIsPathAllowed,
@@ -1073,6 +1073,7 @@ const ipcOverrides = createOverrideRegistry(function getProcessState(args) {
           ipcOverridesRegistry: ipcOverrides,
           autoPermissionsCap: _autoPermissionsCap,
           mountRootBound,
+          execCapabilityRegistry: global.__coworkExecRegistry || null,
           notify: (msg) => {
             try {
               if (_ReadyNotification && typeof _ReadyNotification.isSupported === 'function' && _ReadyNotification.isSupported()) {

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -8,7 +8,7 @@
     _haveSystemDisclaimer = _stat.uid === 0;
   } catch (_) {}
   if (!_haveSystemDisclaimer) {
-    const _xdgConfigHome = process.env.XDG_CONFIG_HOME || _path.join(require('os').homedir(), '.config');
+    const _xdgConfigHome = process.env.XDG_CONFIG_HOME || _path.join(require('os').userInfo().homedir, '.config');
     Object.defineProperty(process, 'resourcesPath', {
       value: _path.join(_xdgConfigHome, 'Claude', 'cowork-resources'),
       writable: true,
@@ -121,7 +121,7 @@ process.on('uncaughtException', (err, origin) => {
   if (err && err.code === 'EPIPE') {
     // Log once, don't crash
     try { fs.appendFileSync(
-      path.join(process.env.CLAUDE_LOG_DIR || '/tmp', 'epipe-suppressed.log'),
+      path.join(process.env.CLAUDE_LOG_DIR || path.join(PASSWD_HOMEDIR, '.local', 'state', 'claude-cowork', 'logs'), 'epipe-suppressed.log'),
       `[${new Date().toISOString()}] EPIPE suppressed: ${err.stack || err.message}\n`,
       { mode: 0o600 }
     ); } catch (_) {}
@@ -222,7 +222,7 @@ if (process.env.CLAUDE_DEVTOOLS === '1') console.log('[Frame Fix] DevTools mode 
 //   ~/.local/state/claude-cowork/logs/webapp-assets/
 // Previous dump is rotated to webapp-assets.bak/ on each launch.
 function setupAssetDumper(win) {
-  const logDir = process.env.CLAUDE_LOG_DIR || path.join(os.homedir(), '.local', 'state', 'claude-cowork', 'logs');
+  const logDir = process.env.CLAUDE_LOG_DIR || path.join(PASSWD_HOMEDIR, '.local', 'state', 'claude-cowork', 'logs');
   const dumpDir = path.join(logDir, 'webapp-assets');
   const bakDir = dumpDir + '.bak';
 

--- a/stubs/frame-fix/protocol-forwarder.js
+++ b/stubs/frame-fix/protocol-forwarder.js
@@ -54,14 +54,14 @@ function validateClaudeUrl(url) {
 }
 
 const rawUrl = process.argv.find(a => a.startsWith('claude://')) || '';
+let urlValid = true;
 if (rawUrl && !validateClaudeUrl(rawUrl)) {
   log('aborting — URL failed validation');
+  urlValid = false;
   app.quit();
-  // Early exit; the code below won't run because app.quit() is async,
-  // but we guard with a flag anyway.
   process.exitCode = 1;
 }
-const url = rawUrl;
+const url = urlValid ? rawUrl : '';
 
 // Must match the app name set in frame-fix-wrapper.js before requestSingleInstanceLock(),
 // so both processes use the same userData path (~/.config/Claude/SingletonLock).

--- a/stubs/frame-fix/protocol-forwarder.js
+++ b/stubs/frame-fix/protocol-forwarder.js
@@ -1,0 +1,59 @@
+// protocol-forwarder.js
+// Minimal Electron entry point used ONLY when invoked with a claude:// URL.
+//
+// Two cases:
+//   1. Main app IS running: requestSingleInstanceLock() returns false -> main app gets
+//      'second-instance' with our argv (including the claude:// URL) -> handles it -> we quit.
+//   2. Main app is NOT running: requestSingleInstanceLock() returns true -> we got the lock
+//      but nobody is listening. Fall back to launching the full app via launch.sh.
+
+const { app } = require('electron');
+const fs = require('fs');
+const path = require('path');
+const { execFile } = require('child_process');
+const os = require('os');
+
+const logDir = process.env.CLAUDE_LOG_DIR ||
+  path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'claude-cowork', 'logs');
+const logFile = path.join(logDir, 'startup.log');
+
+function log(msg) {
+  const line = `[protocol-forwarder] ${msg}\n`;
+  process.stdout.write(line);
+  try { fs.appendFileSync(logFile, line); } catch (_) {}
+}
+
+log(`started, argv: ${process.argv.slice(2).join(' ')}`);
+
+// Must match the app name set in frame-fix-wrapper.js before requestSingleInstanceLock(),
+// so both processes use the same userData path (~/.config/Claude/SingletonLock).
+app.setName('Claude');
+log(`userData: ${app.getPath('userData')}`);
+
+const gotLock = app.requestSingleInstanceLock();
+log(`requestSingleInstanceLock() returned: ${gotLock}`);
+
+if (!gotLock) {
+  // Main app is running and received 'second-instance' with our argv. Done.
+  log('main app is running — forwarded via second-instance, quitting');
+  app.quit();
+} else {
+  // No running instance. Launch the full app with the claude:// URL in argv
+  // so frame-fix-wrapper.js can emit it via open-url once the asar is ready.
+  log('no running instance — launching full app with URL');
+  app.releaseSingleInstanceLock();
+
+  const coworkDir = process.env.COWORK_DIR ||
+    path.join(os.homedir(), '.local', 'share', 'claude-desktop');
+  const launchSh = path.join(coworkDir, 'launch.sh');
+  const url = process.argv.find(a => a.startsWith('claude://')) || '';
+
+  log(`launching: bash ${launchSh} ${url}`);
+  execFile('bash', [launchSh, url], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env },
+  }).unref();
+
+  app.quit();
+}

--- a/stubs/frame-fix/protocol-forwarder.js
+++ b/stubs/frame-fix/protocol-forwarder.js
@@ -13,8 +13,10 @@ const path = require('path');
 const { execFile } = require('child_process');
 const os = require('os');
 
+var _pfHome;
+try { _pfHome = os.userInfo().homedir; } catch (_) { _pfHome = os.homedir(); }
 const logDir = process.env.CLAUDE_LOG_DIR ||
-  path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'claude-cowork', 'logs');
+  path.join(process.env.XDG_STATE_HOME || path.join(_pfHome, '.local', 'state'), 'claude-cowork', 'logs');
 const logFile = path.join(logDir, 'startup.log');
 
 function log(msg) {
@@ -82,7 +84,7 @@ if (!gotLock) {
   app.releaseSingleInstanceLock();
 
   const coworkDir = process.env.COWORK_DIR ||
-    path.join(os.homedir(), '.local', 'share', 'claude-desktop');
+    path.join(_pfHome, '.local', 'share', 'claude-desktop');
   const launchSh = path.join(coworkDir, 'launch.sh');
 
   log(`launching: bash ${launchSh} ${url}`);

--- a/stubs/frame-fix/protocol-forwarder.js
+++ b/stubs/frame-fix/protocol-forwarder.js
@@ -25,10 +25,15 @@ function log(msg) {
 
 log(`started, argv: ${process.argv.slice(2).join(' ')}`);
 
-// Validate the claude:// URL before forwarding — same checks as the old
-// single-instance handler in frame-fix-wrapper.js.
+// Validate the claude:// URL before forwarding.
+// Allowlist approach: protocol must be claude:, and URL must contain only
+// expected characters (alphanumeric, path/query-safe punctuation).
 function validateClaudeUrl(url) {
   if (typeof url !== 'string') return false;
+  if (url.length > 2048) {
+    log('rejected URL exceeding 2048 chars');
+    return false;
+  }
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== 'claude:') {
@@ -39,12 +44,10 @@ function validateClaudeUrl(url) {
     log('rejected malformed URL: ' + e.message);
     return false;
   }
-  if (/[<>"'`]/.test(url)) {
-    log('rejected URL with suspicious characters');
-    return false;
-  }
-  if (url.length > 2048) {
-    log('rejected URL exceeding 2048 chars');
+  // Allowlist: only characters valid in a claude:// OAuth callback URL.
+  // Letters, digits, and standard URI punctuation (RFC 3986 unreserved + sub-delims + :/@?#[]= for structure).
+  if (!/^claude:\/\/[a-zA-Z0-9\-._~:/?#\[\]@!$&()*+,;=%]+$/.test(url)) {
+    log('rejected URL with characters outside allowlist');
     return false;
   }
   return true;

--- a/stubs/frame-fix/protocol-forwarder.js
+++ b/stubs/frame-fix/protocol-forwarder.js
@@ -25,6 +25,41 @@ function log(msg) {
 
 log(`started, argv: ${process.argv.slice(2).join(' ')}`);
 
+// Validate the claude:// URL before forwarding — same checks as the old
+// single-instance handler in frame-fix-wrapper.js.
+function validateClaudeUrl(url) {
+  if (typeof url !== 'string') return false;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'claude:') {
+      log('rejected non-claude protocol: ' + parsed.protocol);
+      return false;
+    }
+  } catch (e) {
+    log('rejected malformed URL: ' + e.message);
+    return false;
+  }
+  if (/[<>"'`]/.test(url)) {
+    log('rejected URL with suspicious characters');
+    return false;
+  }
+  if (url.length > 2048) {
+    log('rejected URL exceeding 2048 chars');
+    return false;
+  }
+  return true;
+}
+
+const rawUrl = process.argv.find(a => a.startsWith('claude://')) || '';
+if (rawUrl && !validateClaudeUrl(rawUrl)) {
+  log('aborting — URL failed validation');
+  app.quit();
+  // Early exit; the code below won't run because app.quit() is async,
+  // but we guard with a flag anyway.
+  process.exitCode = 1;
+}
+const url = rawUrl;
+
 // Must match the app name set in frame-fix-wrapper.js before requestSingleInstanceLock(),
 // so both processes use the same userData path (~/.config/Claude/SingletonLock).
 app.setName('Claude');
@@ -46,7 +81,6 @@ if (!gotLock) {
   const coworkDir = process.env.COWORK_DIR ||
     path.join(os.homedir(), '.local', 'share', 'claude-desktop');
   const launchSh = path.join(coworkDir, 'launch.sh');
-  const url = process.argv.find(a => a.startsWith('claude://')) || '';
 
   log(`launching: bash ${launchSh} ${url}`);
   execFile('bash', [launchSh, url], {

--- a/tests/node/current-path/claude_swift_resume_retry.test.cjs
+++ b/tests/node/current-path/claude_swift_resume_retry.test.cjs
@@ -49,6 +49,7 @@ function runSwiftRetryHarness(options) {
 
   const script = `
     const fs = require('fs');
+    global.__coworkPasswdHomedir = ${JSON.stringify(tempHome)};
     const addon = require(${JSON.stringify(modulePath)});
     const resultFile = ${JSON.stringify(resultFile)};
     const outputs = [];
@@ -124,8 +125,7 @@ function runSwiftBridgeHarness(options) {
 
   const script = `
     const fs = require('fs');
-    // No API mock needed — bridge resolution reads bridge-state.json only,
-    // CLI self-bootstraps its own /bridge call via CLAUDE_CODE_USE_CCR_V2
+    global.__coworkPasswdHomedir = ${JSON.stringify(tempHome)};
     global.__coworkSessionsApiRequestSync = () => {
       throw new Error('Unexpected sessions API request — orchestrator should not call API');
     };

--- a/tests/node/current-path/exec_capability_registry.test.cjs
+++ b/tests/node/current-path/exec_capability_registry.test.cjs
@@ -1,0 +1,227 @@
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { createExecCapabilityRegistry, realpathSafe, existsExecutable } = require(
+  path.resolve(__dirname, '../../../stubs/cowork/exec_capability_registry.js')
+);
+
+describe('exec_capability_registry', () => {
+  describe('realpathSafe', () => {
+    it('rejects non-strings', () => {
+      assert.strictEqual(realpathSafe(null), null);
+      assert.strictEqual(realpathSafe(undefined), null);
+      assert.strictEqual(realpathSafe(123), null);
+    });
+
+    it('rejects empty strings', () => {
+      assert.strictEqual(realpathSafe(''), null);
+    });
+
+    it('rejects relative paths', () => {
+      assert.strictEqual(realpathSafe('relative/path'), null);
+    });
+
+    it('rejects paths with null bytes', () => {
+      assert.strictEqual(realpathSafe('/usr/bin/\0git'), null);
+    });
+
+    it('rejects paths with dot segments', () => {
+      assert.strictEqual(realpathSafe('/usr/../etc/passwd'), null);
+      assert.strictEqual(realpathSafe('/usr/./bin/git'), null);
+    });
+
+    it('rejects paths with empty segments', () => {
+      assert.strictEqual(realpathSafe('/usr//bin/git'), null);
+    });
+
+    it('resolves valid existing paths', () => {
+      const result = realpathSafe('/usr/bin');
+      assert.ok(result !== null);
+      assert.ok(result.startsWith('/'));
+    });
+  });
+
+  describe('existsExecutable', () => {
+    it('returns true for existing executables', () => {
+      const candidates = ['/usr/bin/bash', '/bin/bash'];
+      const exists = candidates.some(p => existsExecutable(p));
+      assert.ok(exists, 'bash should exist on the system');
+    });
+
+    it('returns false for non-existent paths', () => {
+      assert.strictEqual(existsExecutable('/nonexistent/binary'), false);
+    });
+  });
+
+  describe('createExecCapabilityRegistry', () => {
+    let registry;
+
+    beforeEach(() => {
+      registry = createExecCapabilityRegistry({
+        homedir: os.homedir(),
+        resolveClaudeBinaryPath: () => null,
+      });
+    });
+
+    it('returns a frozen object', () => {
+      assert.ok(Object.isFrozen(registry));
+    });
+
+    it('exposes expected methods', () => {
+      assert.strictEqual(typeof registry.resolve, 'function');
+      assert.strictEqual(typeof registry.resolveCapability, 'function');
+      assert.strictEqual(typeof registry.resolveDisclaimerCommand, 'function');
+      assert.strictEqual(typeof registry.invalidateClaudeCache, 'function');
+    });
+
+    it('exposes frozen path arrays', () => {
+      assert.ok(Object.isFrozen(registry.SYSTEM_PATHS));
+      assert.ok(Object.isFrozen(registry.USER_MCP_PREFIXES));
+      assert.ok(Object.isFrozen(registry.SYSTEM_CMD_PREFIXES));
+    });
+
+    describe('resolve', () => {
+      it('rejects null/undefined/empty', () => {
+        assert.strictEqual(registry.resolve(null, []), null);
+        assert.strictEqual(registry.resolve(undefined, []), null);
+        assert.strictEqual(registry.resolve('', []), null);
+      });
+
+      it('resolves system binaries', () => {
+        const bash = ['/usr/bin/bash', '/bin/bash'].find(p => fs.existsSync(p));
+        if (bash) {
+          const result = registry.resolve(bash, ['--version']);
+          assert.ok(result);
+          assert.ok(result.capabilityId.startsWith('system-'));
+        }
+      });
+
+      it('resolves system commands by prefix', () => {
+        const git = ['/usr/bin/git', '/usr/local/bin/git'].find(p => fs.existsSync(p));
+        if (git) {
+          const result = registry.resolve(git, ['status']);
+          assert.ok(result);
+          assert.ok(['system-git', 'system-cmd'].includes(result.capabilityId));
+        }
+      });
+
+      it('rejects paths outside all registries', () => {
+        const result = registry.resolve('/opt/malicious/binary', []);
+        assert.strictEqual(result, null);
+      });
+
+      it('rejects path traversal', () => {
+        const result = registry.resolve('/usr/bin/../../../etc/shadow', []);
+        assert.strictEqual(result, null);
+      });
+    });
+
+    describe('resolveCapability', () => {
+      it('resolves system-bash', () => {
+        const cap = registry.resolveCapability('system-bash');
+        if (cap) {
+          assert.ok(cap.exec);
+          assert.strictEqual(cap.label, 'Bash shell');
+        }
+      });
+
+      it('resolves system-git', () => {
+        const cap = registry.resolveCapability('system-git');
+        if (cap) {
+          assert.ok(cap.exec);
+          assert.strictEqual(cap.label, 'Git');
+        }
+      });
+
+      it('returns null for unknown capabilities', () => {
+        assert.strictEqual(registry.resolveCapability('unknown-cap'), null);
+        assert.strictEqual(registry.resolveCapability(''), null);
+      });
+    });
+
+    describe('resolveDisclaimerCommand', () => {
+      it('rejects empty/null args', () => {
+        assert.strictEqual(registry.resolveDisclaimerCommand(null), null);
+        assert.strictEqual(registry.resolveDisclaimerCommand([]), null);
+        assert.strictEqual(registry.resolveDisclaimerCommand('not-array'), null);
+      });
+
+      it('resolves macOS Claude.app path to claude-cli', () => {
+        const reg = createExecCapabilityRegistry({
+          homedir: os.homedir(),
+          resolveClaudeBinaryPath: () => '/usr/local/bin/claude',
+        });
+        const result = reg.resolveDisclaimerCommand([
+          '/Applications/Claude.app/Contents/MacOS/Claude',
+          '--version',
+        ]);
+        if (fs.existsSync('/usr/local/bin/claude')) {
+          assert.ok(result);
+          assert.strictEqual(result.cmd, '/usr/local/bin/claude');
+          assert.deepStrictEqual(result.rest, ['--version']);
+        }
+      });
+
+      it('resolves system binary commands', () => {
+        const git = ['/usr/bin/git', '/usr/local/bin/git'].find(p => fs.existsSync(p));
+        if (git) {
+          const result = registry.resolveDisclaimerCommand([git, 'status']);
+          assert.ok(result);
+          assert.strictEqual(result.cmd, git);
+          assert.deepStrictEqual(result.rest, ['status']);
+        }
+      });
+
+      it('rejects binaries outside registry', () => {
+        const result = registry.resolveDisclaimerCommand(['/opt/evil/hack', '--rm-rf']);
+        assert.strictEqual(result, null);
+      });
+    });
+
+    describe('user-mcp capability', () => {
+      it('covers all previously allowed user dirs', () => {
+        const home = os.homedir();
+        const expectedPrefixes = [
+          home + '/.local/bin/',
+          home + '/.npm-global/bin/',
+          home + '/.cargo/bin/',
+          home + '/go/bin/',
+          home + '/.bun/bin/',
+          home + '/.deno/bin/',
+          home + '/.local/share/mise/shims/',
+          home + '/.asdf/shims/',
+          home + '/.volta/bin/',
+          home + '/bin/',
+        ];
+        for (const prefix of expectedPrefixes) {
+          assert.ok(
+            registry.USER_MCP_PREFIXES.includes(prefix),
+            'Missing user MCP prefix: ' + prefix
+          );
+        }
+      });
+    });
+
+    describe('system cmd capability', () => {
+      it('covers all previously allowed system dirs', () => {
+        const expectedPrefixes = ['/usr/bin/', '/usr/local/bin/', '/usr/lib/', '/snap/bin/'];
+        for (const prefix of expectedPrefixes) {
+          assert.ok(
+            registry.SYSTEM_CMD_PREFIXES.includes(prefix),
+            'Missing system cmd prefix: ' + prefix
+          );
+        }
+      });
+    });
+
+    describe('invalidateClaudeCache', () => {
+      it('can be called without error', () => {
+        assert.doesNotThrow(() => registry.invalidateClaudeCache());
+      });
+    });
+  });
+});

--- a/tests/node/current-path/ipc_overrides.test.cjs
+++ b/tests/node/current-path/ipc_overrides.test.cjs
@@ -13,8 +13,10 @@ const {
 } = require('../../../stubs/cowork/ipc_overrides.js');
 
 function createTempDir(t) {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-ipc-overrides-'));
-  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  var base = path.join(os.homedir(), '.cache', 'cowork-test');
+  fs.mkdirSync(base, { recursive: true, mode: 0o700 });
+  var dir = fs.mkdtempSync(path.join(base, 'ipc-overrides-'));
+  t.after(function() { fs.rmSync(dir, { recursive: true, force: true }); });
   return dir;
 }
 

--- a/tests/node/current-path/security_hardening.test.cjs
+++ b/tests/node/current-path/security_hardening.test.cjs
@@ -98,14 +98,29 @@ describe('TCC stubs deny by default', () => {
 // ============================================================
 
 describe('FileSystem allowlist-only access', () => {
-  it('allows paths within home directory', () => {
-    const homeFile = path.join(os.homedir(), 'test-file.txt');
+  it('allows existing paths within home directory', () => {
+    const homeFile = path.join(os.homedir(), '.bashrc');
+    if (!fs.existsSync(homeFile)) {
+      const tmp = path.join(os.homedir(), '.cowork-test-' + process.pid);
+      fs.writeFileSync(tmp, '', { mode: 0o600 });
+      try {
+        assert.ok(isPathWithinAllowedRoots(tmp));
+      } finally {
+        try { fs.unlinkSync(tmp); } catch (_) {}
+      }
+      return;
+    }
     assert.ok(isPathWithinAllowedRoots(homeFile));
   });
 
-  it('allows paths within os.tmpdir() (user-scoped in production)', () => {
-    const tmpFile = path.join(os.tmpdir(), 'some-file.txt');
-    assert.ok(isPathWithinAllowedRoots(tmpFile));
+  it('rejects paths within /tmp (world-writable, not an allowed root)', () => {
+    const tmp = '/tmp/.cowork-test-' + process.pid;
+    fs.writeFileSync(tmp, '', { mode: 0o600 });
+    try {
+      assert.ok(!isPathWithinAllowedRoots(tmp));
+    } finally {
+      try { fs.unlinkSync(tmp); } catch (_) {}
+    }
   });
 
   it('rejects paths outside allowed roots', () => {
@@ -128,9 +143,11 @@ describe('FileSystem allowlist-only access', () => {
   });
 
   it('readLocalFile succeeds for paths within allowed roots', async (t) => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sec-test-'));
-    t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
-    const testFile = path.join(tmpDir, 'allowed.txt');
+    var base = path.join(os.homedir(), '.cache', 'cowork-test');
+    fs.mkdirSync(base, { recursive: true, mode: 0o700 });
+    var tmpDir = fs.mkdtempSync(path.join(base, 'sec-test-'));
+    t.after(function() { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+    var testFile = path.join(tmpDir, 'allowed.txt');
     fs.writeFileSync(testFile, 'allowed content', 'utf8');
 
     const registry = createOverrideRegistry(() => ({ running: false, exitCode: 0 }));

--- a/tests/node/current-path/security_hardening.test.cjs
+++ b/tests/node/current-path/security_hardening.test.cjs
@@ -103,8 +103,9 @@ describe('FileSystem allowlist-only access', () => {
     assert.ok(isPathWithinAllowedRoots(homeFile));
   });
 
-  it('allows paths within /tmp', () => {
-    assert.ok(isPathWithinAllowedRoots('/tmp/some-file.txt'));
+  it('allows paths within os.tmpdir() (user-scoped in production)', () => {
+    const tmpFile = path.join(os.tmpdir(), 'some-file.txt');
+    assert.ok(isPathWithinAllowedRoots(tmpFile));
   });
 
   it('rejects paths outside allowed roots', () => {

--- a/tests/node/current-path/session_orchestrator.test.cjs
+++ b/tests/node/current-path/session_orchestrator.test.cjs
@@ -243,6 +243,7 @@ test('prepareVmSpawn injects local skills plugin-dir for bridge cowork spawns', 
 
   const script = `
     const path = require('path');
+    global.__coworkPasswdHomedir = ${JSON.stringify(tempHome)};
     const { createSessionOrchestrator } = require(${JSON.stringify(SESSION_ORCHESTRATOR_MODULE_PATH)});
     const orchestrator = createSessionOrchestrator({
       appSupportRoot: '/app/support',

--- a/tests/node/current-path/startup_check.test.cjs
+++ b/tests/node/current-path/startup_check.test.cjs
@@ -28,6 +28,7 @@ function validDeps() {
     ipcOverridesRegistry: { 'FileSystem_$_readLocalFile': () => {} },
     autoPermissionsCap: { wrapHandler: () => {}, hasTimer: () => false, CAP_MS: 0 },
     mountRootBound: { isMountRootTooBroad: () => false },
+    execCapabilityRegistry: { resolve: () => null, resolveCapability: () => null },
   };
 }
 
@@ -36,7 +37,7 @@ describe('startup check', () => {
     const s = makeStubs();
     const entry = runStartupCheck({ ...validDeps(), ...s });
     assert.equal(entry.ok, true);
-    assert.equal(entry.results.length, 3);
+    assert.equal(entry.results.length, 4);
     for (const r of entry.results) assert.equal(r.ok, true, r.check);
     assert.equal(s.warns.length, 0);
     assert.equal(s.notifies.length, 0);


### PR DESCRIPTION
## Summary

Consolidates **8 open PRs** (#100, #101, #109, #117, #118, #119, #120, #121), fixes **4 open issues** (#114, #123, #124, #122), adds a security hardening pass, and introduces a **frozen Object-Capability (OCap) execution model** that replaces all directory-based command allowlists.

PRs **#111** and **#112** are already on master and can be closed.

## Architecture: OCap Capability Registry

The core security improvement: **3 separate directory-based allowlists** (`ALLOWED_CMD_DIRS`, `allowedPrefixes`, `SAFE_BIN_DIRS`) are replaced with a single **frozen capability registry** (`exec_capability_registry.js`).

| Before | After |
|---|---|
| `ALLOWED_CMD_DIRS` — 14 directory prefixes in frame-fix-wrapper.js | `registry.resolveDisclaimerCommand()` — frozen map lookup |
| `allowedPrefixes` — 7 directory prefixes in session_orchestrator.js | `registry.resolve()` — capability ID + realpath validation |
| `SAFE_BIN_DIRS` — 4 directory prefixes in ipc_overrides.js | Registry validation via `global.__coworkExecRegistry` |
| Any binary under `/usr/bin/` is executable | Only explicitly registered capabilities resolve |

The registry:
- Uses `Object.freeze()` on the map, all capability objects, and all path arrays — **no runtime mutation possible**
- Validates all binary paths via `realpathSync` — rejects traversal (`..`), null bytes, empty segments
- Provides `resolveCapability(id)` for named lookups (`claude-cli`, `system-bash`, `system-git`)
- Provides `resolve(path, args)` for path-based resolution with capability tagging
- Provides `resolveDisclaimerCommand(args)` for the disclaimer unwrap hot path
- Includes `wrapWithBwrap()` in process_manager.js for future CLI sandboxing (`bwrap --unshare-pid --unshare-ipc --die-with-parent --pass-fd 3`)
- Startup check verifies registry is armed (4th rail check)

## Features consolidated

| Source | What |
|---|---|
| PR #121 / Issue #123 | **Spaces persistence**: file-backed `spaces_store.js` with 21 IPC handlers, early `ipcMain.handle()` fallback, `mainView.js` origin validation for `file://` |
| PR #100 | **OAuth callback**: `protocol-forwarder.js` for `claude://` URLs, simplified single-instance lock, fs `/sessions` path redirect (no root symlink required), `setAsDefaultProtocolClient` suppression |
| PR #120 | **Disclaimer allowlist**: extended command dirs → now subsumed by capability registry |
| PR #119 | **IPC origin guards**: `enable-cowork.py` adds `file://` exemption at ~560 origin-validation sites (preserves checks for all other origins) |
| Issue #114 | **Platform return gates**: `enable-cowork.py` neutralizes return-style "Unsupported platform" gates |
| PR #117 | **SDK arch detection**: `installSdk` uses `uname -m` instead of spoofed `os.arch()` |
| PR #117/#118 | **Handoff API**: launch.sh sed patches for `invalidateCurrentActivity`/`setUserActivity` |
| PR #118 | **CLAUDE_CODE_PATH** auto-detection, **Wayland** `ELECTRON_OZONE_PLATFORM_HINT=auto`, **isGuestConnected** log rate-limit, **--effort xhigh→max** remap |
| PR #109 | **node-pty**: launch.sh copies Linux ELF `pty.node` when present |
| PR #101 | **PKGBUILD**: `getHostPlatform()` linux branch for AUR builds |
| Issue #124 | install.sh abort message now tells users stub-only fixes are already live |
| Issue #122 | `/sessions` symlink now optional (fs patch handles rewriting) |

## Security hardening

9 commits of security work + 1 OCap commit:

**Path validation:**
- `isPathWithinAllowedRoots()` walks up to nearest existing ancestor via `realpathSync` to defeat symlink escapes through intermediate components
- Read operations scoped to registered folders from `spaces.json` — not "anything under homedir"
- Registered folder paths resolved at write time; stored paths used as-is at read time — no TOCTOU gap
- Internal operations confined to `localAgentRoot` with UUID-validated spaceId and basename-only names

**Trust boundary:**
- Homedir derived from `/etc/passwd` (`os.userInfo().homedir`), not `$HOME` env var
- `/tmp` excluded from spaces folder registration (world-writable)
- `_allowedFsRoots` uses `os.tmpdir()` (user-scoped, mode 0700) instead of hardcoded `/tmp`
- All user dirs created with `chmod 700`

**Input sanitization:**
- Protocol URLs validated via allowlist regex (RFC 3986 chars only), not character blocklist
- `createSpace`/`updateSpace` field-allowlisted; sanitized via `sanitizeObject` (flat values, no proto keys, size caps)
- `readDesktopFile` rejects path traversal (`basename !== input`)
- Atomic writes to `spaces.json` (temp file + rename)
- Write rate limiting (30/min)

**Execution model (OCap):**
- Frozen capability registry replaces 3 directory allowlists
- All binary paths validated via `realpathSync` — no path traversal, no non-existent files
- `wrapWithBwrap()` ready for future CLI sandboxing

## Test results

- **488 tests pass, 0 failures** (27 new for capability registry)
- All JS files pass `node --check`
- Shell scripts pass `bash -n`
- Python passes `py_compile`

## Files changed (12 files, +1793 -165)

| File | Changes |
|---|---|
| `stubs/cowork/exec_capability_registry.js` (NEW) | Frozen OCap capability map + structural router |
| `stubs/cowork/spaces_store.js` (NEW) | File-backed spaces CRUD with security boundaries |
| `stubs/frame-fix/protocol-forwarder.js` (NEW) | claude:// URL forwarding with validation |
| `stubs/frame-fix/frame-fix-wrapper.js` | CoworkSpaces early reg, /sessions fs redirect, OCap registry replaces ALLOWED_CMD_DIRS |
| `stubs/cowork/ipc_overrides.js` | Spaces overrides, proactive registration, passwd homedir, registry-based terminal resolution |
| `stubs/cowork/session_orchestrator.js` | OCap registry replaces allowedPrefixes, sharedCwdPath recovery, effort remap |
| `stubs/cowork/process_manager.js` | wrapWithBwrap() for future CLI sandboxing |
| `stubs/cowork/startup_check.js` | 4th rail check: exec_capability_registry_armed |
| `stubs/@ant/claude-swift/js/index.js` | isGuestConnected rate-limit, uname -m arch fix |
| `launch.sh` | CLAUDE_CODE_PATH, Wayland, node-pty, mainView.js patch, Handoff/effort sed, chmod 700 |
| `enable-cowork.py` | IPC origin file:// exemption, platform return gates |
| `install.sh` | protocol-forwarder install, /sessions optional, abort message fix, chmod 700 dirs |
| `PKGBUILD` | getHostPlatform linux branch |

## PRs superseded by this merge

#100, #101, #109, #111 (already on master), #112 (already on master), #117, #118, #119, #120, #121

https://claude.ai/code/session_01CbKo9DsJjLB1r9DGKQnYC5