### PR TITLE
fix(spaces): createSpaceFolder (parentPath, folderName) contract + symlink-escape hardening

### DIFF
--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -68,9 +68,20 @@ function createSpacesStore(options) {
     }
   }
 
-  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  function isValidUUID(s) {
-    return typeof s === 'string' && UUID_RE.test(s);
+  // Resolve the nearest EXISTING ancestor of p through realpathSync. Used by
+  // create operations where the target (and possibly some parent dirs) don't
+  // exist yet, but we still must ensure no symlink in the existing portion of
+  // the chain redirects the write outside the allowed roots. Returns null if
+  // nothing along the chain can be resolved.
+  function resolveExistingAncestor(p) {
+    if (typeof p !== 'string' || !path.isAbsolute(p)) return null;
+    let cur = path.normalize(p);
+    while (!fs.existsSync(cur)) {
+      const parent = path.dirname(cur);
+      if (parent === cur) return null; // reached fs root without an existing dir
+      cur = parent;
+    }
+    return resolvePath(cur);
   }
 
   // Sanitize a value from the renderer to a plain string (max 10KB).
@@ -481,30 +492,70 @@ function createSpacesStore(options) {
     return true;
   }
 
-  function createSpaceFolder(_event, spaceId, folderName) {
-    // Internal operation: only allows simple basenames, no path separators
-    // or traversal. Output is always under localAgentRoot.
-    if (typeof folderName !== 'string' || folderName.length === 0 || folderName.length > 255) return null;
-    if (/[/\\]/.test(folderName) || folderName === '.' || folderName === '..') {
+  function createSpaceFolder(_event, parentPath, folderName) {
+    // Contract (asar 1.14271.0): the renderer's "New Project" flow invokes
+    // this with a filesystem parentPath at position 0 and a folderName at
+    // position 1 — confirmed against the bundle's IPC validator, which names
+    // the args "parentPath" then "folderName". We create
+    // <parentPath>/<folderName> on disk, dedup on collision ("name (1)",
+    // "name (2)", …) to match the native impl, and return the created path.
+    //
+    // Older builds used (spaceId, name) rooted under
+    // localAgentRoot/spaces/<uuid>; that contract changed and the old shape
+    // rejected every call with "invalid spaceId", so project creation failed.
+    if (typeof folderName !== 'string') return null;
+    const name = folderName.trim();
+    if (name.length === 0 || name.length > 255) {
       trace('[spaces] createSpaceFolder BLOCKED (invalid name): ' + folderName);
       return null;
     }
-    if (!isValidUUID(spaceId)) {
-      trace('[spaces] createSpaceFolder BLOCKED (invalid spaceId): ' + spaceId);
+    // folderName must be a single path segment — no separators or traversal.
+    if (/[/\\]/.test(name) || name === '.' || name === '..' || name.includes('\0')) {
+      trace('[spaces] createSpaceFolder BLOCKED (invalid name): ' + name);
       return null;
     }
-    const p = discoverSpacesPath();
-    if (!p) return null;
-    const spaceFolderPath = path.join(path.dirname(p), 'spaces', spaceId, folderName);
-    // Verify the constructed path is still under localAgentRoot
-    const normalized = path.normalize(spaceFolderPath);
-    if (!normalized.startsWith(localAgentRoot + path.sep)) {
-      trace('[spaces] createSpaceFolder BLOCKED (escaped localAgentRoot): ' + normalized);
+    if (typeof parentPath !== 'string' || !path.isAbsolute(parentPath) || parentPath.includes('\0')) {
+      trace('[spaces] createSpaceFolder BLOCKED (invalid parentPath): ' + parentPath);
+      return null;
+    }
+    // Security: the native macOS impl relies on the OS sandbox; Linux has
+    // none, so confine creation to allowed roots (homedir, no /tmp) — the
+    // same policy as addFolderToSpace. Validate the normalized target so a
+    // parentPath containing `..` segments can't escape lexically.
+    const base = path.normalize(path.join(parentPath, name));
+    if (!requireAllowedPath(base)) {
+      trace('[spaces] createSpaceFolder BLOCKED (outside allowed roots): ' + base);
+      return null;
+    }
+    // A lexical check alone is insufficient on Linux: a symlinked ancestor
+    // (e.g. ~/Projects -> /etc) would let recursive mkdir escape the home
+    // confinement. Mirror addFolderToSpace's symlink defense by resolving the
+    // nearest EXISTING ancestor through realpath and requiring it to stay
+    // within the allowed roots. We resolve the nearest existing ancestor
+    // (rather than parentPath itself) so a not-yet-created Projects tree still
+    // works — recursive mkdir then only adds fresh, non-symlink segments below
+    // a verified-real directory.
+    const resolvedAncestor = resolveExistingAncestor(base);
+    if (!resolvedAncestor || !requireAllowedPath(resolvedAncestor)) {
+      trace('[spaces] createSpaceFolder BLOCKED (symlinked/escaping ancestor): ' + base);
       return null;
     }
     try {
-      fs.mkdirSync(spaceFolderPath, { recursive: true });
-      return spaceFolderPath;
+      let target = base;
+      for (let i = 1; fs.existsSync(target); i++) {
+        if (i > 1000) {
+          trace('[spaces] createSpaceFolder BLOCKED (too many collisions): ' + base);
+          return null;
+        }
+        target = path.normalize(path.join(parentPath, name + ' (' + i + ')'));
+        if (!requireAllowedPath(target)) {
+          trace('[spaces] createSpaceFolder BLOCKED (outside allowed roots): ' + target);
+          return null;
+        }
+      }
+      fs.mkdirSync(target, { recursive: true });
+      trace('[spaces] createSpaceFolder created: ' + target);
+      return target;
     } catch (e) {
       trace('[spaces] createSpaceFolder error: ' + e.message);
       return null;

--- a/tests/node/current-path/spaces_store.test.cjs
+++ b/tests/node/current-path/spaces_store.test.cjs
@@ -1,0 +1,122 @@
+'use strict';
+
+// Regression coverage for createSpaceFolder (issue #144 / PR #145).
+//
+// asar 1.14271.0 changed the "New Project" IPC contract from
+// createSpaceFolder(spaceId, folderName) to (parentPath, folderName), which
+// broke project creation entirely ("invalid spaceId"). This verifies the new
+// contract AND the Linux-specific hardening: creation is confined to the home
+// dir (no /tmp), folderName must be a single segment, collisions dedup, and a
+// symlinked ancestor cannot redirect mkdir outside the allowed roots.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createSpacesStore } = require('../../../stubs/cowork/spaces_store.js');
+
+// The store rejects /tmp on purpose, so the fake home must live OUTSIDE /tmp.
+// Root it under the real homedir and point the store's passwd-home override at
+// it so requireAllowedPath confines to this temp tree.
+function setup(t) {
+  const tempRoot = fs.mkdtempSync(path.join(os.homedir(), '.cowork-spaces-test-'));
+  t.after(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    delete global.__coworkPasswdHomedir;
+  });
+  const tempHome = path.join(tempRoot, 'home');
+  fs.mkdirSync(tempHome, { recursive: true });
+  global.__coworkPasswdHomedir = tempHome;
+  const store = createSpacesStore({
+    localAgentRoot: path.join(tempHome, '.config', 'Claude', 'local-agent-mode-sessions'),
+    isPathAllowed: () => true, // defer to the store's own home/realpath checks
+    trace: () => {},
+  });
+  return { tempRoot, tempHome, store };
+}
+
+test('createSpaceFolder creates <parentPath>/<name> and returns the path', (t) => {
+  const { tempHome, store } = setup(t);
+  const parent = path.join(tempHome, 'Projects');
+  fs.mkdirSync(parent, { recursive: true });
+
+  const created = store.createSpaceFolder(null, parent, 'My Project');
+  assert.equal(created, path.join(parent, 'My Project'));
+  assert.ok(fs.existsSync(created) && fs.statSync(created).isDirectory());
+});
+
+test('createSpaceFolder dedups on collision (name, name (1), name (2))', (t) => {
+  const { tempHome, store } = setup(t);
+  const parent = path.join(tempHome, 'Projects');
+  fs.mkdirSync(parent, { recursive: true });
+
+  const a = store.createSpaceFolder(null, parent, 'Proj');
+  const b = store.createSpaceFolder(null, parent, 'Proj');
+  const c = store.createSpaceFolder(null, parent, 'Proj');
+  assert.equal(a, path.join(parent, 'Proj'));
+  assert.equal(b, path.join(parent, 'Proj (1)'));
+  assert.equal(c, path.join(parent, 'Proj (2)'));
+});
+
+test('createSpaceFolder creates a not-yet-existing parent tree under home', (t) => {
+  // Guards against the hardening over-rejecting: the nearest existing ancestor
+  // (home) is real, so a brand-new Projects tree must still be created.
+  const { tempHome, store } = setup(t);
+  const parent = path.join(tempHome, 'brand', 'new', 'tree');
+  const created = store.createSpaceFolder(null, parent, 'First');
+  assert.equal(created, path.join(parent, 'First'));
+  assert.ok(fs.existsSync(created));
+});
+
+test('createSpaceFolder rejects a parentPath in /tmp', (t) => {
+  const { store } = setup(t);
+  const tmpParent = fs.mkdtempSync(path.join(os.tmpdir(), 'spaces-reject-'));
+  t.after(() => fs.rmSync(tmpParent, { recursive: true, force: true }));
+  assert.equal(store.createSpaceFolder(null, tmpParent, 'x'), null);
+  assert.ok(!fs.existsSync(path.join(tmpParent, 'x')));
+});
+
+test('createSpaceFolder rejects a parentPath outside home (/etc)', (t) => {
+  const { store } = setup(t);
+  assert.equal(store.createSpaceFolder(null, '/etc', 'x'), null);
+});
+
+test('createSpaceFolder rejects folderName with separators / traversal / null byte', (t) => {
+  const { tempHome, store } = setup(t);
+  const parent = path.join(tempHome, 'Projects');
+  fs.mkdirSync(parent, { recursive: true });
+  for (const bad of ['../escape', 'a/b', '..', '.', 'has\0null', '']) {
+    assert.equal(store.createSpaceFolder(null, parent, bad), null, 'should reject name: ' + JSON.stringify(bad));
+  }
+});
+
+test('createSpaceFolder rejects a parentPath that escapes home via ..', (t) => {
+  const { tempHome, store } = setup(t);
+  // Lexically under home but ".."-escaping to the real home root.
+  const escaping = path.join(tempHome, '..', '..', '..', 'etc');
+  assert.equal(store.createSpaceFolder(null, escaping, 'x'), null);
+});
+
+test('createSpaceFolder rejects a relative parentPath', (t) => {
+  const { store } = setup(t);
+  assert.equal(store.createSpaceFolder(null, 'relative/dir', 'x'), null);
+});
+
+test('createSpaceFolder rejects a symlinked ancestor that escapes home (no mkdir at target)', (t) => {
+  // The core hardening over PR #145's lexical-only check: parentPath is
+  // lexically under home, but an ancestor symlink resolves outside it.
+  const { tempHome, store } = setup(t);
+  // Writable escape target outside home so that WITHOUT the realpath defense
+  // the recursive mkdir would succeed there — making this test fail loudly if
+  // the symlink defense regresses.
+  const escapeTarget = fs.mkdtempSync(path.join(os.tmpdir(), 'spaces-escape-'));
+  t.after(() => fs.rmSync(escapeTarget, { recursive: true, force: true }));
+  const evil = path.join(tempHome, 'evil'); // ~/evil -> /tmp/spaces-escape-XXXX
+  fs.symlinkSync(escapeTarget, evil);
+
+  const result = store.createSpaceFolder(null, evil, 'pwned');
+  assert.equal(result, null, 'symlinked-ancestor escape must be rejected');
+  assert.ok(!fs.existsSync(path.join(escapeTarget, 'pwned')), 'nothing may be created at the escape target');
+});


### PR DESCRIPTION
## Problem

Creating a project fails with "Failed to create project." (`[spaces] createSpaceFolder BLOCKED (invalid spaceId)`). asar **1.14271.0** changed the "New Project" IPC contract from `createSpaceFolder(spaceId, folderName)` to `createSpaceFolder(parentPath, folderName)`, so the old UUID-based stub rejected every call. **Fixes #144.**

## What this does

This builds on @shawnyeager's contract fix in #145 and **supersedes it** with added Linux hardening + test coverage.

**Contract fix (from #145):** rewrite `createSpaceFolder` to the `(parentPath, folderName)` shape — create `<parentPath>/<folderName>`, dedup on collision (`name (1)`, `name (2)`, …), return the created path. Removes the now-unused `isValidUUID`/`UUID_RE`.

**Added hardening:** this handler now accepts a renderer-supplied absolute `parentPath` and creates directories there. The native macOS impl relies on the OS sandbox; Linux has none. #145 confined creation with a **lexical** `requireAllowedPath` check (homedir, no `/tmp`), but a lexical check can be defeated by a symlinked ancestor (e.g. `~/Projects -> /etc`), letting `mkdir -p` escape home. The sibling `addFolderToSpace` already defends against this by also checking the **realpath'd** path — so this mirrors that:

- Resolve the **nearest existing ancestor** of the target through `realpath` and require it to stay within the allowed roots.
- Resolving the *nearest existing* ancestor (not `parentPath` itself) means a brand-new `Projects` tree is still created normally — the legitimate flow isn't broken.

**Tests:** adds `tests/node/current-path/spaces_store.test.cjs` (the spaces store had **no** coverage): contract, dedup, not-yet-existing parent creation, and rejection of `/tmp`, outside-home, `..`-escape, bad names (separators/traversal/null byte), relative parent, and the **symlinked-ancestor escape**.

## Verification

- Full node suite: **502/502 pass** (`node --test tests/node/current-path/*.test.cjs`).
- The symlink-escape test is **mutation-verified**: neutralizing the realpath-ancestor guard makes it fail (the escape succeeds), so it genuinely guards the defense.

Co-authored with @shawnyeager (#145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ppc1fHpgw5BxN4RsuE5jx)_