### PR TITLE
fix(cowork): intercept space navigation so local spaces load via IPC (#147)

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -532,7 +532,10 @@ function shouldInterceptSpaceNavigation(currentUrl, targetUrl) {
   // The SPA must already be loaded on claude.ai; otherwise a real navigation
   // (initial load, auth bounce) is required and must proceed untouched.
   if (cur.protocol !== 'https:' || cur.hostname !== 'claude.ai') return false;
-  // No-op navigation to the exact same route — nothing to intercept.
+  // No intercept when the space page (path + query) is unchanged. A
+  // fragment-only difference is an in-page anchor, not a navigation we need
+  // to convert — so hash is deliberately excluded here. (When we DO intercept
+  // a genuine route change, coworkSpaceRoute() still preserves any hash.)
   if (cur.pathname === tgt.pathname && cur.search === tgt.search) return false;
   return true;
 }

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -499,6 +499,77 @@ function installLinuxMenuInterceptors(electronModule) {
 }
 
 // ============================================================
+// Cowork space navigation intercept (issue #147)
+// ============================================================
+// The Cowork "Projects" feature is served entirely from local, file-backed
+// IPC handlers (CoworkSpaces_$_*). A space created locally lives only on disk
+// (spaces.json) — Anthropic's backend has no record of its ID. Right after
+// creating a space, the webapp performs a FULL-PAGE navigation to
+// https://claude.ai/cowork/space/<id>. That round-trips to the backend, which
+// can't find the space and serves the "Project not found" page, so the
+// locally-stored space never gets a chance to load over IPC.
+//
+// Fix: catch that hard navigation while the SPA is already loaded on claude.ai
+// and convert it into an in-app (client-side) route change. The already-running
+// webapp then renders the space page and fetches its data via IPC instead of
+// hitting the backend.
+//
+// shouldInterceptSpaceNavigation() is intentionally narrow: it only fires for a
+// same-origin claude.ai cowork *space* URL when the SPA is already loaded on
+// claude.ai and the route is actually changing. First loads, auth redirects,
+// and external links are all left untouched.
+function shouldInterceptSpaceNavigation(currentUrl, targetUrl) {
+  let cur, tgt;
+  try {
+    cur = new URL(currentUrl);
+    tgt = new URL(targetUrl);
+  } catch (_) {
+    return false;
+  }
+  // Target must be a same-origin claude.ai cowork space route.
+  if (tgt.protocol !== 'https:' || tgt.hostname !== 'claude.ai') return false;
+  if (!/^\/cowork\/space\/[^/]+/.test(tgt.pathname)) return false;
+  // The SPA must already be loaded on claude.ai; otherwise a real navigation
+  // (initial load, auth bounce) is required and must proceed untouched.
+  if (cur.protocol !== 'https:' || cur.hostname !== 'claude.ai') return false;
+  // No-op navigation to the exact same route — nothing to intercept.
+  if (cur.pathname === tgt.pathname && cur.search === tgt.search) return false;
+  return true;
+}
+
+// Extract the SPA route (path + query + fragment) from a full space URL.
+// Returns null for anything that isn't parseable.
+function coworkSpaceRoute(targetUrl) {
+  try {
+    const u = new URL(targetUrl);
+    return u.pathname + u.search + u.hash;
+  } catch (_) {
+    return null;
+  }
+}
+
+// Build the JS injected into the renderer to perform client-side navigation.
+// The route is JSON-encoded (never string-concatenated raw) so a hostile space
+// name/URL cannot break out of the string literal into executable code.
+function buildSpaNavigationScript(route) {
+  const target = JSON.stringify(String(route));
+  return [
+    '(function(){',
+    '  try {',
+    '    var t = ' + target + ';',
+    '    if (location.pathname + location.search + location.hash === t) return;',
+    '    history.pushState({}, "", t);',
+    // Next.js App Router (14.1+) reacts to history.pushState directly; older
+    // routers only listen for popstate. Dispatch both to be safe.
+    '    window.dispatchEvent(new PopStateEvent("popstate", { state: {} }));',
+    '  } catch (e) {',
+    '    try { location.assign(' + target + '); } catch (_) {}',
+    '  }',
+    '})();',
+  ].join('\n');
+}
+
+// ============================================================
 // IPC TAP — must be created before the early ipcMain patch so
 // it can instrument _invokeHandlers before any asar code runs.
 // ============================================================
@@ -1299,6 +1370,21 @@ Module.prototype.require = function(id) {
           });
           contents.on('did-navigate', () => {
             contents.insertCSS(_fixCSS).catch(() => {});
+          });
+          // Issue #147: convert a full-page navigation to a locally-created
+          // Cowork space into an in-app SPA route change, so it loads from IPC
+          // instead of round-tripping to the backend ("Project not found").
+          contents.on('will-navigate', (event, targetUrl) => {
+            let currentUrl = '';
+            try { currentUrl = contents.getURL(); } catch (_) {}
+            if (!shouldInterceptSpaceNavigation(currentUrl, targetUrl)) return;
+            const route = coworkSpaceRoute(targetUrl);
+            if (!route) return;
+            event.preventDefault();
+            console.log('[Cowork] Intercepted space navigation -> SPA route:', route);
+            contents.executeJavaScript(buildSpaNavigationScript(route)).catch((e) => {
+              console.error('[Cowork] SPA navigation failed:', e && e.message);
+            });
           });
         });
         console.log('[Frame Fix] CSS app-region fix registered for all webContents');

