### PR TITLE
fix(frame-fix): load index.pre.js so the sentry stash runs

### DIFF
--- a/stubs/frame-fix/frame-fix-entry.js
+++ b/stubs/frame-fix/frame-fix-entry.js
@@ -1,4 +1,28 @@
 // Load frame fix first
 require('./frame-fix-wrapper.js');
-// Then load patched main (index.js has yukonSilver patches)
-require('./.vite/build/index.js');
+
+// Then load the real main entry.
+//
+// Newer asars (observed on 1.19367.0) split the Electron main entry in two:
+//   .vite/build/index.pre.js  — the true entry. It stashes the
+//     @sentry/electron/main namespace onto globalThis.__sentryElectronMain
+//     and then require()s ./index.js itself.
+//   .vite/build/index.js      — carries the yukonSilver/cowork patches, but
+//     now begins with a "sentryMainShim" that THROWS if __sentryElectronMain
+//     is unset.
+// Loading index.js directly skips the stash and crashes on startup with
+// "sentryMainShim: globalThis.__sentryElectronMain is unset". Loading
+// index.pre.js runs the stash and then pulls in the (patched) index.js, so
+// the patches still apply.
+//
+// Older asars (<= the 1.6259.1 baseline) have no index.pre.js, so fall back
+// to index.js there. Detect at runtime rather than assuming either layout.
+const fs = require('node:fs');
+const path = require('node:path');
+
+const preEntry = path.join(__dirname, '.vite', 'build', 'index.pre.js');
+if (fs.existsSync(preEntry)) {
+  require('./.vite/build/index.pre.js');
+} else {
+  require('./.vite/build/index.js');
+}


### PR DESCRIPTION
## Problem

Fixes #154. On newer Claude Desktop asars (observed on **1.19367.0**) the app crashes on launch with:

```
Error: sentryMainShim: globalThis.__sentryElectronMain is unset — index.pre.js must stash its @sentry/electron/main namespace before index.js loads.
```

Because it's an uncaught main-process exception, Electron leaves the process alive showing only the error dialog, which then holds the single-instance lock and makes subsequent launches silently `[SingleInstance] Another instance is running, quitting` with no window.

## Root cause

These builds split the Electron main entry into two files:

- `.vite/build/index.pre.js` — the **real** entry. It stashes the `@sentry/electron/main` namespace onto `globalThis.__sentryElectronMain`, then `require("./index.js")` itself.
- `.vite/build/index.js` — carries the yukonSilver/cowork patches, but now begins with a `sentryMainShim` that **throws** if `__sentryElectronMain` is unset.

`frame-fix-entry.js` required `./.vite/build/index.js` directly, so `index.pre.js` never ran, the stash never happened, and the shim threw. Older asars (≤ the 1.6259.1 baseline) had no `index.pre.js`, which is why requiring `index.js` directly worked before.

## Fix

Load `index.pre.js` when it exists (it stashes sentry and then pulls in the still-patched `index.js`), and fall back to `index.js` on older asars that don't have it. Runtime `fs.existsSync` detection keeps **both** layouts working — no version assumption baked in.

## Testing

- asar **1.19367.0**, Electron 43.1.0, Arch/CachyOS, KDE Plasma (KWin) Wayland: app now launches to the main window, Cowork session spawn works, and `startup.log` shows **zero** `sentryMainShim` errors.
- `node --check stubs/frame-fix/frame-fix-entry.js` passes.
- Verified the detection selects `index.pre.js` on this install and would select `index.js` when absent.

## Out of scope

The secondary UX issue noted in #154 — Electron lingering after a fatal load error and holding the single-instance lock — is left for a separate change. This PR removes the crash that triggers it.
