### PR TITLE
security: CSPRNG for temp/id suffixes + redact home dir from path logs

### DIFF
--- a/stubs/cowork/credential_classifier.js
+++ b/stubs/cowork/credential_classifier.js
@@ -148,10 +148,31 @@ function redactCredentials(text) {
   return out;
 }
 
+function redactHomeDir(text) {
+  // Replace the user's home-directory prefix with '~' in log output so that
+  // absolute paths don't leak the OS username. Desktop logs are routinely
+  // pasted into public bug reports (see the issue templates), so keeping the
+  // username out of them is basic PII hygiene. This is a display-only
+  // transform — it never touches the paths used for filesystem operations.
+  if (typeof text !== 'string' || text.length === 0) return text;
+  let home = typeof global !== 'undefined' ? global.__coworkPasswdHomedir : undefined;
+  if (typeof home !== 'string' || !home) {
+    try {
+      home = require('os').userInfo().homedir;
+    } catch (_) {
+      home = process.env.HOME || '';
+    }
+  }
+  // Guard against an empty or root ('/') home, which would corrupt every path.
+  if (typeof home !== 'string' || home.length < 2) return text;
+  return text.split(home).join('~');
+}
+
 module.exports = {
   classifyEnvEntry,
   isLikelyCredentialKey,
   isLikelyCredentialValue,
   redactCredentials,
+  redactHomeDir,
   shannonEntropy,
 };

--- a/stubs/cowork/credential_classifier.js
+++ b/stubs/cowork/credential_classifier.js
@@ -165,7 +165,13 @@ function redactHomeDir(text) {
   }
   // Guard against an empty or root ('/') home, which would corrupt every path.
   if (typeof home !== 'string' || home.length < 2) return text;
