### PR TITLE
Address open issues: WSL2/install resilience (#136), tray icon (#64), shortcut docs (#28)

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -55,6 +55,12 @@ These URLs and checksums are best-effort pointers contributed by users,
 not an endorsement to redistribute. If a recorded SHA-256 shows
 `<pending>`, compute it locally and open a PR to fill it in.
 
+> **Note on DMG vs ZIP:** older `.dmg` CDN URLs now serve LZFSE-compressed
+> images that `p7zip`/`7zz` cannot open. Recent releases ship as `.zip`
+> (the artifact the Homebrew cask tracks), which extracts cleanly — prefer
+> the `.zip` when pinning. `node fetch-dmg.js --json` prints the current
+> version, `.zip` URL, and SHA-256.
+
 ## Reporting a tested version
 
 Open a PR that bumps `LAST_TESTED_ASAR_VERSION` (the HTML comment line

--- a/README.md
+++ b/README.md
@@ -610,9 +610,21 @@ claude-desktop
 <details>
 <summary><strong>Global shortcuts don't work on Wayland (GNOME)</strong></summary>
 
-The app enables `GlobalShortcutsPortal` for Wayland global shortcut support via `xdg-desktop-portal`. This works on **KDE Plasma** and **Hyprland** but **not on GNOME** — `xdg-desktop-portal-gnome` has not implemented the GlobalShortcuts portal yet.
+The app routes global shortcuts through the `org.freedesktop.portal.GlobalShortcuts` portal on Wayland (Electron's native `globalShortcut` relies on X11 `XGrabKey`, which Wayland doesn't expose). This works on **KDE Plasma**, **Hyprland**, **COSMIC**, and **GNOME 48+** — `xdg-desktop-portal-gnome` implements the GlobalShortcuts portal since version 48 (refined in 50). The shortcut shows up under Settings > Keyboard and may prompt for confirmation the first time it's registered.
 
-**Workaround for GNOME Wayland users:** Set a custom shortcut in GNOME Settings > Keyboard > Custom Shortcuts to launch `claude-desktop`.
+**Workaround for GNOME < 48 (and compositors without the portal):** Set a custom shortcut in GNOME Settings > Keyboard > Custom Shortcuts to launch `claude-desktop`.
+
+</details>
+
+<details>
+<summary><strong>Running under WSL2</strong></summary>
+
+Cowork runs on WSL2 (tested with WSLg on Ubuntu). Four things to know — `./install.sh --doctor` checks all of them:
+
+1. **Dependency install conflicts** — if Node.js came from NodeSource, the distro `npm` package conflicts with it. The installer installs packages individually so one conflict no longer blocks the rest (`zstd`, `curl`, …); NodeSource's `nodejs` already bundles npm.
+2. **Missing Electron libraries** — fresh minimal installs lack NSS/NSPR/ALSA. The installer adds them on apt; manually: `sudo apt install -y libnspr4 libnss3 libasound2t64` (or `libasound2` before Ubuntu 24.04).
+3. **OAuth opens in the Windows browser** — WSL2's `xdg-open` forwards URLs to Windows via interop, so the `claude://` login callback never reaches the Linux app. The installer offers an opt-in wrapper at `~/.local/bin/xdg-open` that routes `claude://` to `claude-desktop` and `http(s)` to a Linux browser. Install it any time with `bash install.sh --wsl-xdg-open`; remove with `rm ~/.local/bin/xdg-open`. You'll need a Linux browser (install Chrome/Firefox via `.deb`/apt, not snap) for the OAuth round-trip under WSLg.
+4. **No Secret Service / safeStorage** — expected on stock WSL2; credentials fall back to the basic password store and you re-login after each WSL restart. Enabling systemd plus `gnome-keyring` makes logins persist.
 
 </details>
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -239,11 +239,18 @@ done
 <details>
 <summary><strong>Global shortcuts don't work on GNOME Wayland (#28)</strong></summary>
 
-GNOME's `xdg-desktop-portal-gnome` has not implemented the GlobalShortcuts portal. This is an upstream limitation.
+`xdg-desktop-portal-gnome` implements the GlobalShortcuts portal since **GNOME 48** (refined in 50) — shortcuts work there, appear under Settings > Keyboard, and may prompt for confirmation on first registration. On GNOME < 48 the portal is missing and shortcuts silently fail.
 
-**Workaround**: Set a custom shortcut in GNOME Settings > Keyboard > Custom Shortcuts to launch `claude-desktop`.
+**Workaround for GNOME < 48**: Set a custom shortcut in GNOME Settings > Keyboard > Custom Shortcuts to launch `claude-desktop`.
 
-Works on: KDE Plasma, Hyprland, Sway (via `xdg-desktop-portal-wlr`).
+Also works on: KDE Plasma, Hyprland, COSMIC, Sway (via `xdg-desktop-portal-wlr`).
+
+</details>
+
+<details>
+<summary><strong>Tray icon invisible or wrong variant (#64)</strong></summary>
+
+The app ships a macOS template tray icon (black-on-transparent) that Linux panels don't auto-tint. The wrapper redirects it to the white variant by default, since most Linux panels are dark. On a light panel, set `CLAUDE_TRAY_ICON=light` before launching to use the black variant instead.
 
 </details>
 
@@ -271,6 +278,52 @@ sudo pacman -S libnotify
 # Debian/Ubuntu
 sudo apt install libnotify-bin
 ```
+
+</details>
+
+---
+
+## WSL2
+
+<details>
+<summary><strong>install.sh fails installing dependencies (npm conflict)</strong></summary>
+
+If Node.js was installed from NodeSource, the distro `npm` package conflicts with it and apt refuses the transaction. The installer now installs missing packages one at a time, so the conflict no longer blocks `zstd`, `curl`, etc. NodeSource's `nodejs` package already bundles npm — don't install distro `npm` alongside it.
+
+</details>
+
+<details>
+<summary><strong>Electron fails to start: missing shared libraries</strong></summary>
+
+Fresh minimal Ubuntu/WSL2 installs lack the NSS/NSPR/ALSA libraries the npm Electron build links against. The installer adds them on apt-based systems; manually:
+
+```bash
+sudo apt install -y libnspr4 libnss3 libasound2t64   # libasound2 before Ubuntu 24.04
+```
+
+`./install.sh --doctor` runs `ldd` against the Electron binary and lists anything unresolved.
+
+</details>
+
+<details>
+<summary><strong>OAuth login opens in the Windows browser and never completes</strong></summary>
+
+WSL2's `xdg-open` forwards URLs to Windows via interop, bypassing `$BROWSER`. The login page opens in your Windows browser, but the `claude://` callback is registered in Linux — so the login never round-trips.
+
+Fix: install the opt-in wrapper, which shadows `xdg-open` in `~/.local/bin` and routes `claude://` URLs to `claude-desktop`, `http(s)` to a Linux browser, and everything else to the system `xdg-open`:
+
+```bash
+bash install.sh --wsl-xdg-open
+```
+
+You need a Linux browser for the OAuth page (install Chrome or Firefox via apt/.deb, **not snap**, so it runs under WSLg). To remove the wrapper: `rm ~/.local/bin/xdg-open`. Note the wrapper affects every app in your WSL session that calls `xdg-open`.
+
+</details>
+
+<details>
+<summary><strong>Logged out after every WSL restart</strong></summary>
+
+Stock WSL2 has no Secret Service, so Electron's `safeStorage` falls back to the basic password store and credentials don't survive a WSL restart. This is expected and non-fatal. To persist logins, enable systemd in `/etc/wsl.conf` and set up `gnome-keyring`.
 
 </details>
 

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,27 @@ detect_pkg_manager() {
     else echo "unknown"; fi
 }
 
+# Map a required command to its package name for the active package manager.
+pkg_for_cmd() {
+    local mgr="$1" cmd="$2"
+    case "$mgr:$cmd" in
+        apt:7z) echo "p7zip-full" ;;
+        pacman:7z|dnf:7z|nix:7z) echo "p7zip" ;;
+        zypper:7z) echo "7zip" ;;
+        *:bwrap) echo "bubblewrap" ;;
+        zypper:node) echo "nodejs-default" ;;
+        *:node) echo "nodejs" ;;
+        *) echo "$cmd" ;;   # git, npm, curl, zstd map 1:1
+    esac
+}
+
+is_wsl() {
+    # WSL1/WSL2 kernels identify themselves in /proc/version
+    # (e.g. "...-microsoft-standard-WSL2"). Optional arg for testing.
+    local f="${1:-/proc/version}"
+    grep -qi microsoft "$f" 2>/dev/null
+}
+
 # ============================================================
 # Compatibility helpers (COMPAT.md)
 # ============================================================
