### PR TITLE
Add Nix flake for NixOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,26 @@ You can also provide an archive manually:
 CLAUDE_ARCHIVE=~/Downloads/Claude-1.6259.1.dmg ./install.sh
 ```
 
+### Method 4: Nix flake (NixOS)
+
+NixOS can't use `install.sh` directly: its package-manager branch runs imperative `nix-env -iA`, and the npm `electron` it would otherwise install is a prebuilt ELF that won't run on NixOS. The flake builds the app against `electron_41` from nixpkgs instead.
+
+```bash
+# Run without installing
+nix run github:johnzfitch/claude-cowork-linux
+
+# Or add to a NixOS / home-manager config
+# environment.systemPackages = [ inputs.claude-cowork-linux.packages.${system}.default ];
+```
+
+The derivation extracts and patches the pinned Claude release at build time, then a wrapper mirrors the tree into `$XDG_DATA_HOME/claude-cowork-linux` (writable) and runs the upstream `launch.sh` with all dependencies on `PATH`. The pinned version lives in [`nix/package.nix`](nix/package.nix); override `claudeVersion`/`claudeUrl`/`claudeHash` to track a different release.
+
+A `nix develop` shell is also provided with every dependency `install.sh` needs, for the manual installer flow.
+
 ### Updating
 
 ```bash
