### PR TITLE
fix(disclaimer): correct require path and patch node:child_process

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -738,7 +738,7 @@ try {
     const _cp = require('child_process');
     const _origExecFile = _cp.execFile;
     const _origSpawn = _cp.spawn;
-    const { createExecCapabilityRegistry } = require('../cowork/exec_capability_registry');
+    const { createExecCapabilityRegistry } = require('./cowork/exec_capability_registry');
     const _execRegistry = createExecCapabilityRegistry({
       homedir: PASSWD_HOMEDIR,
     });
@@ -762,6 +762,17 @@ try {
       return _origSpawn.call(_cp, file, args, ...rest);
     };
     Object.assign(_cp.spawn, _origSpawn);
+
+    // The asar bundle's spawnClaudeCodeProcess (jZi) uses MI=require("node:child_process"),
+    // a different module cache entry from require("child_process"). Patch it too so the
+    // disclaimer interception applies when the Cowork tab spawns Claude Code.
+    try {
+      const _cpNode = require('node:child_process');
+      if (_cpNode !== _cp) {
+        _cpNode.spawn = _cp.spawn;
+        _cpNode.execFile = _cp.execFile;
+      }
+    } catch (_) {}
 
     console.log('[disclaimer] Intercepting exec calls at ' + disclaimerBin);
   }


### PR DESCRIPTION
## Problem

Two bugs in the TMPDIR setup block of `stubs/frame-fix/frame-fix-wrapper.js` caused **"Claude Code process exited with code 127"** on the Cowork tab for all Linux users. Both bugs are in the same try-catch, so the first one silently aborts the entire block.

### Bug 1 — Wrong require path (line 741)

```js
// Before (broken)
const { createExecCapabilityRegistry } = require('../cowork/exec_capability_registry');
// After
const { createExecCapabilityRegistry } = require('./cowork/exec_capability_registry');
```

`frame-fix-wrapper.js` is deployed to `linux-app-extracted/` by `install.sh`. The `../cowork/` path therefore resolves to the parent of `linux-app-extracted/`, where no `cowork/` directory exists. This throws `MODULE_NOT_FOUND`, silently swallowed by the surrounding try-catch. Consequences:
- `global.__coworkExecRegistry` is never set → startup check reports `exec_capability_registry_armed: false`
- `_cp.spawn` is never patched
- The disclaimer stub (`#!/bin/sh; exit 127`) runs for real on every Claude Code spawn

### Bug 2 — Missing `node:child_process` patch

The asar bundle's `spawnClaudeCodeProcess` function (`jZi`) uses `MI = require("node:child_process")`, which is a **separate module cache entry** from `require("child_process")` in Node.js/Electron. The disclaimer interception only patched the latter, leaving `MI.spawn` as the raw, unpatched spawn.

Fix: after patching `require('child_process')`, apply the same `spawn`/`execFile` overrides to `require('node:child_process')`, guarded by `_cpNode !== _cp` to avoid double-patching if Electron ever unifies the two entries.

## Environment

- **OS:** Ubuntu 24.04
- **Electron:** v42.1.0
- **Claude Desktop version:** v5.1.0

## Testing

After applying this fix, `~/.local/state/claude-cowork/logs/cowork-startup.log` shows all four checks passing:

```json
{"ok":true,"results":[
  {"check":"bridge_overrides_absent","ok":true},
  {"check":"auto_permissions_cap_armed","ok":true},
  {"check":"mount_bound_armed","ok":true},
  {"check":"exec_capability_registry_armed","ok":true}
]}
```

And the Cowork tab launches without "Claude Code process exited with code 127".