### PR TITLE
fix(cowork): remove dead per-session global-config symlink workaround

### DIFF
--- a/stubs/cowork/session_orchestrator.js
+++ b/stubs/cowork/session_orchestrator.js
@@ -669,16 +669,6 @@ class SessionOrchestrator {
       translateVmPathStrict,
     });
 
-    // Symlink global config (skills, commands, etc.) into session .claude dir
-    if (typeof hostConfigDir === 'string' && hostConfigDir.trim()) {
-      try {
-        const resolvedConfigDir = fs.realpathSync(hostConfigDir);
-        symlinkGlobalConfig(resolvedConfigDir, trace);
-      } catch (e) {
-        trace('WARNING: Could not resolve CLAUDE_CONFIG_DIR for global config symlinks: ' + e.message);
-      }
-    }
-
     // Step 8: Update sessions API with OAuth token if available
     const spawnOAuthToken = translatedEnvVars.CLAUDE_CODE_OAUTH_TOKEN;
     if (
@@ -1830,65 +1820,12 @@ function transformSdkMessages(messages, sessionIdOverride) {
   return mergeConsecutiveAssistantMessages(normalizedMessages);
 }
 
-// Global Claude Code config directory (skills, commands, settings, etc.)
+// Global Claude Code config directory (~/.claude). Cowork now reads the user's
+// global config (CLAUDE.md, settings.json, plugins, etc.) directly from this
+// standard location, so it no longer needs to be composed into per-session
+// config dirs. It is only referenced here to locate the user's local skills
+// for --plugin-dir injection.
 const GLOBAL_CLAUDE_DIR = path.join(global.__coworkPasswdHomedir || os.userInfo().homedir, '.claude');
-
-/**
- * Symlink global Claude Code config into a session's CLAUDE_CONFIG_DIR.
- *
- * The CLI uses CLAUDE_CONFIG_DIR as its config root, which points to the
- * per-session .claude dir. Without these symlinks, the CLI can't find
- * the user's global skills, commands, settings, hooks, or CLAUDE.md.
- *
- * Only read-mostly global config is symlinked. Session-specific dirs
- * (projects, plans, session-env, backups, shell-snapshots) are left alone
- * so transcript storage and session isolation work correctly.
- *
- * @param {string} sessionClaudeDir - Resolved host path to session .claude dir
- * @param {function} [trace] - Logging function
- */
-function symlinkGlobalConfig(sessionClaudeDir, trace = () => {}) {
-  if (!fs.existsSync(GLOBAL_CLAUDE_DIR)) {
-    trace('No global .claude dir found, skipping config symlinks');
-    return;
-  }
-
-  const GLOBAL_DIRS = ['commands', 'skills', 'agents', 'hooks', 'plugins'];
-  const GLOBAL_FILES = ['CLAUDE.md', 'settings.json', 'settings.local.json'];
-
-  trace('=== SYMLINK GLOBAL CONFIG ===');
-  trace('Global: ' + GLOBAL_CLAUDE_DIR);
-  trace('Session: ' + sessionClaudeDir);
-
-  for (const name of [...GLOBAL_DIRS, ...GLOBAL_FILES]) {
-    const globalPath = path.join(GLOBAL_CLAUDE_DIR, name);
-    const sessionPath = path.join(sessionClaudeDir, name);
-
-    if (!fs.existsSync(globalPath)) {
-      continue;
-    }
-
-    try {
-      const stat = fs.lstatSync(sessionPath);
-      if (stat.isSymbolicLink() && fs.readlinkSync(sessionPath) === globalPath) {
-        continue;
-      }
-      trace('  SKIP ' + name + ': session already has its own copy');
-      continue;
-    } catch (_) {
-      // lstatSync throws if path doesn't exist -- create the symlink
-    }
-
-    try {
-      fs.symlinkSync(globalPath, sessionPath);
-      trace('  LINKED ' + name + ' -> ' + globalPath);
-    } catch (e) {
-      trace('  ERROR linking ' + name + ': ' + e.message);
-    }
-  }
-
-  trace('=== END GLOBAL CONFIG ===');
-}
 
 function createSessionOrchestrator(deps) {
   const orchestrator = new SessionOrchestrator(deps);
@@ -1903,7 +1840,6 @@ module.exports = {
   SessionOrchestrator,
   createSessionOrchestrator,
   removeResumeArgs,
-  symlinkGlobalConfig,
   // Bridge credential helpers
   readRemoteSessionIdFromBridgeState,
   // Bridge spawn args (exported for testing)


### PR DESCRIPTION
## What does this change?

Removes `symlinkGlobalConfig()` from `stubs/cowork/session_orchestrator.js` — the workaround that symlinked `~/.claude/*` (`CLAUDE.md`, `settings.json`, `plugins`, `commands`, `hooks`, `agents`, `skills`) into each per-session `.claude` config dir.

This dates from when the Cowork CLI read its config **only** from the per-session `CLAUDE_CONFIG_DIR`, so global config had to be composed into that dir to be seen. Cowork now reads global config directly from the standard `~/.claude` location, so this composition is unnecessary. It was also dead/unreached in practice — no session `.claude` dir ever actually received the symlinks (see #150).

Removed:
- the spawn-time call site (Step 7 block in `buildPreparedSpawn`)
- the `symlinkGlobalConfig()` function definition
- its entry in `module.exports`

Kept `GLOBAL_CLAUDE_DIR`, which is still used to inject the user's local skills (`~/.claude/skills`) as a `--plugin-dir`, and updated its comment to reflect that this is now its only use.

Fixes #150

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

- Distro / desktop: N/A (logic change in the orchestration stub)
- `node --check stubs/cowork/session_orchestrator.js` passes
- Full node test suite green: `node --test tests/node/current-path/*.test.cjs` → **520 pass / 0 fail** (66 suites), including `session_orchestrator.test.cjs`, `process_manager.test.cjs`, and `security_hardening.test.cjs`
- Confirmed no remaining references to `symlinkGlobalConfig` in `stubs/`, `tests/`, or the patched `index.js`

## Security impact

- [ ] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code — explanation below:

The removed code lives in the spawn-preparation path but only performed filesystem symlink side-effects (linking read-mostly global config into session dirs). It does **not** alter `filterEnv`, env/token passthrough, spawn arguments, `AuthRequest`, or `isPathSafe`. Net effect is strictly fewer filesystem writes during session spawn; env and credential handling are unchanged.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system (not run in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127CPB9dTYFYEKNaec5AnVM

---
_Generated by [Claude Code](https://claude.ai/code/session_0127CPB9dTYFYEKNaec5AnVM)_