@@ -145,16 +166,39 @@ install_dependencies() {
         fi
     done
 
+    # Only install packages for commands that are actually missing, and install
+    # them one at a time on apt: a single conflicting package (e.g. distro npm
+    # vs NodeSource nodejs, issue #136) must not abort the whole transaction
+    # and leave zstd/curl/etc. uninstalled. The verify loop below remains the
+    # hard gate.
     if [[ ${#missing[@]} -gt 0 ]]; then
-        log_info "Missing packages: ${missing[*]}"
+        log_info "Missing commands: ${missing[*]}"
+        local pkgs=() failed=() c p
+        for c in "${missing[@]}"; do
+            pkgs+=("$(pkg_for_cmd "$pkg_manager" "$c")")
+        done
         case "$pkg_manager" in
-            apt) sudo apt-get update -qq && sudo apt-get install -y git p7zip-full nodejs npm bubblewrap curl zstd ;;
-            pacman) sudo pacman -S --noconfirm --needed git p7zip nodejs npm bubblewrap curl zstd ;;
-            dnf) sudo dnf install -y git p7zip nodejs npm bubblewrap curl zstd ;;
-            zypper) sudo zypper install -y git 7zip nodejs-default npm bubblewrap curl zstd ;;
-            nix) nix-env -iA nixpkgs.git nixpkgs.p7zip nixpkgs.nodejs nixpkgs.bubblewrap nixpkgs.curl nixpkgs.zstd ;;
-            *) die "Unknown package manager. Install manually: git p7zip nodejs npm bubblewrap curl zstd" ;;
+            apt)
+                sudo apt-get update -qq || log_warn "apt-get update failed; trying install anyway"
+                for p in "${pkgs[@]}"; do
+                    sudo apt-get install -y "$p" || failed+=("$p")
+                done
+                ;;
+            pacman) sudo pacman -S --noconfirm --needed "${pkgs[@]}" || failed+=("${pkgs[@]}") ;;
+            dnf)    sudo dnf install -y "${pkgs[@]}" || failed+=("${pkgs[@]}") ;;
+            zypper) sudo zypper install -y "${pkgs[@]}" || failed+=("${pkgs[@]}") ;;
+            nix)    for p in "${pkgs[@]}"; do nix-env -iA "nixpkgs.$p" || failed+=("$p"); done ;;
+            *)      die "Unknown package manager. Install manually: ${pkgs[*]}" ;;
         esac