--- a/tests/node/current-path/frame_fix_space_nav.test.cjs
+++ b/tests/node/current-path/frame_fix_space_nav.test.cjs
@@ -1,0 +1,150 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// Extract the pure space-navigation helpers from frame-fix-wrapper.js and run
+// them in an isolated vm context. These functions have no closure dependencies,
+// so we can slice from the first helper to the IPC TAP section and evaluate it.
+function loadSpaceNavHelpers() {
+  const wrapperPath = path.join(
+    __dirname, '..', '..', '..', 'stubs', 'frame-fix', 'frame-fix-wrapper.js'
+  );
+  const source = fs.readFileSync(wrapperPath, 'utf8');
+  const start = source.indexOf('function shouldInterceptSpaceNavigation');
+  const end = source.indexOf('// IPC TAP — must be created before the early ipcMain patch');
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('Failed to locate space-nav helper block in ' + wrapperPath);
+  }
+  const block = source.slice(start, end);
+  const context = {
+    URL, // provided from this realm — vm contexts don't include URL by default
+    JSON,
+    console: { log() {}, error() {} },
+  };
+  vm.createContext(context);
+  vm.runInContext(block, context, { filename: path.basename(wrapperPath) });
+  return context;
+}
+
+const helpers = loadSpaceNavHelpers();
+const { shouldInterceptSpaceNavigation, coworkSpaceRoute, buildSpaNavigationScript } = helpers;
+
+test('intercepts an in-app navigation to a locally-created space', () => {
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork',
+      'https://claude.ai/cowork/space/100750d9-4cfa-4248-909e-0c87b64f0a54'
+    ),
+    true
+  );
+});
+
+test('intercepts with query/fragment on the space route', () => {
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork/space/aaa',
+      'https://claude.ai/cowork/space/bbb?tab=files#top'
+    ),
+    true
+  );
+});
+
+test('does NOT intercept the initial/hard load (SPA not yet on claude.ai)', () => {
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'about:blank',
+      'https://claude.ai/cowork/space/abc'
+    ),
+    false
+  );
+});
+
+test('does NOT intercept auth/external hosts', () => {
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork',
+      'https://auth.anthropic.com/oauth?next=/cowork/space/abc'
+    ),
+    false
+  );
+  // current host is not claude.ai -> real navigation must proceed untouched
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://evil.example/cowork/space/abc',
+      'https://claude.ai/cowork/space/abc'
+    ),
+    false
+  );
+});
+
+test('does NOT intercept non-space cowork routes', () => {
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork',
+      'https://claude.ai/cowork/settings'
+    ),
+    false
+  );
+  // /cowork/space with no id is not a specific space
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork',
+      'https://claude.ai/cowork/space/'
+    ),
+    false
+  );
+});
+
+test('does NOT intercept a no-op navigation to the same route', () => {
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork/space/abc',
+      'https://claude.ai/cowork/space/abc'
+    ),
+    false
+  );
+});
+
+test('does NOT intercept http (non-https) targets', () => {
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork',
+      'http://claude.ai/cowork/space/abc'
+    ),
+    false
+  );
+});
+
+test('returns false on unparseable urls instead of throwing', () => {
+  assert.equal(shouldInterceptSpaceNavigation('not a url', 'also not'), false);
+  assert.equal(shouldInterceptSpaceNavigation(null, undefined), false);
+});
+
+test('coworkSpaceRoute returns path + query + fragment', () => {
+  assert.equal(
+    coworkSpaceRoute('https://claude.ai/cowork/space/abc?tab=files#top'),
+    '/cowork/space/abc?tab=files#top'
+  );
+  assert.equal(coworkSpaceRoute('::::not a url'), null);
+});
+
+test('buildSpaNavigationScript JSON-encodes the route (injection-safe)', () => {
+  const script = buildSpaNavigationScript('/cowork/space/abc');
+  assert.match(script, /history\.pushState/);
+  assert.match(script, /popstate/);
+  assert.match(script, /"\/cowork\/space\/abc"/);
+
+  // A hostile route containing a quote + script terminator must stay a string
+  // literal, never break out into executable code.
+  const hostile = '/cowork/space/x";alert(1);//';
+  const hostileScript = buildSpaNavigationScript(hostile);
+  // The route must appear only as a JSON-encoded string literal, and the
+  // generated script must itself be syntactically valid JS — so a hostile
+  // route cannot break out of the string into executable code.
+  assert.ok(hostileScript.includes(JSON.stringify(hostile)));
+  assert.doesNotThrow(() => new vm.Script(hostileScript));
+});