-claude-desktop --update          # re-fetch and repack with prompt
+claude-desktop --update          # re-fetch and repack with prompt (install.sh flow)
 ```
 
 The launcher prints a `[WARN]` line once if your installed asar is newer than the last tested version listed in [COMPAT.md](COMPAT.md). To dismiss the warning permanently for the current version, just keep using the app -- it only fires once per asar version change.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780511130,
+        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Claude Desktop Cowork (Local Agent Mode) on Linux, packaged for NixOS";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          claude-cowork-linux = pkgs.callPackage ./nix/package.nix { };
+        in
+        {
+          inherit claude-cowork-linux;
+          default = claude-cowork-linux;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.claude-cowork-linux}/bin/claude-desktop";
+        };
+      });
+
+      # `nix develop` then `bash ./install.sh` — runs the upstream installer with
+      # all of its dependencies provided declaratively, instead of its imperative
+      # `nix-env -iA` / `npm install -g electron` path (the npm electron binary is
+      # a prebuilt ELF that does not run on NixOS).
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.electron_41
+              pkgs.asar
+              pkgs.nodejs
+              pkgs.python3
+              pkgs.unzip
+              pkgs.p7zip
+              pkgs._7zz
+              pkgs.bubblewrap
+              pkgs.curl
+              pkgs.zstd
+              pkgs.file
+              pkgs.dbus
+              pkgs.xdg-utils
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt-rfc-style);
+    };
+}

--- a/nix/claude-desktop-launcher.sh
+++ b/nix/claude-desktop-launcher.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# launch.sh mutates its own directory (sed patches + `asar pack` into
+# .asar-cache/), so it cannot run from the read-only Nix store. Mirror the
+# prepared tree into a writable per-user copy, refreshing only when the store
+# path changes (i.e. after a flake/version bump).
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+work_dir="$data_home/claude-cowork-linux"
+marker="$work_dir/.nix-store-path"
+
+if [ ! -f "$marker" ] || [ "$(cat "$marker" 2>/dev/null)" != "$CLAUDE_COWORK_STORE" ]; then
+  rm -rf "$work_dir"
+  mkdir -p "$work_dir"
+  cp -r --no-preserve=mode,ownership "$CLAUDE_COWORK_STORE"/. "$work_dir"/
+  printf '%s\n' "$CLAUDE_COWORK_STORE" > "$marker"
+fi
+
+cd "$work_dir"
+exec bash ./launch.sh "$@"

--- a/nix/extract-icns.py
+++ b/nix/extract-icns.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import struct, os, sys
+
+icns_path, icon_root = sys.argv[1], sys.argv[2]
+with open(icns_path, 'rb') as f:
+    data = f.read()
+
+size_map = {b'ic07': 128, b'ic08': 256, b'ic09': 512, b'ic10': 1024}
+installed = []
+offset = 8
+while offset < len(data) - 8:
+    chunk_type = data[offset:offset + 4]
+    chunk_size = struct.unpack('>I', data[offset + 4:offset + 8])[0]
+    if chunk_size < 8:
+        break
+    chunk_data = data[offset + 8:offset + chunk_size]
+    px = size_map.get(chunk_type)
+    if px and chunk_data[:8] == b'\x89PNG\r\n\x1a\n':
+        d = os.path.join(icon_root, f'{px}x{px}', 'apps')
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, 'claude.png'), 'wb') as out:
+            out.write(chunk_data)
+        installed.append(px)
+    offset += chunk_size
+
+if not installed:
+    raise SystemExit('No PNG chunks found in .icns')
+print(f"Installed icon sizes: {sorted(installed)}")

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,185 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  unzip,
+  asar,
+  nodejs,
+  python3,
+  file,
+  electron_41,
+  dbus,
+  gnused,
+  gnugrep,
+  findutils,
+  gawk,
+  coreutils,
+  bashInteractive,
+  curl,
+  zstd,
+  bubblewrap,
+  xdg-utils,
+  which,
+  procps,
+  # Pinned Claude Desktop release. To bump: run `node fetch-dmg.js --json` for
+  # the current version/url/sha256, then `nix hash convert --to sri --hash-algo
+  # sha256 <hex>` for `hash`. Newer releases ship as .zip (older ones were DMGs
+  # in LZFSE format that p7zip cannot open); the .zip is what we expect here.
+  claudeVersion ? "1.11187.4",
+  claudeUrl ? "https://downloads.claude.ai/releases/darwin/universal/1.11187.4/Claude-58400536f3ccde1cff9a129de6c3112dc8cb489a.zip",
+  claudeHash ? "sha256-qyVqIlNz1Y1PgBY940OOB2+i0E114w7MvubZ1LSx/Fs=",
+}:
+
+let
+  electron = electron_41;
+
+  claudeArchive = fetchurl {
+    url = claudeUrl;
+    hash = claudeHash;
+  };
+
+  # launch.sh resolves these from PATH at every launch; the in-app SDK loader
+  # (claude-swift stub) shells out to curl/zstd/bwrap, and Chromium needs dbus.
+  runtimePath = lib.makeBinPath [
+    electron
+    asar
+    nodejs
+    dbus
+    file
+    gnused
+    gnugrep
+    findutils
+    gawk
+    coreutils
+    bashInteractive
+    curl
+    zstd
+    bubblewrap
+    xdg-utils
+    which
+    procps
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = "claude";
+    desktopName = "Claude";
+    comment = "AI assistant by Anthropic";
+    exec = "claude-desktop %U";
+    icon = "claude";
+    terminal = false;
+    startupWMClass = "Claude";
+    categories = [
+      "Utility"
+      "Development"
+      "Chat"
+    ];
+    keywords = [
+      "AI"
+      "assistant"
+      "chat"
+      "anthropic"
+    ];
+    mimeTypes = [ "x-scheme-handler/claude" ];
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "claude-cowork-linux";
+  version = claudeVersion;
+
+  src = ../.;
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+    unzip
+    asar
+    nodejs
+    python3
+  ];
+
+  desktopItems = [ desktopItem ];
+
+  # The Claude app tree is prepared at build time (extract → asar-extract →
+  # stubs → cowork patch). Per-launch work that mutates the tree (the sed
+  # patches and `asar pack` in launch.sh) is left to the upstream launcher,
+  # which the wrapper runs from a writable per-user copy — so the patch logic
+  # lives in exactly one place (launch.sh) and never needs to be mirrored here.
+  buildPhase = ''
+    runHook preBuild
+
+    unzip -q ${claudeArchive} -d claude-app
+    appDir=$(find claude-app -maxdepth 2 -name "*.app" -type d | head -1)
+    [ -n "$appDir" ] || (echo "Claude.app not found in archive" >&2; exit 1)
+    res="$appDir/Contents/Resources"
+    [ -f "$res/app.asar" ] || (echo "app.asar not found at $res" >&2; exit 1)
+
+    tree=tree/linux-app-extracted
+    mkdir -p tree
+    asar extract "$res/app.asar" "$tree"
+
+    if [ -d "$res/app.asar.unpacked" ]; then
+      cp -r "$res/app.asar.unpacked"/* "$tree/" || true
+    fi
+
+    mkdir -p "$tree/resources"
+    for item in "$res"/*; do
+      case "$(basename "$item")" in
+        app.asar | app.asar.unpacked) continue ;;
+      esac
+      cp -r "$item" "$tree/resources/" || true
+    done
+    mkdir -p "$tree/resources/i18n"
+    if ls "$tree/resources"/*.json >/dev/null 2>&1; then
+      mv "$tree/resources"/*.json "$tree/resources/i18n/"
+    fi
+
+    mkdir -p "$tree/node_modules/@ant/claude-swift/js" "$tree/node_modules/@ant/claude-native"
+    cp stubs/@ant/claude-swift/js/index.js "$tree/node_modules/@ant/claude-swift/js/index.js"
+    cp stubs/@ant/claude-native/index.js "$tree/node_modules/@ant/claude-native/index.js"
+    for f in frame-fix-wrapper.js frame-fix-entry.js protocol-forwarder.js; do
+      [ -f "stubs/frame-fix/$f" ] && cp "stubs/frame-fix/$f" "$tree/$f"
+    done
+    mkdir -p "$tree/cowork"
+    cp -f stubs/cowork/*.js "$tree/cowork/"
+
+    python3 enable-cowork.py "$tree/.vite/build/index.js"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    share="$out/share/claude-cowork-linux"
+    mkdir -p "$share"
+    cp -r tree/linux-app-extracted "$share/"
+    cp launch.sh launch-devtools.sh enable-cowork.py COMPAT.md "$share/"
+    cp -r stubs "$share/"
+
+    icns="$share/linux-app-extracted/resources/electron.icns"
+    if [ -f "$icns" ]; then
+      python3 ${./extract-icns.py} "$icns" "$out/share/icons/hicolor" || \
+        echo "icon extraction failed (non-fatal)" >&2
+    fi
+
+    makeWrapper ${bashInteractive}/bin/bash "$out/bin/claude-desktop" \
+      --prefix PATH : "${runtimePath}" \
+      --add-flags ${./claude-desktop-launcher.sh} \
+      --set CLAUDE_COWORK_STORE "$share" \
+      --set CLAUDE_COWORK_VERSION "${finalAttrs.version}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Claude Desktop Cowork (Local Agent Mode) on Linux, packaged for NixOS";
+    homepage = "https://github.com/johnzfitch/claude-cowork-linux";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "claude-desktop";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## What

Adds a Nix flake so NixOS users can install and run Claude Cowork.

NixOS can't use `install.sh` as-is:
- its package-manager branch runs imperative `nix-env -iA` (against the declarative model), and
- the npm `electron` it would otherwise install is a prebuilt ELF that won't run under NixOS's dynamic linker.

This flake builds against `electron_41` from nixpkgs instead (matches the Electron 41 ABI the bundled `pty.node` targets).

## How

- **`packages.default`** — extracts and patches the pinned Claude release at build time (`unzip` → `asar extract` → stubs → `enable-cowork.py`). Because `launch.sh` mutates its own directory (sed patches + `asar pack` into `.asar-cache/`) it can't run from the read-only store, so a thin wrapper mirrors the prepared tree into `$XDG_DATA_HOME/claude-cowork-linux` (writable) and runs the **upstream `launch.sh`** with every runtime dependency on `PATH`. All per-launch patch/repack logic stays in `launch.sh` — it is **not** duplicated in Nix, so only the version pin needs bumping per release.
- **`devShells.default`** — provides every dependency `install.sh` needs (electron, asar, p7zip/7zz, node, python3, bwrap, curl, zstd, …), for the manual installer flow.
- Pinned to **1.11187.4** (the current `.zip` release). Note: the DMG URLs in `COMPAT.md` now serve LZFSE-compressed DMGs that `p7zip`/`7zz` can't open; the Homebrew-cask `.zip` extracts cleanly. `claudeVersion`/`claudeUrl`/`claudeHash` are overridable args (bump via `node fetch-dmg.js --json`).

## Usage

```bash
nix run github:johnzfitch/claude-cowork-linux
# or add packages.${system}.default to a NixOS / home-manager config
```

## Testing

On NixOS (x86_64):
- `nix build .#claude-cowork-linux` succeeds; `enable-cowork.py` patches cleanly on 1.11187.4 (platform gate `qEr()`, 616 IPC origin sites).
- `result/bin/claude-desktop` launches **electron 41.7.1**, cowork is enabled, and the main window comes up.

Two pre-existing, non-Nix-specific runtime warnings remain (also reproducible via the regular installer): the `shell-path-worker` lookup and `frame-fix-wrapper.js:741`'s `require('../cowork/exec_capability_registry')` (every other require in that file uses `./cowork/` — looks like a stray `..`). Happy to split that into a separate fix if useful.