### PR TITLE
fix(swift): vm.spawn() returns a promise resolving to { failedMounts }

### DIFF
--- a/stubs/@ant/claude-swift/js/index.js
+++ b/stubs/@ant/claude-swift/js/index.js
@@ -1294,8 +1294,21 @@ class SwiftAddonStub extends EventEmitter {
           sharedCwdPath,
           onError: self._onError,
         });
+        // The asar (v1.5xx+) treats vm.spawn()'s return value as a Promise:
+        //   const o = vm.spawn(...); o.catch(()=>{});
+        //   await Promise.race([o, waitForExit()]);
+        //   const { failedMounts = [] } = await o;
+        // Returning a plain object here makes the app crash with
+        //   "o.catch is not a function"
+        // on every workspace bash command (resume/create/re-resume all fail).
+        // So spawn must resolve to an object exposing `failedMounts`, and
+        // reject when the process cannot be launched so the error surfaces
+        // instead of hanging until the 30s oneshot timeout.
         if (!preparedSpawn.success) {
-          return preparedSpawn;
+          return Promise.reject(Object.assign(
+            new Error(preparedSpawn.error || 'spawn preparation failed'),
+            { failedMounts: [] }
+          ));
         }
 
         console.log('[claude-swift] vm.spawn() id=' + id + ' cmd=' + preparedSpawn.command);
@@ -1312,7 +1325,25 @@ class SwiftAddonStub extends EventEmitter {
           preparedSpawn.sharedCwdPath
         );
 
-        return spawnResult;
+        if (!spawnResult || spawnResult.success !== true) {
+          return Promise.reject(Object.assign(
+            new Error((spawnResult && spawnResult.error) || 'spawn failed'),
+            { failedMounts: [] }
+          ));
+        }
+
+        // Resolve to the shape the asar destructures ({ failedMounts }).
+        // Critical mount failures already reject above via preparedSpawn;
+        // non-critical mounts are best-effort, so report none failed here.
+        const resolved = { ...spawnResult, failedMounts: [] };
+        // Hybrid: also expose success/pid synchronously so existing callers
+        // and the node test harness (which read spawnResult.success right
+        // after the call) keep working without awaiting.
+        const spawnPromise = Promise.resolve(resolved);
+        spawnPromise.success = spawnResult.success;
+        spawnPromise.pid = spawnResult.pid;
+        spawnPromise.failedMounts = resolved.failedMounts;
+        return spawnPromise;
       },
 
       kill: (id, signal) => {


### PR DESCRIPTION
## Problem

On asar v1.5xx+ the app awaits `vm.spawn()`'s return value and calls `.catch()` on it, then destructures `{ failedMounts }`:

```js
const o = vm.spawn(...); o.catch(()=>{});
await Promise.race([o, waitForExit()]);
const { failedMounts = [] } = await o;
```

The stub returned a plain object, so every workspace bash command (resume/create/re-resume) crashed with `o.catch is not a function`.

## Fix

- `vm.spawn()` now returns a Promise.
- Rejects on prepare/spawn failure (with `failedMounts: []` attached) so the error surfaces immediately instead of hanging until the 30s oneshot timeout.
- Otherwise resolves to `{ ...spawnResult, failedMounts: [] }` — the shape the asar destructures.
- Keeps `success`/`pid`/`failedMounts` attached synchronously on the returned promise so existing non-awaiting callers and the node test harness keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)