### PR TITLE
fix: support Claude Desktop asar 1.19367.0 (split entry + code moved to chunk)

### DIFF
--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -146,8 +146,12 @@ def patch_host_platform(filepath):
 # add a file:// origin exemption at each call site: the original FUNC(i) still
 # validates non-file:// origins (e.g. would reject http://evil.com), so the
 # defense-in-depth layer is preserved for everything except our local renderer.
+# The validator name and the sender-arg name are both minified and rotate per
+# build (e.g. the arg was `i` in older builds and is `n` in 1.19367.0; validator
+# names like `$m` even contain `$`), so match both with [\w$]+ and reuse the
+# captured arg in the exemption rather than hardcoding it.
 IPC_ORIGIN_GUARD_RE = re.compile(
-    r'if\(!(\w+)\(i\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
+    r'if\(!([\w$]+)\(([\w$]+)\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
 )
 IPC_PATCH_MARKER = '/*cowork-ipc-patched*/'
 
@@ -162,10 +166,11 @@ def patch_ipc_origin_guards(filepath):
         print(f"  IPC origin guards: already patched")
         return True
 
-    # Replace if(!FUNC(i)) with if(!FUNC(i)&&!(i.senderFrame&&i.senderFrame.url&&i.senderFrame.url.startsWith("file://")))
+    # Replace if(!FUNC(ARG)) with
+    #   if(!FUNC(ARG)&&!(ARG.senderFrame&&ARG.senderFrame.url&&ARG.senderFrame.url.startsWith("file://")))
     # This lets file:// through while keeping the validator for everything else.
     new_content, count = IPC_ORIGIN_GUARD_RE.subn(
-        r'if(!\1(i)&&!(i.senderFrame&&i.senderFrame.url&&i.senderFrame.url.startsWith("file://")))\2',
+        r'if(!\1(\2)&&!(\2.senderFrame&&\2.senderFrame.url&&\2.senderFrame.url.startsWith("file://")))\3',
         content
     )
     if count == 0:

--- a/install.sh
+++ b/install.sh
@@ -694,7 +694,8 @@ seed_version_sentinel() {
 # ============================================================
 
 apply_patches() {
-    local index_js="$INSTALL_DIR/linux-app-extracted/.vite/build/index.js"
+    local build_dir="$INSTALL_DIR/linux-app-extracted/.vite/build"
+    local index_js="$build_dir/index.js"
     local script_dir
     script_dir=$(cd "$(dirname "$0")" && pwd)
     local patch_script=""
@@ -706,13 +707,29 @@ apply_patches() {
         patch_script="$INSTALL_DIR/enable-cowork.py"
     fi
 
-    if [[ -n "$patch_script" && -f "$index_js" ]]; then
-        log_info "Applying cowork patch..."
-        python3 "$patch_script" "$index_js" || log_warn "Patch may have already been applied"
-        log_success "Patches applied"
-    else
+    if [[ -z "$patch_script" || ! -f "$index_js" ]]; then
         log_warn "Patch script or index.js not found, skipping patches"
+        return
     fi
+
+    # Newer Claude Desktop builds emit index.js as a thin entry shim that
+    # require()s the real main code from an index.chunk-<hash>.js file, so the
+    # platform-gate / IPC / host-platform patterns live in the chunk, not in
+    # index.js. Patch index.js plus every chunk it require()s; enable-cowork.py
+    # is idempotent (marker-guarded) and reports "not found" harmlessly for
+    # files that don't contain a given pattern.
+    local -a targets=("$index_js")
+    local chunk
+    while IFS= read -r chunk; do
+        [[ -n "$chunk" && -f "$build_dir/$chunk" ]] && targets+=("$build_dir/$chunk")
+    done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$index_js" | sort -u)
+
+    log_info "Applying cowork patch to ${#targets[@]} file(s)..."
+    local t
+    for t in "${targets[@]}"; do
+        python3 "$patch_script" "$t" || log_warn "Patch may have already been applied: ${t##*/}"
+    done
+    log_success "Patches applied"
 }
 
 # ============================================================

--- a/launch.sh
+++ b/launch.sh
@@ -119,26 +119,56 @@ if [ -f "$PKG_JSON" ] && grep -q '"main":.*index\.pre\.js"' "$PKG_JSON"; then
   sed -i 's|"main":.*"\.vite/build/index\.pre\.js"|"main": "frame-fix-entry.js"|' "$PKG_JSON"
 fi
 
-# Fix window decorations: remove macOS-specific titlebar options from main window
-# The Vite bundle bypasses the frame-fix-wrapper's require interception, so we patch directly.
-INDEX_JS="linux-app-extracted/.vite/build/index.js"
-if [ -f "$INDEX_JS" ] && grep -q 'titleBarOverlay' "$INDEX_JS"; then
-  echo "Patching macOS titlebar options for Linux..."
-  # Main window: remove titleBarStyle:"hidden",titleBarOverlay:VAR,trafficLightPosition:VAR,
-  sed -i 's/titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_]\+,trafficLightPosition:[A-Za-z0-9_]\+,//g' "$INDEX_JS"
-  # About window: remove titleBarStyle:"hiddenInset" (keep other options)
-  sed -i 's/titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g' "$INDEX_JS"
+# ── Locate the main-process code file(s) ────────────────────────────────────
+# Vite compiles the main process into .vite/build/. Newer Claude Desktop builds
+# emit index.js as a thin entry shim that require()s the real code from an
+# index.chunk-<hash>.js file (the <hash> changes every build); older builds keep
+# everything in index.js. The patches below must run against whichever file
+# actually holds the code, so collect index.js plus every chunk it require()s.
+# Applying each grep-guarded patch across all of them is safe: a file that lacks
+# the pattern is skipped. This also survives minifier identifier rotation because
+# the patterns below match on stable API/string tokens, not minified var names.
+_BUILD_DIR="linux-app-extracted/.vite/build"
+INDEX_TARGETS=()
+if [ -f "$_BUILD_DIR/index.js" ]; then
+  INDEX_TARGETS+=("$_BUILD_DIR/index.js")
+  while IFS= read -r _chunk; do
+    [ -n "$_chunk" ] && [ -f "$_BUILD_DIR/$_chunk" ] && INDEX_TARGETS+=("$_BUILD_DIR/$_chunk")
+  done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$_BUILD_DIR/index.js" | sort -u)
 fi
+
+# patch_index "<log message>" "<grep -E guard>" "<sed -E script>"
+# Runs the sed against every main-process code file matching the guard; logs once
+# if any file matched. Minified identifiers are matched with [A-Za-z0-9_$]+ so the
+# patches keep working when a new build reshuffles variable names.
+patch_index() {
+  local msg="$1" pat="$2" script="$3" f matched=""
+  for f in "${INDEX_TARGETS[@]}"; do
+    if grep -qE "$pat" "$f" 2>/dev/null; then
+      sed -i -E "$script" "$f"
+      matched=1
+    fi
+  done
+  [ -n "$matched" ] && echo "$msg"
+}
+
+# Fix window decorations: remove macOS-specific titlebar options from the windows.
+# The Vite bundle bypasses the frame-fix-wrapper's require interception, so we patch directly.
+patch_index "Patching macOS titlebar options for Linux (main window)..." \
+  'titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_$]+,trafficLightPosition:[A-Za-z0-9_$]+,' \
+  's/titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_$]+,trafficLightPosition:[A-Za-z0-9_$]+,//g'
+patch_index "Patching macOS titlebar options for Linux (about window)..." \
+  'titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0' \
+  's/titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g'
 
 # Fix origin validation: the asar's nue() function rejects file:// preloads
 # when app.isPackaged is false (which it always is when running via `electron .asar`).
 # This causes the mainWindow/findInPage preloads to crash before exposing `process`
 # via contextBridge, breaking the renderer shell. Drop the isPackaged requirement
 # for file:// origins — the content is inside our asar, so there's no security risk.
-if [ -f "$INDEX_JS" ] && grep -q 'e\.protocol==="file:"&&Ee\.app\.isPackaged===!0' "$INDEX_JS"; then
-  echo "Patching origin validation for file:// preloads..."
-  sed -i 's/e\.protocol==="file:"&&Ee\.app\.isPackaged===!0/e.protocol==="file:"/g' "$INDEX_JS"
-fi
+patch_index "Patching origin validation for file:// preloads..." \
+  '[A-Za-z0-9_$]+\.protocol==="file:"&&[A-Za-z0-9_$]+\.app\.isPackaged===!0' \
+  's/([A-Za-z0-9_$]+)\.protocol==="file:"&&[A-Za-z0-9_$]+\.app\.isPackaged===!0/\1.protocol==="file:"/g'
 
 # Fix preload origin validation: the mainView.js preload's h() guard checks
 # if window.location.href origin matches claude.ai/preview.claude.ai etc.
@@ -154,18 +184,18 @@ fi
 
 # Fix --effort xhigh: Claude Desktop may pass --effort xhigh but the SDK binary
 # only supports low/medium/high/max. Remap xhigh -> max in the CLI arg builder.
-if [ -f "$INDEX_JS" ] && grep -q 'O\.push("--effort",this\.options\.effort)' "$INDEX_JS"; then
-  echo "Patching --effort xhigh -> max..."
-  sed -i 's/O\.push("--effort",this\.options\.effort)/O.push("--effort",this.options.effort==="xhigh"?"max":this.options.effort)/' "$INDEX_JS"
-fi
+patch_index "Patching --effort xhigh -> max..." \
+  '[A-Za-z0-9_$]+\.push\("--effort",this\.options\.effort\)' \
+  's/([A-Za-z0-9_$]+)\.push\("--effort",this\.options\.effort\)/\1.push("--effort",this.options.effort==="xhigh"?"max":this.options.effort)/g'
 
 # Fix macOS Handoff API: invalidateCurrentActivity() and setUserActivity() are
 # macOS-only Electron APIs that crash on Linux. Replace with safe no-op fallbacks.
-if [ -f "$INDEX_JS" ] && grep -q 'cA\.app\.invalidateCurrentActivity()' "$INDEX_JS"; then
-  echo "Patching macOS Handoff APIs for Linux..."
-  sed -i 's/cA\.app\.invalidateCurrentActivity()/(cA.app.invalidateCurrentActivity||function(){})()/' "$INDEX_JS"
-  sed -i 's/cA\.app\.setUserActivity(adt,/((cA.app.setUserActivity||function(){}))(adt,/' "$INDEX_JS"
-fi
+patch_index "Patching macOS Handoff API invalidateCurrentActivity for Linux..." \
+  '[A-Za-z0-9_$]+\.app\.invalidateCurrentActivity\(\)' \
+  's/([A-Za-z0-9_$]+)\.app\.invalidateCurrentActivity\(\)/(\1.app.invalidateCurrentActivity||function(){})()/g'
+patch_index "Patching macOS Handoff API setUserActivity for Linux..." \
+  '[A-Za-z0-9_$]+\.app\.setUserActivity\([A-Za-z0-9_$]+,' \
+  's/([A-Za-z0-9_$]+)\.app\.setUserActivity\(([A-Za-z0-9_$]+),/((\1.app.setUserActivity||function(){}))(\2,/g'
 
 # Fix resource path lookup for i18n, shim-lib, icon, etc.
 # The asar uses `app.isPackaged ? process.resourcesPath : <asar-relative path>`.
@@ -174,10 +204,9 @@ fi
 # locales live at /usr/lib/electron39/locales/*.pak (wrong format, wrong path).
 # The fallback branch resolves to resources/ inside our asar, where launch.sh
 # populates resources/i18n/*.json. Always use the fallback so locale JSONs load.
-if [ -f "$INDEX_JS" ] && grep -qE '[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?process\.resourcesPath:' "$INDEX_JS"; then
-  echo "Patching resourcesPath lookups to use asar-internal resources/..."
-  sed -i -E 's/[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?process\.resourcesPath://g' "$INDEX_JS"
-fi
+patch_index "Patching resourcesPath lookups to use asar-internal resources/..." \
+  '[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath:' \
+  's/[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath://g'
 
 # Fix MCP node-host path resolution ("MCP Filesystem: Node host not found").
 # The MCP runtime computes its host paths as
@@ -192,10 +221,9 @@ fi
 # isPackaged-guarded asar-internal lookup. The resourcesPath patch above only
 # matches the bare `isPackaged?process.resourcesPath:` shape, not these join()
 # forms, so this is a separate pass.
-if [ -f "$INDEX_JS" ] && grep -qE '[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?[a-zA-Z_$][a-zA-Z0-9_$]*\.join\(process\.resourcesPath,"app\.asar"' "$INDEX_JS"; then
-  echo "Patching MCP node-host asar paths to use getAppPath()..."
-  sed -i -E 's/([a-zA-Z_$][a-zA-Z0-9_$]*)\.app\.isPackaged\?([a-zA-Z_$][a-zA-Z0-9_$]*)\.join\(process\.resourcesPath,"app\.asar"/\1.app.isPackaged?\2.join(\1.app.getAppPath()/g' "$INDEX_JS"
-fi
+patch_index "Patching MCP node-host asar paths to use getAppPath()..." \
+  '[A-Za-z0-9_$]+\.app\.isPackaged\?[A-Za-z0-9_$]+\.join\(process\.resourcesPath,"app\.asar"' \
+  's/([A-Za-z0-9_$]+)\.app\.isPackaged\?([A-Za-z0-9_$]+)\.join\(process\.resourcesPath,"app\.asar"/\1.app.isPackaged?\2.join(\1.app.getAppPath()/g'
 
 # Only repack if stub is newer than asar (or asar doesn't exist)
 # Repack if any file in the extracted tree is newer than the cached asar.

--- a/stubs/frame-fix/frame-fix-entry.js
+++ b/stubs/frame-fix/frame-fix-entry.js
@@ -1,4 +1,17 @@
 // Load frame fix first
 require('./frame-fix-wrapper.js');
-// Then load patched main (index.js has yukonSilver patches)
-require('./.vite/build/index.js');
+// Load the app's real main entry.
+//
+// Newer Claude Desktop builds split the main process into two files:
+//   index.pre.js  — stashes the @sentry/electron/main namespace on
+//                   globalThis.__sentryElectronMain, then require()s index.js
+//   index.js      — the real main; a sentry shim guard throws
+//                   "globalThis.__sentryElectronMain is unset" if index.pre.js
+//                   did not run first.
+// Requiring index.js directly skips the stash and crashes the main process on
+// launch. Load index.pre.js when present (it chains to index.js itself); fall
+// back to index.js for older single-entry builds that ship no index.pre.js.
+const fs = require('fs');
+const path = require('path');
+const preEntry = path.join(__dirname, '.vite', 'build', 'index.pre.js');
+require(fs.existsSync(preEntry) ? './.vite/build/index.pre.js' : './.vite/build/index.js');


### PR DESCRIPTION
## Problem

Claude Desktop **1.19367.0** restructured its Vite main bundle in two ways that broke the Linux port across the board.

### 1. Split entry point → launch crash
The main process is now `index.pre.js` (stashes the `@sentry/electron/main` namespace on `globalThis.__sentryElectronMain`, then `require()`s `index.js`) + `index.js`. A sentry shim guard throws if `index.pre.js` didn't run first:

```
Error: sentryMainShim: globalThis.__sentryElectronMain is unset — index.pre.js
must stash its @sentry/electron/main namespace before index.js loads.
```

`frame-fix-entry.js` `require()`d `index.js` directly, skipping the stash → main process crashes on launch.

### 2. Main code moved into a chunk → every patch silently no-op'd
`index.js` is now a ~800-byte shim that `require()`s the real main code from `index.chunk-<hash>.js`. **Both** patch mechanisms targeted `.vite/build/index.js`, so both stopped applying:

- **`launch.sh`** (runtime seds): titlebar, file:// origin, `--effort xhigh→max`, macOS Handoff, `resourcesPath`, and the MCP node-host path. The last one surfaced as:
  ```
  MCP Filesystem: Node host not found at:
  …/.config/Claude/cowork-resources/app.asar/.vite/build/mcp-runtime/nodeHost.js
  ```
- **`enable-cowork.py`** (install-time, the actual Cowork *enablers*): the platform gate → `{status:"supported"}`, 711 IPC origin-validation guards (file:// exemption), `getHostPlatform()`, and return-style platform gates. Result: **zero** cowork markers in the packed app.

Four patterns additionally hardcoded minifier-assigned identifiers (`e`, `Ee`, `O`, `cA`, arg `i`, validators like `$m`) that rotate every build.

## Fix

- **`stubs/frame-fix/frame-fix-entry.js`** — load `index.pre.js` when present (it chains to `index.js`), fall back to `index.js` for older single-entry builds.
- **`launch.sh`** — discover the real code file(s) (`index.js` + the chunk it `require()`s) and apply every grep-guarded patch across them via a `patch_index` helper; generalize the four identifier-hardcoded patterns to `[A-Za-z0-9_$]+`.
- **`install.sh`** — `apply_patches` runs `enable-cowork.py` against `index.js` plus every chunk it `require()`s (same discovery as launch.sh).
- **`enable-cowork.py`** — generalize the IPC origin-guard regex: the sender-arg rotated `i`→`n` and some validators contain `$`, so match both with `[\w$]+` and reuse the captured arg in the exemption. Matches all 711 sites on 1.19367.0.

## Verification (end-to-end on asar 1.19367.0)

- App launches, main window opens, no sentry crash.
- MCP filesystem node-host resolves — error gone.
- All eight `launch.sh` patch passes report **applied** (previously zero reached the relocated code).
- All four `enable-cowork.py` patches apply to the chunk; patched chunk passes `node --check`; after repack the cowork markers are embedded in the running app.
- No `did not pass origin validation` throws, no `process is not defined`.