-  return text.split(home).join('~');
+  // Only rewrite `home` when it forms a complete path segment — i.e. it is
+  // immediately followed by a path separator, ends the token, or is followed
+  // by a delimiter. A plain substring replace would corrupt a different path
+  // that merely shares the prefix (e.g. turn /home/bob2 into ~2 when
+  // home=/home/bob).
+  const escaped = home.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(escaped + '(?=/|$|[\\s"\'`:,;)\\]}])', 'g'), '~');
 }
 
 module.exports = {

--- a/stubs/cowork/file_registry.js
+++ b/stubs/cowork/file_registry.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 
@@ -24,7 +25,7 @@ function pathExists(targetPath) {
 }
 
 function createFileId() {
-  return 'file_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+  return 'file_' + Date.now().toString(36) + '_' + crypto.randomBytes(5).toString('hex');
 }
 
 function parseRegistryLines(serializedValue) {

--- a/stubs/cowork/ipc_tap.js
+++ b/stubs/cowork/ipc_tap.js
@@ -25,7 +25,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { redactCredentials } = require('./credential_classifier.js');
+const { redactCredentials, redactHomeDir } = require('./credential_classifier.js');
 const { parseEipcChannel, classifyMethod, isPlatformError } = require('./eipc_channel.js');
 
 const MAX_PAYLOAD_LENGTH = 4000;
@@ -341,7 +341,7 @@ function createIpcTap(options) {
     }
 
     if (logPath) {
-      console.log('[IPC-TAP] Summary written to ' + logPath);
+      console.log('[IPC-TAP] Summary written to ' + redactHomeDir(logPath));
       console.log('[IPC-TAP] ' + summary.registrations + ' registered, '
         + summary.handleCalls + ' invoked, '
         + summary.handleErrors + ' errors ('
@@ -354,7 +354,7 @@ function createIpcTap(options) {
   // Write summary on exit
   process.on('exit', writeSummary);
 
-  console.log('[IPC-TAP] Enabled, logging to ' + (logPath || 'stdout'));
+  console.log('[IPC-TAP] Enabled, logging to ' + (logPath ? redactHomeDir(logPath) : 'stdout'));
 
   return {
     enabled: true,

--- a/stubs/cowork/session_store.js
+++ b/stubs/cowork/session_store.js
@@ -8,6 +8,7 @@ const {
   getTranscriptProjectKeyCandidates,
   sanitizeTranscriptProjectKey,
 } = require('./transcript_store.js');
+const { redactHomeDir } = require('./credential_classifier.js');
 
 // ============================================================================
 // SESSION STORE - SESSION METADATA & STATE MANAGEMENT
@@ -319,7 +320,7 @@ function readSessionAuditInitEntries(sessionDirectory) {
   const parsed = lines.map((line) => parseAuditLine(line));
   const parseFailures = parsed.filter((entry, i) => entry === null && lines[i].trim()).length;
   if (parseFailures > 0) {
-    console.error('[session_store] ' + parseFailures + ' corrupt lines in ' + auditPath);
+    console.error('[session_store] ' + parseFailures + ' corrupt lines in ' + redactHomeDir(auditPath));
   }
   return parsed
     .filter((entry) => (

--- a/stubs/cowork/spaces_store.js
+++ b/stubs/cowork/spaces_store.js
@@ -9,7 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { randomUUID } = require('crypto');
+const { randomUUID, randomBytes } = require('crypto');
 
 // Hard caps to prevent unbounded growth of spaces.json. Even with rate
 // limits a malicious renderer could grow the file to GB scale over time.
@@ -251,10 +251,11 @@ function createSpacesStore(options) {
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
-      // Atomic write: write to temp file then rename. Use random suffix
+      // Atomic write: write to temp file then rename. Use a random suffix
       // (not just pid) so two SpacesStore instances in the same process
-      // can't collide on the temp filename.
-      const tmp = p + '.tmp.' + process.pid + '.' + Math.random().toString(36).slice(2);
+      // can't collide on the temp filename. Use a CSPRNG so the name isn't
+      // predictable (avoids temp-file races/symlink pre-creation).
+      const tmp = p + '.tmp.' + process.pid + '.' + randomBytes(8).toString('hex');
       fs.writeFileSync(tmp, payload, 'utf8');
       fs.renameSync(tmp, p);
       return true;

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -93,6 +93,7 @@ const { createIpcTap } = require('./cowork/ipc_tap.js');
 const { createOverrideRegistry, matchOverride, extractEipcUuid, proactivelyRegisterOverrides, isProactiveChannel } = require('./cowork/ipc_overrides.js');
 const { createAutoPermissionsCap } = require('./cowork/auto_permissions_cap.js');
 const { createBridgeCanary } = require('./cowork/bridge_canary.js');
+const { redactHomeDir } = require('./cowork/credential_classifier.js');
 
 // Single cap instance for the process. Closure-private state lives inside
 // the factory; we just keep the wrapHandler reference. The cap is one of
@@ -250,7 +251,7 @@ function setupAssetDumper(win) {
         fs.writeFile(path.join(dumpDir, safeName), body, () => {
           dumpCount++;
           if (dumpCount <= 5 || dumpCount % 10 === 0) {
-            console.log('[Asset Dump] ' + dumpCount + ' files -> ' + dumpDir);
+            console.log('[Asset Dump] ' + dumpCount + ' files -> ' + redactHomeDir(dumpDir));
           }
         });
       }).catch(() => {});
@@ -260,8 +261,8 @@ function setupAssetDumper(win) {
   console.log('');
   console.log('╔══════════════════════════════════════════════════════════════╗');
   console.log('║  DEVTOOLS MODE  —  Asset dumper active                      ║');
-  console.log('║  Current: ' + dumpDir.padEnd(49) + '║');
-  console.log('║  Backup:  ' + bakDir.padEnd(49) + '║');
+  console.log('║  Current: ' + redactHomeDir(dumpDir).padEnd(49) + '║');
+  console.log('║  Backup:  ' + redactHomeDir(bakDir).padEnd(49) + '║');
   console.log('║  Diff with: diff <dir> <dir.bak> to spot protocol changes   ║');
   console.log('╚══════════════════════════════════════════════════════════════╝');
   console.log('');

--- a/tests/node/current-path/credential_classifier.test.cjs
+++ b/tests/node/current-path/credential_classifier.test.cjs
@@ -208,6 +208,22 @@ describe('redactHomeDir', () => {
     });
   });
 
+  it('does NOT rewrite a different dir that shares the home prefix', () => {
+    // Regression: a plain substring replace would turn /home/testuser2/a
+    // into ~2/a. Only a complete path segment should be rewritten.
+    withHome(HOME, () => {
+      assert.equal(redactHomeDir('/home/testuser2/a'), '/home/testuser2/a');
+      assert.equal(redactHomeDir('/home/testuserX'), '/home/testuserX');
+    });
+  });
+
+  it('rewrites the home path when it is the entire token', () => {
+    withHome(HOME, () => {
+      assert.equal(redactHomeDir('/home/testuser'), '~');
+      assert.equal(redactHomeDir('cwd=/home/testuser done'), 'cwd=~ done');
+    });
+  });
+
   it('returns non-string / empty input unchanged', () => {
     withHome(HOME, () => {
       assert.equal(redactHomeDir(''), '');

--- a/tests/node/current-path/credential_classifier.test.cjs
+++ b/tests/node/current-path/credential_classifier.test.cjs
@@ -8,6 +8,7 @@ const {
   isLikelyCredentialKey,
   isLikelyCredentialValue,
   redactCredentials,
+  redactHomeDir,
   shannonEntropy,
 } = require('../../../stubs/cowork/credential_classifier.js');
 
@@ -164,5 +165,63 @@ describe('redactCredentials', () => {
     const input = 'version=3.0.7-beta.1';
     const result = redactCredentials(input);
     assert.ok(!result.includes('[REDACTED]'));
+  });
+});
+
+describe('redactHomeDir', () => {
+  const HOME = '/home/testuser';
+  let prevHome;
+
+  // Pin the home directory via the global the wrapper sets, so the result is
+  // deterministic regardless of the machine running the tests.
+  function withHome(home, fn) {
+    prevHome = global.__coworkPasswdHomedir;
+    global.__coworkPasswdHomedir = home;
+    try {
+      return fn();
+    } finally {
+      global.__coworkPasswdHomedir = prevHome;
+    }
+  }
+
+  it('replaces the home-directory prefix with ~', () => {
+    withHome(HOME, () => {
+      assert.equal(
+        redactHomeDir('logging to /home/testuser/.local/state/claude-cowork/logs'),
+        'logging to ~/.local/state/claude-cowork/logs'
+      );
+    });
+  });
+
+  it('replaces every occurrence in the string', () => {
+    withHome(HOME, () => {
+      assert.equal(
+        redactHomeDir('/home/testuser/a and /home/testuser/b'),
+        '~/a and ~/b'
+      );
+    });
+  });
+
+  it('leaves paths outside the home directory untouched', () => {
+    withHome(HOME, () => {
+      assert.equal(redactHomeDir('/usr/bin/claude'), '/usr/bin/claude');
+    });
+  });
+
+  it('returns non-string / empty input unchanged', () => {
+    withHome(HOME, () => {
+      assert.equal(redactHomeDir(''), '');
+      assert.equal(redactHomeDir(null), null);
+      assert.equal(redactHomeDir(42), 42);
+    });
+  });
+
+  it('does not corrupt paths when home is root or empty', () => {
+    withHome('/', () => {
+      assert.equal(redactHomeDir('/usr/bin/claude'), '/usr/bin/claude');
+    });
+    withHome('', () => {
+      assert.equal(redactHomeDir('/usr/bin/claude'), '/usr/bin/claude');
+    });
   });
 });


### PR DESCRIPTION
## What does this change?

Addresses the open CodeQL code-scanning alerts.

**Insecure randomness (1 alert).** Replaces the two remaining `Math.random()` uses with `crypto.randomBytes()`:
- `spaces_store.js` atomic-write temp-file suffix — a predictable temp name invites temp-file races / symlink pre-creation, so it now uses a CSPRNG.
- `file_registry.js` file-id generator — switched to CSPRNG as well.

The alert's cited location (`transcript_store.js:417`) no longer contains any randomness — that code was removed in earlier hardening, so that alert is stale and should auto-close on the next scan. These were the only live `Math.random()` uses left.

**Clear-text logging of paths (6 alerts).** Every flagged line logged a **directory path** (not a credential), but those paths embed the OS username and desktop logs are routinely pasted into public bug reports (issue #147 itself shows `/home/gc/…`). A new `redactHomeDir()` helper rewrites the home-directory prefix to `~`, and the flagged log statements in the asset dumper, `ipc_tap`, and `session_store` now pass their paths through it. The helper is display-only and never touches paths used for filesystem I/O.

> Note: CodeQL flags these because the value flows from `process.env` to a log sink regardless of content, so the six logging alerts may still need manual dismissal as false positives in the Security tab even with this redaction in place. Happy to adjust if you'd prefer a different approach (e.g. dismiss-only, no code change).

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

- Added `redactHomeDir` unit tests (prefix rewrite, multiple occurrences, non-home paths untouched, non-string input, root/empty-home guard) in `credential_classifier.test.cjs`.
- Full node suite green: `node --test 'tests/node/current-path/*.test.cjs'` → 518 passed, 0 failed.
- `node --check` clean on all six changed source files.

- Distro / desktop: not run in a live desktop session (pure logic + logging changes, unit-tested).
- Tested with `./install.sh --doctor`: n/a in this environment
- Tested a full Cowork session: n/a

## Security impact

- [ ] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code — explanation below:

Tightens randomness (CSPRNG for temp/id suffixes) and reduces username/PII exposure in log output. No change to credential handling, token passthrough, spawning, or path-safety checks — `redactHomeDir()` is applied only to log strings, never to paths used for I/O.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system (not run — no live desktop in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZe2i8j1fedSDzZ6Seqhoi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZe2i8j1fedSDzZ6Seqhoi)_