### PR TITLE
fix: stub configureWebAuthn no-op for asar 1.8555.2

### DIFF
--- a/stubs/@ant/claude-native/index.js
+++ b/stubs/@ant/claude-native/index.js
@@ -314,6 +314,8 @@ module.exports = {
   get_app_info_for_file,
   getAppInfoForFile: get_app_info_for_file,
 
+  // WebAuthn (no-op on Linux)
+  configureWebAuthn: () => {},
   // Native stub functions
   ...nativeStub,
 };

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -49,6 +49,7 @@ if (_earlyApp) {
     'updateCurrentActivity',
     'resignCurrentActivity',
     'getCurrentActivityType',
+    'configureWebAuthn',
   ];
   for (const _m of _macOnlyAppMethods) {
     if (typeof _earlyApp[_m] !== 'function') {


### PR DESCRIPTION
## What
Stubs `app.configureWebAuthn()` as a no-op so asar 1.8555.2 starts on Linux.

## Why
asar 1.8555.2 calls `app.configureWebAuthn()` early in startup. Linux Electron 
doesn't have this method, so the main process crashes before any window appears.

## Tested
- Ubuntu 24.04, GNOME/Wayland
- asar 1.8555.2
- App opens and Cowork tab is functional

- [ ] This change does not touch credential handling, token passthrough, or process spawning
- [ ] This change does touch security-sensitive code — explanation below:

<!-- explanation if needed -->

## Checklist

- [ ] No API keys, tokens, `.env` files, or log output with credentials included
- [ ] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system
