### PR TITLE
fix: stub app.configureWebAuthn no-op to prevent launch crash (#128)

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -49,6 +49,9 @@ if (_earlyApp) {
     'updateCurrentActivity',
     'resignCurrentActivity',
     'getCurrentActivityType',
+    // WebAuthn (passkey/security-key) setup is macOS-only; absent on Linux
+    // Electron, so the darwin-gated callsite throws and crashes launch. See #128.
+    'configureWebAuthn',
   ];
   for (const _m of _macOnlyAppMethods) {
     if (typeof _earlyApp[_m] !== 'function') {


### PR DESCRIPTION
## Problem

Newer Claude Desktop asar versions call `app.configureWebAuthn()` during main-process init. Because we spoof `process.platform === "darwin"`, this darwin-gated callsite fires on Linux — where Electron has no such method — and throws an uncaught `TypeError`, crashing the app before any window opens.

This is issue #128:

```
TypeError: gA.app.configureWebAuthn is not a function
```

The crash trace shows `gA.app` — the Electron `app` object, which is exactly what the existing `_macOnlyAppMethods` no-op loop in `frame-fix-wrapper.js` already handles for the Handoff / NSUserActivity methods (#104 / #106, same root cause).

## Fix

One line: add `'configureWebAuthn'` to that existing array. The loop's `typeof _earlyApp[_m] !== 'function'` guard means we only stub the method when it's genuinely absent, so a platform that ships a real implementation is never clobbered. WebAuthn (passkey / security-key) setup is macOS-only and was never going to function on Linux Electron, so a no-op is the truthful and correct stand-in — no security feature is being disabled.

## Why this instead of #129 / #130

Both open PRs fix the same crash but do more than necessary:

- **#129** edits two files (the wrapper array *and* the `@ant/claude-native` stub exports). The crash is on the Electron `app` object, so the wrapper edit alone resolves it.
- **#130** edits the wrapper array but also bumps `COMPAT.md` last-tested to 1.9659.2 — a version its own note marks `[PARTIAL]` with "full feature exercise pending," so that claim isn't fully backed.

This PR is the minimal change: one string in the existing guarded loop, no new files, no unverified version claims.

## Testing

- `node --check stubs/frame-fix/frame-fix-wrapper.js` — syntax OK
- `node --test tests/node/current-path/*.test.cjs` — **488 pass, 0 fail**

Closes #128.

https://claude.ai/code/session_01LxAaF3raqdkyZyTPHBG8f4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxAaF3raqdkyZyTPHBG8f4)_