### PR TITLE
stub app.configureWebAuthn for Linux (asar 1.9659.2+)

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -5,13 +5,14 @@ to work with claude-cowork-linux. `install.sh` and the launcher grep the
 machine-readable lines below; the table further down is for humans.
 
 <!-- machine-readable; do not remove the next two lines -->
-<!-- LAST_TESTED_ASAR_VERSION=1.6259.1 -->
-<!-- LAST_TESTED_DATE=2026-05-14 -->
+<!-- LAST_TESTED_ASAR_VERSION=1.9659.2 -->
+<!-- LAST_TESTED_DATE=2026-05-30 -->
 
 ## Tested versions
 
 | Asar     | Status     | Date       | Notes                                                |
 |:---------|:-----------|:-----------|:-----------------------------------------------------|
+| 1.9659.2 | [PARTIAL]  | 2026-05-30 | Requires `app.configureWebAuthn` stub (PR #130); app launches, growthbook OK, cowork rails engaged. Full feature exercise (login, sessions, MCP) pending. |
 | 1.6259.1 | [OK]       | 2026-05-14 | v5.1.0 baseline. Activity stubs and bridge rails verified via test suite. |
 | 1.6608.2 | [PARTIAL]  | 2026-05-07 | `/setup-cowork` reports "Unsupported platform: linux-x64" -- see issue #114. |
 | 1.6700.0 | [UNTESTED] | -          | Not yet exercised by any contributor.                |

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -49,6 +49,7 @@ if (_earlyApp) {
     'updateCurrentActivity',
     'resignCurrentActivity',
     'getCurrentActivityType',
+    'configureWebAuthn',
   ];
   for (const _m of _macOnlyAppMethods) {
     if (typeof _earlyApp[_m] !== 'function') {


### PR DESCRIPTION
## Problem

asar v1.9659.2 calls  during main-process initialisation. This is a macOS-only Electron API — on Linux Electron it does not exist, causing an uncaught  that crashes the app before any window opens:



## Fix

Add  to the  no-op list in , alongside the existing NSUserActivity / Handoff stubs (issues #104, #106). The method is stubbed to a no-op so the app continues without WebAuthn hardware-key support (not relevant on Linux).

## Testing

- Reproduced crash locally with asar 1.9659.2 + Electron v42.3.0 on Wayland (GNOME)
- Applied fix → app launches cleanly, all cowork rails engaged
- No regression on existing features (chat, Code tab, cowork sessions)