--- a/tests/node/current-path/frame_fix_space_nav.test.cjs
+++ b/tests/node/current-path/frame_fix_space_nav.test.cjs
@@ -14,8 +14,10 @@ function loadSpaceNavHelpers() {
     __dirname, '..', '..', '..', 'stubs', 'frame-fix', 'frame-fix-wrapper.js'
   );
   const source = fs.readFileSync(wrapperPath, 'utf8');
+  // Boundaries are code sentinels (not comment text) so they survive comment
+  // rewraps/punctuation edits around the helper block.
   const start = source.indexOf('function shouldInterceptSpaceNavigation');
-  const end = source.indexOf('// IPC TAP — must be created before the early ipcMain patch');
+  const end = source.indexOf('const ipcTap = createIpcTap();');
   if (start === -1 || end === -1 || end <= start) {
     throw new Error('Failed to locate space-nav helper block in ' + wrapperPath);
   }
@@ -104,6 +106,18 @@ test('does NOT intercept a no-op navigation to the same route', () => {
     shouldInterceptSpaceNavigation(
       'https://claude.ai/cowork/space/abc',
       'https://claude.ai/cowork/space/abc'
+    ),
+    false
+  );
+});
+
+test('does NOT intercept a hash-only change on the same route', () => {
+  // path + query identical, only the fragment differs -> in-page anchor,
+  // not a navigation worth intercepting (hash is excluded from the no-op guard).
+  assert.equal(
+    shouldInterceptSpaceNavigation(
+      'https://claude.ai/cowork/space/abc?tab=files',
+      'https://claude.ai/cowork/space/abc?tab=files#section'
     ),
     false
   );


### PR DESCRIPTION
## What does this change?

Fixes #147 — "Project not found" after creating a Cowork space.

The Cowork "Projects" feature is served entirely from local, file-backed IPC handlers (`CoworkSpaces_$_*`). A space created locally lives only on disk (`spaces.json`); Anthropic's backend has no record of its ID. Right after creation the webapp performs a **full-page** navigation to `https://claude.ai/cowork/space/<id>`, which round-trips to the backend, can't find the space, and renders "Project not found" — the locally-stored space never gets a chance to load over IPC.

This adds a `will-navigate` intercept in `frame-fix-wrapper.js` (registered on the existing `web-contents-created` hook) that:

- catches a hard navigation to a cowork **space** route while the SPA is already loaded on `claude.ai`,
- calls `event.preventDefault()` to stop the backend round-trip, and
- converts it into an in-app client-side route change via `history.pushState` + a `popstate` event, so the already-running webapp renders the space page and fetches its data via IPC.

The decision logic is factored into pure, unit-tested helpers (`shouldInterceptSpaceNavigation` / `coworkSpaceRoute` / `buildSpaNavigationScript`). The injected route is JSON-encoded so a hostile space name/URL cannot break out of the string literal. The intercept is intentionally narrow — first loads, auth redirects, external links, and no-op same-route navigations are all left untouched.

Note: the two secondary fixes described in the issue comment were already present in the tree, so no change was needed for them:
- the `exec_capability_registry` require path is already `./cowork/exec_capability_registry` (frame-fix-wrapper.js:812),
- `createSpaceFolder(parentPath, folderName)` already matches the current asar contract (commit 8653597 / PR #146).

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

- Added `tests/node/current-path/frame_fix_space_nav.test.cjs` (10 cases) covering the intercept decision, route extraction, and injection-safety of the generated script.
- Full node suite green: `node --test 'tests/node/current-path/*.test.cjs'` → 512 passed, 0 failed.
- `node --check stubs/frame-fix/frame-fix-wrapper.js` passes.

- Distro / desktop: not run in a live desktop session (change reasoned + unit-tested; needs a maintainer smoke test on a real Cowork session).
- Tested with `./install.sh --doctor`: n/a in this environment
- Tested a full Cowork session: pending live verification

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning

The intercept only rewrites in-app navigation for same-origin `claude.ai` cowork space routes; the injected script is a fixed template with the route JSON-encoded (no raw interpolation).

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system (not run — no live desktop in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZe2i8j1fedSDzZ6Seqhoi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZe2i8j1fedSDzZ6Seqhoi)_