### PR TITLE
fix(install): write claude-cowork alias via temp+mv to survive legacy symlink

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -801,11 +801,22 @@ EOF
 
     # Alias for familiarity. Symlinks are banned -- write a real wrapper script
     # that execs the canonical launcher by its full path instead of a symlink.
-    cat > "$HOME/.local/bin/claude-cowork" << 'WRAP'
+    #
+    # Pre-8ad9bd7 installs left ~/.local/bin/claude-cowork as a symlink to
+    # claude-desktop. A plain `cat > claude-cowork` would FOLLOW that symlink
+    # and overwrite the just-written claude-desktop launcher with this wrapper,
+    # which then exec's itself in an infinite loop (PR #138). Write to a temp
+    # file in the same dir and `mv` it into place: mv replaces the symlink
+    # itself rather than its target, atomically, with no unconditional rm.
+    local cowork_alias="$HOME/.local/bin/claude-cowork"
+    local cowork_tmp
+    cowork_tmp="$(mktemp "$HOME/.local/bin/.claude-cowork.XXXXXX")" || die "Failed to create temp file for claude-cowork wrapper"
+    cat > "$cowork_tmp" << 'WRAP'
 #!/bin/bash
 exec "$HOME/.local/bin/claude-desktop" "$@"
 WRAP
-    chmod +x "$HOME/.local/bin/claude-cowork"
+    chmod +x "$cowork_tmp"
+    mv -f "$cowork_tmp" "$cowork_alias"
 
     log_success "Created launchers: ~/.local/bin/claude-desktop, ~/.local/bin/claude-cowork"
 }


### PR DESCRIPTION
## Summary

Fixes the upgrade-time regression diagnosed in #138 (credit to @rmorison), using the symlink-safe atomic-replace variant instead of an unconditional `rm`.

**The bug:** Pre-`8ad9bd7` installs created `~/.local/bin/claude-cowork` as a *symlink* to `claude-desktop`. The current `create_launcher()` writes the alias with `cat > ~/.local/bin/claude-cowork`, which **follows that legacy symlink and overwrites the just-written `claude-desktop` launcher** (~3.4 KB) with the 56-byte wrapper body. `claude-desktop` then `exec`s itself in an infinite loop — 99% CPU, no Electron child, no logs. The installer reports success because the in-tree `COWORK_WRAPPER_OK` check only validates `claude-cowork`. Confirmed on upgrades to current `master`.

**The fix:** Write the wrapper to a temp file in the same directory and `mv -f` it into place. `mv` replaces the symlink itself rather than writing through it, atomically, with **no unconditional `rm` on a live path** — so the legacy symlink is broken cleanly and `claude-desktop` is never touched.

## Why this variant over `rm -f` + `cat`

@rmorison's original fix (`rm -f` before the `cat`) is correct and bounded. This PR uses the temp-file + `mv` form instead because it avoids deleting a live path entirely and is atomic (no window where the alias is missing or half-written). Same outcome, slightly more defensive.

## Test plan

- [x] `bash -n install.sh`
- [x] Repro the legacy state (`claude-cowork` symlinked → `claude-desktop`), run the patched alias-writing block, and confirm: `claude-desktop` **retains the full launcher** (not clobbered), `claude-cowork` is a real file (the wrapper), both are regular files (neither a symlink), and no temp files leak.

```
claude-desktop is symlink? no   (full launcher content intact)
claude-cowork  is symlink? no   (wrapper content)
leftover temps: 0
```

https://claude.ai/code/session_01JN4faDKhhBv6qGFvPWRF21

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN4faDKhhBv6qGFvPWRF21)_