### PR TITLE
fix(spaces): match createSpaceFolder to new (parentPath, folderName) contract

### DIFF
--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -68,11 +68,6 @@ function createSpacesStore(options) {
     }
   }
 
-  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  function isValidUUID(s) {
-    return typeof s === 'string' && UUID_RE.test(s);
-  }
-
   // Sanitize a value from the renderer to a plain string (max 10KB).
   // Rejects objects, arrays, and excessively large strings.
   function sanitizeString(v, maxLen) {
@@ -481,30 +476,57 @@ function createSpacesStore(options) {
     return true;
   }
 
-  function createSpaceFolder(_event, spaceId, folderName) {
-    // Internal operation: only allows simple basenames, no path separators
-    // or traversal. Output is always under localAgentRoot.
-    if (typeof folderName !== 'string' || folderName.length === 0 || folderName.length > 255) return null;
-    if (/[/\\]/.test(folderName) || folderName === '.' || folderName === '..') {
+  function createSpaceFolder(_event, parentPath, folderName) {
+    // Contract (asar 1.14271.0): the renderer's "New Project" flow invokes
+    // this with a filesystem parentPath at position 0 and a folderName at
+    // position 1 — confirmed against the bundle's IPC validator, which names
+    // the args "parentPath" then "folderName". We create
+    // <parentPath>/<folderName> on disk, dedup on collision ("name (1)",
+    // "name (2)", …) to match the native impl, and return the created path.
+    //
+    // Older builds used (spaceId, name) rooted under
+    // localAgentRoot/spaces/<uuid>; that contract changed and the old shape
+    // rejected every call with "invalid spaceId", so project creation failed.
+    if (typeof folderName !== 'string') return null;
+    const name = folderName.trim();
+    if (name.length === 0 || name.length > 255) {
       trace('[spaces] createSpaceFolder BLOCKED (invalid name): ' + folderName);
       return null;
     }
-    if (!isValidUUID(spaceId)) {
-      trace('[spaces] createSpaceFolder BLOCKED (invalid spaceId): ' + spaceId);
+    // folderName must be a single path segment — no separators or traversal.
+    if (/[/\\]/.test(name) || name === '.' || name === '..' || name.includes('\0')) {
+      trace('[spaces] createSpaceFolder BLOCKED (invalid name): ' + name);
       return null;
     }
-    const p = discoverSpacesPath();
-    if (!p) return null;
-    const spaceFolderPath = path.join(path.dirname(p), 'spaces', spaceId, folderName);
-    // Verify the constructed path is still under localAgentRoot
-    const normalized = path.normalize(spaceFolderPath);
-    if (!normalized.startsWith(localAgentRoot + path.sep)) {
-      trace('[spaces] createSpaceFolder BLOCKED (escaped localAgentRoot): ' + normalized);
+    if (typeof parentPath !== 'string' || !path.isAbsolute(parentPath) || parentPath.includes('\0')) {
+      trace('[spaces] createSpaceFolder BLOCKED (invalid parentPath): ' + parentPath);
+      return null;
+    }
+    // Security: the native macOS impl relies on the OS sandbox; Linux has
+    // none, so confine creation to allowed roots (homedir, no /tmp) — the
+    // same policy as addFolderToSpace. Validate the normalized target so a
+    // parentPath containing `..` segments can't escape.
+    const base = path.normalize(path.join(parentPath, name));
+    if (!requireAllowedPath(base)) {
+      trace('[spaces] createSpaceFolder BLOCKED (outside allowed roots): ' + base);
       return null;
     }
     try {
-      fs.mkdirSync(spaceFolderPath, { recursive: true });
-      return spaceFolderPath;
+      let target = base;
+      for (let i = 1; fs.existsSync(target); i++) {
+        if (i > 1000) {
+          trace('[spaces] createSpaceFolder BLOCKED (too many collisions): ' + base);
+          return null;
+        }
+        target = path.normalize(path.join(parentPath, name + ' (' + i + ')'));
+        if (!requireAllowedPath(target)) {
+          trace('[spaces] createSpaceFolder BLOCKED (outside allowed roots): ' + target);
+          return null;
+        }
+      }
+      fs.mkdirSync(target, { recursive: true });
+      trace('[spaces] createSpaceFolder created: ' + target);
+      return target;
     } catch (e) {
       trace('[spaces] createSpaceFolder error: ' + e.message);
       return null;


### PR DESCRIPTION
## Problem

Creating a project fails with "Failed to create project." Log:

```
[spaces] createSpaceFolder BLOCKED (invalid spaceId): /home/<user>/Claude/Projects
```

Fixes #144.

## Root cause

The CoworkSpaces stub implements the old `createSpaceFolder(spaceId, folderName)` contract — arg0 validated as a UUID, folder created under `localAgentRoot/spaces/<uuid>/<name>`. In asar **1.14271.0** the "New Project" flow calls it as `createSpaceFolder(parentPath, folderName)` (the bundle's IPC validator names the args **parentPath** then **folderName**), so the absolute path hit the UUID check and every call was rejected. COMPAT drift from 1.6259.1 → 1.14271.0; independent of the node-host fix (#142/#143).

## Fix

Rewrite the stub to the new contract:

- `create <parentPath>/<folderName>` on disk, **dedup on collision** (`name (1)`, `name (2)`, …) to match the native impl, return the created path.
- **Security:** the native macOS impl relies on the OS sandbox; Linux has none, so confine creation to the allowed roots (homedir, no `/tmp`) via the existing `requireAllowedPath` (same policy as `addFolderToSpace`), validating the **normalized** target so a `parentPath` with `..` segments can't escape.
- Removes the now-unused `isValidUUID`/`UUID_RE`.

## Verification

`node --check` passes. Exercised against the live store:

| case | result |
|------|--------|
| create folder | ✅ created, correct path |
| same name ×2 | ✅ `name (1)`, `name (2)` |
| parent `/tmp/...` | ✅ rejected |
| parent `/etc` (outside home) | ✅ rejected |
| name `../escape` | ✅ rejected |
| parent with `../../..` | ✅ rejected |
| empty name | ✅ rejected |
| null-byte name | ✅ rejected |
| relative parent | ✅ rejected |