### PR TITLE
fix(frame-fix): load index.pre.js so the sentry stash runs (#154)

### DIFF
--- a/stubs/frame-fix/frame-fix-entry.js
+++ b/stubs/frame-fix/frame-fix-entry.js
@@ -1,4 +1,23 @@
 // Load frame fix first
 require('./frame-fix-wrapper.js');
-// Then load patched main (index.js has yukonSilver patches)
-require('./.vite/build/index.js');
+
+// Then load the patched Electron main process.
+//
+// Newer Claude Desktop builds (observed on asar 1.19367.0+) split the main
+// entry into two files:
+//   - index.pre.js — the real entry: it stashes the @sentry/electron/main
+//     namespace on globalThis.__sentryElectronMain, then require()s index.js.
+//   - index.js — carries the yukonSilver/cowork patches, but now begins with a
+//     "sentryMainShim" guard that throws if __sentryElectronMain is unset.
+// Requiring index.js directly skips the stash, so the shim throws and the main
+// process crashes on launch (issue #154). Older single-entry builds have no
+// index.pre.js and must load index.js directly.
+//
+// Prefer index.pre.js when it exists so the stash runs (it then pulls in the
+// still-patched index.js); fall back to index.js otherwise. Runtime detection
+// keeps both asar layouts working with no version assumption baked in.
+const fs = require('fs');
+const path = require('path');
+const buildDir = path.join(__dirname, '.vite', 'build');
+const preEntry = path.join(buildDir, 'index.pre.js');
+require(fs.existsSync(preEntry) ? preEntry : path.join(buildDir, 'index.js'));


### PR DESCRIPTION
## What does this change?

Fixes the launch crash reported in #154 on newer Claude Desktop asars (observed on **1.19367.0**).

These builds split the Electron main entry into two files:

- `.vite/build/index.pre.js` — the **real** entry: it stashes the `@sentry/electron/main` namespace on `globalThis.__sentryElectronMain`, then `require()`s `index.js`.
- `.vite/build/index.js` — still carries the yukonSilver/cowork patches, but now begins with a `sentryMainShim` guard that **throws** if `__sentryElectronMain` is unset.

`stubs/frame-fix/frame-fix-entry.js` required `./.vite/build/index.js` directly, skipping the stash, so on these builds the shim threw and the main process crashed on launch:

```
Error: sentryMainShim: globalThis.__sentryElectronMain is unset — index.pre.js
must stash its @sentry/electron/main namespace before index.js loads.
```

Because it's an uncaught main-process exception, Electron leaves the dead process alive holding the single-instance lock, so subsequent launches silently `[SingleInstance] Another instance is running, quitting` with no window.

**The fix:** prefer `index.pre.js` when it exists (it chains to the still-patched `index.js`), and fall back to `index.js` on older single-entry builds. Runtime `fs.existsSync` detection keeps **both** asar layouts working with no version assumption baked in.

> **Scope note:** this removes the launch **crash** only. The complementary work — the install/launch patch passes and `enable-cowork.py` also need to target the relocated `index.chunk-*.js` on split-entry builds, or the cowork patches silently no-op — is the larger change tracked in #152, and #156 covers the downstream AUR `PKGBUILD` gaps. This PR intentionally does just the entry-routing half, since it's the confirmed regression and is verifiable without a newer asar. It overlaps with #155 (same one-line intent) and can be closed in favor of whichever the maintainer prefers.

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

This environment has no display and no newer (`1.19367.0`) asar, so a full GUI/install run wasn't possible. Verified by:

- `node --check stubs/frame-fix/frame-fix-entry.js` — passes.
- **Runtime selection exercised** in a stubbed asar layout: with `index.pre.js` present the load order is `frame-fix-wrapper → index.pre.js (stash) → index.js`; with it absent it falls back to `frame-fix-wrapper → index.js`. Both paths behave as intended.
- `node --test tests/node/current-path/*.test.cjs` — **520 passed, 0 failed** (no regression).

- Distro / desktop: n/a (headless CI environment)
- Tested with `./install.sh --doctor`: not run (requires an installed app + display)
- Tested a full Cowork session: not run (no newer asar available here); end-to-end validation on `1.19367.0` is reported in #154/#155

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning

The change only selects which already-present main-entry file to `require()`; it adds no new inputs, spawns nothing, and touches no credential or auth path.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — not runnable in this headless environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVUvcsKUc6vtuYs1PEYnQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVUvcsKUc6vtuYs1PEYnQu)_