### PR TITLE
fix(mcp): resolve node-host path inside asar via getAppPath()

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -179,6 +179,24 @@ if [ -f "$INDEX_JS" ] && grep -qE '[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?pr
   sed -i -E 's/[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?process\.resourcesPath://g' "$INDEX_JS"
 fi
 
+# Fix MCP node-host path resolution ("MCP Filesystem: Node host not found").
+# The MCP runtime computes its host paths as
+#   app.isPackaged ? join(process.resourcesPath,"app.asar",...) : join(getAppPath(),...)
+# but frame-fix-wrapper.js overrides process.resourcesPath to
+# ~/.config/Claude/cowork-resources (so the disclaimer/Helpers dir is writable),
+# and that location has no app.asar — so the packaged branch resolves to a
+# nonexistent nodeHost.js/directMcpHost.js and the MCP server fails to start.
+# getAppPath() already points inside the running asar (and equals
+# resources/app.asar on a stock build), so rewrite the packaged branch to use
+# it. Covers nodeHost.js, directMcpHost.js, and the asar-root helper — every
+# isPackaged-guarded asar-internal lookup. The resourcesPath patch above only
+# matches the bare `isPackaged?process.resourcesPath:` shape, not these join()
+# forms, so this is a separate pass.
+if [ -f "$INDEX_JS" ] && grep -qE '[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?[a-zA-Z_$][a-zA-Z0-9_$]*\.join\(process\.resourcesPath,"app\.asar"' "$INDEX_JS"; then
+  echo "Patching MCP node-host asar paths to use getAppPath()..."
+  sed -i -E 's/([a-zA-Z_$][a-zA-Z0-9_$]*)\.app\.isPackaged\?([a-zA-Z_$][a-zA-Z0-9_$]*)\.join\(process\.resourcesPath,"app\.asar"/\1.app.isPackaged?\2.join(\1.app.getAppPath()/g' "$INDEX_JS"
+fi
+
 # Only repack if stub is newer than asar (or asar doesn't exist)
 # Repack if any file in the extracted tree is newer than the cached asar.
 _needs_repack=false


### PR DESCRIPTION
## Problem

On launch, the MCP Filesystem server fails to start with:

```
MCP Filesystem: Node host not found at:
/home/<user>/.config/Claude/cowork-resources/app.asar/.vite/build/mcp-runtime/nodeHost.js
```

The file genuinely doesn't exist at that path — but it *does* exist inside the running asar at `.vite/build/mcp-runtime/nodeHost.js`.

## Root cause

The Cowork MCP runtime computes its host paths as:

```js
nodeHostPath = app.isPackaged
  ? join(process.resourcesPath, "app.asar", ".vite","build","mcp-runtime","nodeHost.js")  // packaged
  : join(app.getAppPath(),                  ".vite","build","mcp-runtime","nodeHost.js")  // dev
```

The app runs from a repacked asar, so `app.isPackaged === true` → it takes the `process.resourcesPath` branch.

`stubs/frame-fix/frame-fix-wrapper.js` **overrides `process.resourcesPath`** to `~/.config/Claude/cowork-resources` (so `dirname(resourcesPath)/Helpers/disclaimer` lands on a writable path instead of the read-only system Electron resources dir). That location has no `app.asar`, so the packaged branch resolves to a nonexistent file and the MCP server can't spawn its node host.

The existing `resourcesPath` patch in `launch.sh` only neutralizes the bare `isPackaged?process.resourcesPath:` shape — it doesn't match the `isPackaged?join(process.resourcesPath,"app.asar",…)` form, so this construction slipped through. The MCP node-host runtime appears to be newer than the #107 mac-only-path audit, which didn't enumerate it.

## Fix

Rewrite the packaged branch of these asar-internal lookups to use `getAppPath()`, which already points inside the running asar (and equals `resources/app.asar` on a stock Electron build, so the change is a no-op there). A single guarded `sed`, alongside the existing `resourcesPath` patch in `launch.sh`, covers all three `isPackaged`-guarded sites:

- `mcp-runtime/nodeHost.js` (the reported failure)
- `mcp-runtime/directMcpHost.js` (its sibling — the next error you'd hit)
- the asar-root helper (`isPackaged?join(resourcesPath,"app.asar"):getAppPath()`)

The regex uses generic minified-identifier classes (no hardcoded var names) and is idempotent via its `grep` guard.

## Verification

- `bash -n launch.sh` passes.
- Applied the patch block verbatim to the live extracted `index.js`:
  - all 3 ternary sites rewritten, 0 residual broken sites;
  - re-running the guard does not re-match (idempotent);
  - `node --check` parses the result cleanly.

```
# before
nodeHostPath=oA.app.isPackaged?AA.join(process.resourcesPath,"app.asar",".vite","build","mcp-runtime","nodeHost.js"):AA.join(oA.app.getAppPath(),...)
# after
nodeHostPath=oA.app.isPackaged?AA.join(oA.app.getAppPath(),".vite","build","mcp-runtime","nodeHost.js"):AA.join(oA.app.getAppPath(),...)
```

## Note / possible follow-up

There's one more same-class site that this PR intentionally leaves alone: the **shell-path-worker** (`shellPathWorker.js`) is reached via an *unguarded* `join(process.resourcesPath,"app.asar",…)` with no `isPackaged` ternary, so it has a different shape and isn't matched here. It's the same root cause (overridden `resourcesPath` → wrong asar-internal path) and likely degrades shell PATH detection, but it hasn't been reported failing. Happy to fold it into this PR or file a separate one if you'd prefer.