### PR TITLE
fix: load index.pre.js before main entry

### DIFF
--- a/stubs/frame-fix/frame-fix-entry.js
+++ b/stubs/frame-fix/frame-fix-entry.js
@@ -1,4 +1,9 @@
 // Load frame fix first
 require('./frame-fix-wrapper.js');
-// Then load patched main (index.js has yukonSilver patches)
-require('./.vite/build/index.js');
+// Then load the prelude entry (index.pre.js), which is the real main in the
+// upstream package.json. It stashes the @sentry/electron/main namespace into
+// globalThis.__sentryElectronMain and then require()s the patched main
+// (index.js, which carries the yukonSilver patches). Loading index.js directly
+// skips that stash, so the Sentry main shim throws
+// "globalThis.__sentryElectronMain is unset" on Claude Desktop >= 1.19367.0.
+require('./.vite/build/index.pre.js');


### PR DESCRIPTION
## Description
Fixes a launch failure on Claude Desktop >= 1.19367.0 where the app throws `Error: sentryMainShim: globalThis.__sentryElectronMain is unset` in the main process and never opens a window.

## Key changes / New features
- `frame-fix-entry.js` now requires `.vite/build/index.pre.js` instead of `.vite/build/index.js`. `index.pre.js` is the entry declared as `"main"` in the upstream `package.json`: it stashes the `@sentry/electron/main` namespace into `globalThis.__sentryElectronMain` and then requires `index.js`. Loading `index.js` directly skipped that stash, so the newer Sentry main shim threw on startup.
- The patched main is still applied: `index.pre.js` chains into `index.js`, so the yukonSilver patches continue to load unchanged.
- No behavior change on older builds that lack the Sentry pre-stash — `index.pre.js` has always been the real entry point, this restores that order behind the frame-fix wrapper.
- Verified against installed asar `1.19367.0`: window is created and finishes loading, no main-process exception. Full test suite passes (520 tests, `node --test tests/node/current-path/*.test.cjs`).