+        if [[ ${#failed[@]} -gt 0 ]]; then
+            log_warn "Could not install: ${failed[*]}"
+            case " ${failed[*]} " in
+                *" npm "*|*" nodejs "*)
+                    log_warn "If Node.js came from NodeSource, the distro nodejs/npm packages conflict with it."
+                    log_warn "NodeSource's nodejs already bundles npm -- reinstall it or enable corepack instead."
+                    ;;
+            esac
+        fi
     fi
 
     # Install npm packages to user prefix
@@ -173,6 +217,8 @@ install_dependencies() {
         npm install --silent -g --prefix="$npm_prefix" electron || die "Failed to install electron"
     fi
 
+    install_electron_runtime_libs
+
     # Verify
     for cmd in git 7z node npm asar electron bwrap curl zstd; do
         if command_exists "$cmd"; then
@@ -188,6 +234,29 @@ install_dependencies() {
         die "Node.js 18+ required, found v$node_version"
     fi
     log_success "Node.js version OK (v$node_version)"
+}
+
+install_electron_runtime_libs() {
+    # Electron from npm dynamically links NSS/NSPR/ALSA, which minimal
+    # Debian/Ubuntu installs (fresh WSL2 in particular) lack -- issue #136.
+    # Other distros ship them with common desktop packages; only the apt
+    # path needs this. Failures are non-fatal: --doctor has an ldd check.
+    [[ "$(detect_pkg_manager)" == "apt" ]] || return 0
+    local libs=(libnspr4 libnss3) lib
+    # libasound2 became libasound2t64 in Ubuntu 24.04 (time_t transition)
+    if apt-cache show libasound2t64 >/dev/null 2>&1; then
+        libs+=(libasound2t64)
+    else
+        libs+=(libasound2)
+    fi
+    local to_install=()
+    for lib in "${libs[@]}"; do
+        dpkg -s "$lib" >/dev/null 2>&1 || to_install+=("$lib")
+    done
+    [[ ${#to_install[@]} -eq 0 ]] && return 0
+    log_info "Installing Electron runtime libraries: ${to_install[*]}"
+    sudo apt-get install -y "${to_install[@]}" \
+        || log_warn "Failed to install ${to_install[*]} -- electron may fail to start (run --doctor)"
 }
 
 # ============================================================
@@ -831,6 +900,62 @@ EOF
 }
 
 # ============================================================
+# Step 8b: WSL2 support (issue #136)
+# ============================================================
+#
+# On WSL2, /usr/bin/xdg-open forwards URLs to Windows via interop. OAuth
+# then opens in a Windows browser and the claude:// callback never reaches
+# the Linux app. An opt-in wrapper at ~/.local/bin/xdg-open (earlier in
+# PATH) routes claude:// to claude-desktop and http(s) to a Linux browser,
+# falling through to the system xdg-open for everything else.
+
+setup_wsl_support() {
+    is_wsl || return 0
+    log_info "WSL2 detected (/proc/version contains 'microsoft')"
+    local wrapper="$HOME/.local/bin/xdg-open"
+    if [[ -f "$wrapper" ]] && grep -q 'claude-cowork-wsl-xdg-open' "$wrapper" 2>/dev/null; then
+        log_info "Updating existing WSL xdg-open wrapper"
+    elif [[ -e "$wrapper" ]]; then
+        log_warn "$wrapper exists and is not ours -- leaving it alone"
+        return 0
+    elif [[ "${INSTALL_WSL_XDG_OPEN:-0}" != "1" ]]; then
+        if [[ -t 0 ]]; then
+            echo "On WSL2, xdg-open forwards URLs to Windows, so Claude's OAuth"
+            echo "callback (claude://) never reaches the Linux app. A wrapper at"
+            echo "~/.local/bin/xdg-open can route claude:// to claude-desktop and"
+            echo "http(s) to a Linux browser. It affects ALL apps in your session."
+            local _ans
+            read -r -p "Install the wrapper? [y/N] " _ans
+            if [[ ! "$_ans" =~ ^[Yy] ]]; then
+                log_info "Skipped. Re-run with --wsl-xdg-open to install later."
+                return 0
+            fi
+        else
+            log_info "Non-interactive install: skipping xdg-open wrapper (use --wsl-xdg-open)"
+            return 0
+        fi
+    fi
+    mkdir -p "$HOME/.local/bin"
+    cat > "$wrapper" << 'WSLEOF'
+#!/bin/bash
+# claude-cowork-wsl-xdg-open: route claude:// to claude-desktop and web URLs
+# to a Linux browser on WSL2; everything else falls through to the system
+# xdg-open (which forwards to Windows via interop).
+case "${1:-}" in
+    claude://*) exec "$HOME/.local/bin/claude-desktop" "$1" ;;
+    http://*|https://*)
+        for b in "${BROWSER:-}" firefox chromium chromium-browser google-chrome brave-browser; do
+            [[ -n "$b" ]] && command -v "$b" >/dev/null 2>&1 && exec "$b" "$@"
+        done
+        ;;  # no Linux browser found: fall through to the Windows browser
+esac
+exec /usr/bin/xdg-open "$@"
+WSLEOF
+    chmod +x "$wrapper"
+    log_success "WSL xdg-open wrapper installed at $wrapper"
+}
+
+# ============================================================
 # Step 9: Icon extraction (hicolor PNG from embedded .icns blobs)
 # ============================================================
 
@@ -956,6 +1081,24 @@ doctor() {
         fi
     fi
 
+    # --- Electron shared libraries ---
+    # npm's electron dist links NSS/NSPR/ALSA that minimal installs lack
+    # (issue #136). Skipped when there is no npm dist binary (e.g. Nix,
+    # system electron) -- those package managers handle linkage themselves.
+    local electron_dist="$HOME/.local/lib/node_modules/electron/dist/electron"
+    if [[ -x "$electron_dist" ]] && command_exists ldd; then
+        local missing_libs
+        missing_libs=$(ldd "$electron_dist" 2>/dev/null | awk '/not found/ {print $1}' | paste -sd ', ' -)
+        if [[ -n "$missing_libs" ]]; then
+            log_error "Electron shared libraries missing: $missing_libs"
+            log_error "  On Debian/Ubuntu: sudo apt install -y libnspr4 libnss3 libasound2t64 (or libasound2)"
+            fail=$((fail + 1))
+        else
+            log_success "Electron shared libraries: all resolved"
+            ok=$((ok + 1))
+        fi
+    fi
+
     # --- Claude Code CLI ---
     local claude_found=""
     for p in \
@@ -1005,8 +1148,33 @@ doctor() {
         log_success "Secret service (org.freedesktop.secrets): available"
         ok=$((ok + 1))
     else
-        log_warn "Secret service: not available (will fall back to basic password store)"
+        if is_wsl; then
+            log_warn "Secret service: not available (expected on WSL2 -- credentials use the basic password store; re-login after each WSL restart. Enable systemd + gnome-keyring to persist.)"
+        else
+            log_warn "Secret service: not available (will fall back to basic password store)"
+        fi
         warn=$((warn + 1))
+    fi
+
+    # --- WSL2 ---
+    if is_wsl; then
+        log_info "WSL detected (/proc/version contains 'microsoft')"
+        local wsl_wrapper="$HOME/.local/bin/xdg-open"
+        if [[ -f "$wsl_wrapper" ]] && grep -q 'claude-cowork-wsl-xdg-open' "$wsl_wrapper" 2>/dev/null; then
+            log_success "WSL xdg-open wrapper: installed"
+            ok=$((ok + 1))
+            local wsl_browser=""
+            for b in firefox chromium chromium-browser google-chrome brave-browser; do
+                if command_exists "$b"; then wsl_browser="$b"; break; fi
+            done
+            if [[ -z "${BROWSER:-}" && -z "$wsl_browser" ]]; then
+                log_warn "No Linux browser found: http(s) URLs still open in Windows; copy the claude:// callback URL into the terminal manually after OAuth"
+                warn=$((warn + 1))
+            fi
+        else
+            log_warn "WSL xdg-open wrapper: not installed -- OAuth opens in a Windows browser and the claude:// callback may never reach the app. Run: ./install.sh --wsl-xdg-open"
+            warn=$((warn + 1))
+        fi
     fi
 
     # --- Asar version vs last tested ---
@@ -1110,6 +1278,15 @@ main() {
             --force|--yes)
                 INSTALL_FORCE=1
                 ;;
+            --wsl-xdg-open)
+                # Standalone action: install just the WSL xdg-open wrapper.
+                # (During a full install on WSL2 the wrapper is offered
+                # interactively, or forced with INSTALL_WSL_XDG_OPEN=1.)
+                is_wsl || die "--wsl-xdg-open: not running under WSL (no 'microsoft' in /proc/version)"
+                INSTALL_WSL_XDG_OPEN=1
+                setup_wsl_support
+                exit $?
+                ;;
             *)
                 if [[ -n "$archive_arg" ]]; then
                     die "Unexpected argument: $arg"
@@ -1187,6 +1364,10 @@ main() {
     setup_environment
     echo ""
 
+    # Step 8b: WSL2 support (no-op outside WSL)
+    setup_wsl_support
+    echo ""
+
     # Step 9: Icon extraction
     setup_icon
     echo ""
@@ -1214,6 +1395,7 @@ main() {
     echo "  claude-desktop --doctor     Run preflight diagnostics"
     echo "  claude-desktop --update     Re-fetch the Claude Desktop asar"
     echo "  bash install.sh --force     Skip the download confirmation prompt"
+    echo "  bash install.sh --wsl-xdg-open  Install the WSL2 OAuth/xdg-open wrapper"
     echo ""
     echo "Update:"
     echo "  claude-desktop --update                    (preferred)"

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,7 @@ pkg_for_cmd() {
         *:bwrap) echo "bubblewrap" ;;
         zypper:node) echo "nodejs-default" ;;
         *:node) echo "nodejs" ;;
+        nix:npm) echo "nodejs" ;;   # nixpkgs bundles npm with nodejs
         *) echo "$cmd" ;;   # git, npm, curl, zstd map 1:1
     esac
 }
@@ -173,9 +174,13 @@ install_dependencies() {
     # hard gate.
     if [[ ${#missing[@]} -gt 0 ]]; then
         log_info "Missing commands: ${missing[*]}"
-        local pkgs=() failed=() c p
+        local pkgs=() failed=() seen=" " c p
         for c in "${missing[@]}"; do
-            pkgs+=("$(pkg_for_cmd "$pkg_manager" "$c")")
+            p="$(pkg_for_cmd "$pkg_manager" "$c")"
+            # Dedupe: several commands can map to one package (nix node+npm)
+            case "$seen" in *" $p "*) continue ;; esac
+            seen+="$p "
+            pkgs+=("$p")
         done
         case "$pkg_manager" in
             apt)
@@ -1085,7 +1090,15 @@ doctor() {
     # npm's electron dist links NSS/NSPR/ALSA that minimal installs lack
     # (issue #136). Skipped when there is no npm dist binary (e.g. Nix,
     # system electron) -- those package managers handle linkage themselves.
-    local electron_dist="$HOME/.local/lib/node_modules/electron/dist/electron"
+    local electron_dist=""
+    if command_exists npm; then
+        local npm_root
+        npm_root=$(npm root -g 2>/dev/null)
+        [[ -n "$npm_root" ]] && electron_dist="$npm_root/electron/dist/electron"
+    fi
+    if [[ ! -x "$electron_dist" ]]; then
+        electron_dist="$HOME/.local/lib/node_modules/electron/dist/electron"
+    fi
     if [[ -x "$electron_dist" ]] && command_exists ldd; then
         local missing_libs
         missing_libs=$(ldd "$electron_dist" 2>/dev/null | awk '/not found/ {print $1}' | paste -sd ', ' -)

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -1628,6 +1628,83 @@ Module.prototype.require = function(id) {
       }
     }
 
+    // ── Tray icon fix (Linux, issue #64) ────────────────────────────────
+    // The asar creates its Tray from TrayIconTemplate.png — a black-on-
+    // transparent macOS template icon that macOS auto-tints but Linux does
+    // not, so it is invisible on dark panels; the path also resolves inside
+    // the asar where createFromPath can fail. Redirect tray template paths
+    // to the external copies in resources/, preferring the white -Dark@2x
+    // variant: most Linux panels are dark even under light themes. Override
+    // with CLAUDE_TRAY_ICON=light.
+    if (REAL_PLATFORM === 'linux' && module.nativeImage && !global.__coworkTrayIconPatched) {
+      global.__coworkTrayIconPatched = true;
+      try {
+        const _ni = module.nativeImage;
+        const _origCreateFromPath = _ni.createFromPath.bind(_ni);
+        const _extResources = path.join(__dirname, 'resources');
+        _ni.createFromPath = function(p) {
+          try {
+            if (typeof p === 'string' && path.basename(p).startsWith('TrayIconTemplate')) {
+              const preferLight = process.env.CLAUDE_TRAY_ICON === 'light';
+              const candidates = preferLight
+                ? ['TrayIconTemplate.png', 'TrayIconTemplate-Dark@2x.png']
+                : ['TrayIconTemplate-Dark@2x.png', 'TrayIconTemplate.png'];
+              for (const name of candidates) {
+                const ext = path.join(_extResources, name);
+                if (fs.existsSync(ext)) {
+                  const img = _origCreateFromPath(ext);
+                  if (img && !img.isEmpty()) {
+                    // Template tinting is a macOS concept; render as-is on Linux
+                    if (typeof img.setTemplateImage === 'function') img.setTemplateImage(false);
+                    console.log('[Frame Fix] Tray icon redirected to ' + ext);
+                    return img;
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            console.warn('[Frame Fix] Tray icon redirect failed:', e.message);
+          }
+          return _origCreateFromPath(p);
+        };
+        console.log('[Frame Fix] nativeImage.createFromPath tray redirect installed');
+      } catch (e) {
+        console.warn('[Frame Fix] Tray icon patch setup failed:', e.message);
+      }
+    }
+
+    // Fallback tray activation: some StatusNotifier hosts (COSMIC, XWayland
+    // on Hyprland) deliver clicks the asar's macOS-oriented tray code never
+    // handles. A construct-trap Proxy keeps instances as genuine Trays
+    // (instanceof, statics and prototype all intact — unlike a function
+    // wrapper or subclass shim). Served via the module Proxy below.
+    if (REAL_PLATFORM === 'linux' && module.Tray && !global.__coworkPatchedTray) {
+      const _electronModule = module;
+      global.__coworkPatchedTray = new Proxy(module.Tray, {
+        construct(target, args, newTarget) {
+          const tray = Reflect.construct(target, args, newTarget);
+          try {
+            tray.on('click', () => {
+              // Ours is attached first; if the asar registered its own
+              // click handler, stay out of the way.
+              if (tray.listenerCount('click') > 1) return;
+              const BW = global.__coworkPatchedBrowserWindow || _electronModule.BrowserWindow;
+              const wins = BW.getAllWindows().filter((w) => !w.isDestroyed());
+              if (!wins.length) return;
+              const win = wins[0];
+              if (win.isMinimized()) win.restore();
+              win.show();
+              win.focus();
+            });
+            console.log('[Frame Fix] Tray click fallback attached');
+          } catch (e) {
+            console.warn('[Frame Fix] Tray click fallback failed:', e.message);
+          }
+          return tray;
+        },
+      });
+    }
+
   }
 
   // On Linux, wrap the electron module in a Proxy to intercept the
@@ -1636,6 +1713,7 @@ Module.prototype.require = function(id) {
     return new Proxy(module, {
       get(target, prop) {
         if (prop === 'BrowserWindow') return global.__coworkPatchedBrowserWindow;
+        if (prop === 'Tray' && global.__coworkPatchedTray) return global.__coworkPatchedTray;
         return target[prop];
       },
       set(target, prop, value) {


### PR DESCRIPTION
Follow-up round on the open issue backlog, building on the just-merged PR #134 (disclaimer require path + `node:child_process` patch) and PR #135 (Nix flake).

## What's in here

### install.sh resilience + WSL2 support (Fixes #136)

The exit-127 root cause was fixed by #134; this covers the remaining four findings from the WSL2 report:

- **Per-package dependency install** — apt previously installed everything in one transaction, so a distro `npm` vs NodeSource `nodejs` conflict aborted the lot and left `zstd`/`curl` uninstalled. Missing commands are now mapped to packages individually (`pkg_for_cmd`) and installed one at a time on apt, with an actionable warning on the NodeSource conflict. The existing verify loop remains the hard gate.
- **Electron runtime libraries** — `install_electron_runtime_libs()` installs `libnspr4 libnss3 libasound2t64` (or `libasound2` pre-24.04) on apt; `--doctor` gains a distro-agnostic `ldd` check against the npm Electron dist binary.
- **WSL2 OAuth** — WSL2's `xdg-open` forwards URLs to Windows, so the `claude://` callback never reaches the Linux app. New opt-in wrapper at `~/.local/bin/xdg-open` (marker-tagged, idempotent, never overwrites a foreign file) routes `claude://` → `claude-desktop`, `http(s)` → a Linux browser, everything else → system `xdg-open`. Offered interactively during install on WSL, standalone via `bash install.sh --wsl-xdg-open`, automatable with `INSTALL_WSL_XDG_OPEN=1`.
- **Doctor WSL block** — detects WSL via `/proc/version`, reports wrapper status, warns when no Linux browser exists, and explains the expected Secret Service absence.

### Tray icon fix (Fixes #64)

The asar builds its Tray from `TrayIconTemplate.png` — a black-on-transparent macOS template icon that Linux panels don't auto-tint (invisible on dark panels), at a path inside the asar that `createFromPath` can fail to read.

- `nativeImage.createFromPath` is intercepted for `TrayIconTemplate*` paths and served from the external `resources/` copy, preferring the white `-Dark@2x` variant (most Linux panels are dark even under light themes); `CLAUDE_TRAY_ICON=light` flips the preference.
- Click fallback via a construct-trap Proxy on `Tray` (instances remain genuine `Tray`s — prototype, `instanceof`, statics intact) that shows/focuses the main window, gated by `listenerCount` so it stays out of the way whenever the asar registers its own click handler.

**Needs visual confirmation from reporters** on COSMIC / Hyprland / GNOME — this environment is headless.

### Docs (#28, #136, #64)

- README + FAQ: `xdg-desktop-portal-gnome` implements the GlobalShortcuts portal since GNOME 48 (refined in 50); the custom-shortcut workaround now applies only to GNOME < 48.
- README + FAQ: full WSL2 sections covering all four #136 findings.
- FAQ: `CLAUDE_TRAY_ICON=light` override.
- COMPAT.md: older DMG CDN URLs serve LZFSE that p7zip can't open — prefer the `.zip` artifact when pinning (matches `fetch-dmg.js` behavior).

## Verification

- `bash -n install.sh launch.sh`, `node --check` on the wrapper: clean.
- Full suite: `node --test tests/node/current-path/*.test.cjs` — **493/493 pass**.
- Helper unit checks: `pkg_for_cmd` mappings, `is_wsl` positive/negative against fixture files.
- xdg-open wrapper routing tested with stub binaries: `claude://` → claude-desktop, `https` → Linux browser, `mailto:` → system fall-through.
- `./install.sh --doctor` exercised end-to-end (new ldd/WSL blocks no-op correctly off-WSL and without npm electron).
- Not testable here (manual matrix): tray rendering/click on GNOME/KDE/COSMIC/Hyprland; full WSL2 OAuth round-trip; fresh Ubuntu 26.04 + NodeSource install run.

https://claude.ai/code/session_01JN4faDKhhBv6qGFvPWRF21

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN4faDKhhBv6qGFvPWRF21)_