### PR TITLE
fix(install): unlink legacy claude-cowork symlink before writing wrapper

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -727,6 +727,11 @@ EOF
 
     # Alias for familiarity. Symlinks are banned -- write a real wrapper script
     # that execs the canonical launcher by its full path instead of a symlink.
+    # Pre-8ad9bd7 installs left ~/.local/bin/claude-cowork as a symlink to
+    # claude-desktop; the cat-redirect below would follow that symlink and
+    # clobber the just-written claude-desktop launcher with the wrapper, which
+    # then exec's itself in an infinite loop. Unlink first.
+    rm -f "$HOME/.local/bin/claude-cowork"
     cat > "$HOME/.local/bin/claude-cowork" << 'WRAP'
 #!/bin/bash
 exec "$HOME/.local/bin/claude-desktop" "$@"


### PR DESCRIPTION
## Summary

Pre-`8ad9bd7` installs created `~/.local/bin/claude-cowork` as a symlink to `claude-desktop`. After `8ad9bd7` switched the alias to a real wrapper script via `cat > "$HOME/.local/bin/claude-cowork"`, that redirect follows the legacy symlink and clobbers the just-written `claude-desktop` launcher with the wrapper body — which then `exec`'s itself in an infinite loop. The launcher process spins at 99% CPU with no Electron child and no log output. Fix is a one-line `rm -f` before the cat-redirect so the wrapper lands in a fresh inode.

The install itself completes "successfully": the in-tree `COWORK_WRAPPER_OK` assertion (`-x && ! -L`) passes because the cat-redirect did replace the symlink with a regular file at `claude-cowork`. The damage is at the other end — `claude-desktop` is now the 56-byte wrapper instead of the ~3.4KB launcher. The breakage only manifests at launch time on systems that had the prior installer run.

Confirmed in the wild on an upgrade from `e085d75` → `07e9416` (current `master`).

## Repro

```bash
ln -sf "\$HOME/.local/bin/claude-desktop" "\$HOME/.local/bin/claude-cowork"
./install.sh --yes
claude-desktop    # spins at 99% CPU, no UI, no logs
```

After the fix:

```
$ ls -la ~/.local/bin/claude-*
-rwxrwxr-x 1 rod rod   56 ... /home/rod/.local/bin/claude-cowork   # wrapper
-rwxrwxr-x 1 rod rod 3443 ... /home/rod/.local/bin/claude-desktop  # full launcher
```

Both are real files, neither is a symlink.

## Test plan

- [x] `bash -n install.sh`
- [x] Manual repro: pre-seed legacy symlink, run `./install.sh --yes`, confirm `claude-desktop` is the full launcher and `claude-cowork` is the 56-byte wrapper
- [x] Manual smoke launch after fix
- [ ] (Optional follow-up) Extend `tests/test-install-paths.sh` stage 6 to pre-seed the legacy symlink before `bash install.sh` — the current test runs in a fresh `HOME` and does not reproduce this regression. Left out of this PR to keep the diff minimal; happy to add it if you'd like.