### PR TITLE
fix(patch): apply cowork patches across split-entry index.chunk on 1.19367.0+

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -5,16 +5,18 @@ to work with claude-cowork-linux. `install.sh` and the launcher grep the
 machine-readable lines below; the table further down is for humans.
 
 <!-- machine-readable; do not remove the next two lines -->
-<!-- LAST_TESTED_ASAR_VERSION=1.6259.1 -->
-<!-- LAST_TESTED_DATE=2026-05-14 -->
+<!-- LAST_TESTED_ASAR_VERSION=1.19367.0 -->
+<!-- LAST_TESTED_DATE=2026-07-15 -->
 
 ## Tested versions
 
-| Asar     | Status     | Date       | Notes                                                |
-|:---------|:-----------|:-----------|:-----------------------------------------------------|
-| 1.6259.1 | [OK]       | 2026-05-14 | v5.1.0 baseline. Activity stubs and bridge rails verified via test suite. |
-| 1.6608.2 | [PARTIAL]  | 2026-05-07 | `/setup-cowork` reports "Unsupported platform: linux-x64" -- see issue #114. |
-| 1.6700.0 | [UNTESTED] | -          | Not yet exercised by any contributor.                |
+| Asar      | Status     | Date       | Notes                                                |
+|:----------|:-----------|:-----------|:-----------------------------------------------------|
+| 1.6259.1  | [OK]       | 2026-05-14 | v5.1.0 baseline. Activity stubs and bridge rails verified via test suite. |
+| 1.6608.2  | [PARTIAL]  | 2026-05-07 | `/setup-cowork` reports "Unsupported platform: linux-x64" -- see issue #114. |
+| 1.6700.0  | [UNTESTED] | -          | Not yet exercised by any contributor.                |
+| 1.19367.0 | [OK]       | 2026-07-15 | First **split-entry** build: `index.pre.js` + `index.js` shim that require()s the real code from `index.chunk-*.js`. Requires the entry-routing fix (#154/#157) and chunk-aware patching (install.sh/launch.sh/enable-cowork.py discover and patch the chunk; identifier matching generalized for per-build minifier rotation). End-to-end launch + Cowork session reported by contributors in #152/#154; patch logic covered by `tests/test-cowork-patch.sh`. Not re-exercised via a GUI session by a maintainer. |
+| 1.20186.0 | [PARTIAL]  | 2026-07-15 | Split-entry bundle; installer/launcher patching applies as on 1.19367.0. The **AUR** `PKGBUILD` still needs split-bundle handling and a `package.json` `main` rewrite -- see #156. Contributor reports the packed app reaches startup and passes the test suite on this version. |
 
 Status legend:
 

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -146,8 +146,13 @@ def patch_host_platform(filepath):
 # add a file:// origin exemption at each call site: the original FUNC(i) still
 # validates non-file:// origins (e.g. would reject http://evil.com), so the
 # defense-in-depth layer is preserved for everything except our local renderer.
+#
+# The validator name and the sender-arg name are both minified and rotate per
+# build (e.g. the arg was `i` in older builds and is `n` in 1.19367.0; validator
+# names like `$m` even contain `$`), so match both with [\w$]+ and reuse the
+# captured arg in the exemption rather than hardcoding it.
 IPC_ORIGIN_GUARD_RE = re.compile(
-    r'if\(!(\w+)\(i\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
+    r'if\(!([\w$]+)\(([\w$]+)\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
 )
 IPC_PATCH_MARKER = '/*cowork-ipc-patched*/'
 
@@ -162,10 +167,11 @@ def patch_ipc_origin_guards(filepath):
         print(f"  IPC origin guards: already patched")
         return True
 
-    # Replace if(!FUNC(i)) with if(!FUNC(i)&&!(i.senderFrame&&i.senderFrame.url&&i.senderFrame.url.startsWith("file://")))
+    # Replace if(!FUNC(ARG)) with
+    #   if(!FUNC(ARG)&&!(ARG.senderFrame&&ARG.senderFrame.url&&ARG.senderFrame.url.startsWith("file://")))
     # This lets file:// through while keeping the validator for everything else.
     new_content, count = IPC_ORIGIN_GUARD_RE.subn(
-        r'if(!\1(i)&&!(i.senderFrame&&i.senderFrame.url&&i.senderFrame.url.startsWith("file://")))\2',
+        r'if(!\1(\2)&&!(\2.senderFrame&&\2.senderFrame.url&&\2.senderFrame.url.startsWith("file://")))\3',
         content
     )
     if count == 0:

--- a/install.sh
+++ b/install.sh
@@ -694,7 +694,8 @@ seed_version_sentinel() {
 # ============================================================
 
 apply_patches() {
-    local index_js="$INSTALL_DIR/linux-app-extracted/.vite/build/index.js"
+    local build_dir="$INSTALL_DIR/linux-app-extracted/.vite/build"
+    local index_js="$build_dir/index.js"
     local script_dir
     script_dir=$(cd "$(dirname "$0")" && pwd)
     local patch_script=""
@@ -706,13 +707,29 @@ apply_patches() {
         patch_script="$INSTALL_DIR/enable-cowork.py"
     fi
 
-    if [[ -n "$patch_script" && -f "$index_js" ]]; then
-        log_info "Applying cowork patch..."
-        python3 "$patch_script" "$index_js" || log_warn "Patch may have already been applied"
-        log_success "Patches applied"
-    else
+    if [[ -z "$patch_script" || ! -f "$index_js" ]]; then
         log_warn "Patch script or index.js not found, skipping patches"
+        return
     fi
+
+    # Newer Claude Desktop builds emit index.js as a thin entry shim that
+    # require()s the real main code from an index.chunk-<hash>.js file, so the
+    # platform-gate / IPC / host-platform patterns live in the chunk, not in
+    # index.js. Patch index.js plus every chunk it require()s; enable-cowork.py
+    # is idempotent (marker-guarded) and reports "not found" harmlessly for
+    # files that don't contain a given pattern.
+    local -a targets=("$index_js")
+    local chunk
+    while IFS= read -r chunk; do
+        [[ -n "$chunk" && -f "$build_dir/$chunk" ]] && targets+=("$build_dir/$chunk")
+    done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$index_js" | sort -u)
+
+    log_info "Applying cowork patch to ${#targets[@]} file(s)..."
+    local t
+    for t in "${targets[@]}"; do
+        python3 "$patch_script" "$t" || log_warn "Patch may have already been applied: ${t##*/}"
+    done
+    log_success "Patches applied"
 }
 
 # ============================================================

--- a/install.sh
+++ b/install.sh
@@ -724,12 +724,26 @@ apply_patches() {
         [[ -n "$chunk" && -f "$build_dir/$chunk" ]] && targets+=("$build_dir/$chunk")
     done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$index_js" | sort -u)
 
+    # enable-cowork.py exits 0 when it finds (or has already patched) the
+    # platform gate in a file, and 1 otherwise. On split-entry builds the gate
+    # lives in exactly one chunk, so index.js (the shim) and the other files
+    # legitimately exit 1 — that is expected, not a failure. Only treat the run
+    # as successful if at least one target was patched; if none were, the bundle
+    # layout has changed and Cowork would not be enabled, so warn loudly rather
+    # than print a misleading "Patches applied".
     log_info "Applying cowork patch to ${#targets[@]} file(s)..."
-    local t
+    local t any_patched=""
     for t in "${targets[@]}"; do
-        python3 "$patch_script" "$t" || log_warn "Patch may have already been applied: ${t##*/}"
+        if python3 "$patch_script" "$t"; then
+            any_patched=1
+        fi
     done
-    log_success "Patches applied"
+    if [[ -n "$any_patched" ]]; then
+        log_success "Patches applied"
+    else
+        log_warn "Cowork patch matched no target: the platform gate was not found in index.js or any index.chunk-*.js."
+        log_warn "The Claude Desktop bundle layout may have changed; Cowork may not be enabled. See the enable-cowork.py output above."
+    fi
 }
 
 # ============================================================

--- a/launch.sh
+++ b/launch.sh
@@ -119,26 +119,56 @@ if [ -f "$PKG_JSON" ] && grep -q '"main":.*index\.pre\.js"' "$PKG_JSON"; then
   sed -i 's|"main":.*"\.vite/build/index\.pre\.js"|"main": "frame-fix-entry.js"|' "$PKG_JSON"
 fi
 
-# Fix window decorations: remove macOS-specific titlebar options from main window
-# The Vite bundle bypasses the frame-fix-wrapper's require interception, so we patch directly.
-INDEX_JS="linux-app-extracted/.vite/build/index.js"
-if [ -f "$INDEX_JS" ] && grep -q 'titleBarOverlay' "$INDEX_JS"; then
-  echo "Patching macOS titlebar options for Linux..."
-  # Main window: remove titleBarStyle:"hidden",titleBarOverlay:VAR,trafficLightPosition:VAR,
-  sed -i 's/titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_]\+,trafficLightPosition:[A-Za-z0-9_]\+,//g' "$INDEX_JS"
-  # About window: remove titleBarStyle:"hiddenInset" (keep other options)
-  sed -i 's/titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g' "$INDEX_JS"
+# ── Locate the main-process code file(s) ────────────────────────────────────
+# Vite compiles the main process into .vite/build/. Newer Claude Desktop builds
+# emit index.js as a thin entry shim that require()s the real code from an
+# index.chunk-<hash>.js file (the <hash> changes every build); older builds keep
+# everything in index.js. The patches below must run against whichever file
+# actually holds the code, so collect index.js plus every chunk it require()s.
+# Applying each grep-guarded patch across all of them is safe: a file that lacks
+# the pattern is skipped. This also survives minifier identifier rotation because
+# the patterns below match on stable API/string tokens, not minified var names.
+_BUILD_DIR="linux-app-extracted/.vite/build"
+INDEX_TARGETS=()
+if [ -f "$_BUILD_DIR/index.js" ]; then
+  INDEX_TARGETS+=("$_BUILD_DIR/index.js")
+  while IFS= read -r _chunk; do
+    [ -n "$_chunk" ] && [ -f "$_BUILD_DIR/$_chunk" ] && INDEX_TARGETS+=("$_BUILD_DIR/$_chunk")
+  done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$_BUILD_DIR/index.js" | sort -u)
 fi
+
+# patch_index "<log message>" "<grep -E guard>" "<sed -E script>"
+# Runs the sed against every main-process code file matching the guard; logs once
+# if any file matched. Minified identifiers are matched with [A-Za-z0-9_$]+ so the
+# patches keep working when a new build reshuffles variable names.
+patch_index() {
+  local msg="$1" pat="$2" script="$3" f matched=""
+  for f in "${INDEX_TARGETS[@]}"; do
+    if grep -qE "$pat" "$f" 2>/dev/null; then
+      sed -i -E "$script" "$f"
+      matched=1
+    fi
+  done
+  [ -n "$matched" ] && echo "$msg"
+}
+
+# Fix window decorations: remove macOS-specific titlebar options from the windows.
+# The Vite bundle bypasses the frame-fix-wrapper's require interception, so we patch directly.
+patch_index "Patching macOS titlebar options for Linux (main window)..." \
+  'titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_$]+,trafficLightPosition:[A-Za-z0-9_$]+,' \
+  's/titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_$]+,trafficLightPosition:[A-Za-z0-9_$]+,//g'
+patch_index "Patching macOS titlebar options for Linux (about window)..." \
+  'titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0' \
+  's/titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g'
 
 # Fix origin validation: the asar's nue() function rejects file:// preloads
 # when app.isPackaged is false (which it always is when running via `electron .asar`).
 # This causes the mainWindow/findInPage preloads to crash before exposing `process`
 # via contextBridge, breaking the renderer shell. Drop the isPackaged requirement
 # for file:// origins — the content is inside our asar, so there's no security risk.
-if [ -f "$INDEX_JS" ] && grep -q 'e\.protocol==="file:"&&Ee\.app\.isPackaged===!0' "$INDEX_JS"; then
-  echo "Patching origin validation for file:// preloads..."
-  sed -i 's/e\.protocol==="file:"&&Ee\.app\.isPackaged===!0/e.protocol==="file:"/g' "$INDEX_JS"
-fi
+patch_index "Patching origin validation for file:// preloads..." \
+  '[A-Za-z0-9_$]+\.protocol==="file:"&&[A-Za-z0-9_$]+\.app\.isPackaged===!0' \
+  's/([A-Za-z0-9_$]+)\.protocol==="file:"&&[A-Za-z0-9_$]+\.app\.isPackaged===!0/\1.protocol==="file:"/g'
 
 # Fix preload origin validation: the mainView.js preload's h() guard checks
 # if window.location.href origin matches claude.ai/preview.claude.ai etc.
@@ -154,18 +184,18 @@ fi
 
 # Fix --effort xhigh: Claude Desktop may pass --effort xhigh but the SDK binary
 # only supports low/medium/high/max. Remap xhigh -> max in the CLI arg builder.
-if [ -f "$INDEX_JS" ] && grep -q 'O\.push("--effort",this\.options\.effort)' "$INDEX_JS"; then
-  echo "Patching --effort xhigh -> max..."
-  sed -i 's/O\.push("--effort",this\.options\.effort)/O.push("--effort",this.options.effort==="xhigh"?"max":this.options.effort)/' "$INDEX_JS"
-fi
+patch_index "Patching --effort xhigh -> max..." \
+  '[A-Za-z0-9_$]+\.push\("--effort",this\.options\.effort\)' \
+  's/([A-Za-z0-9_$]+)\.push\("--effort",this\.options\.effort\)/\1.push("--effort",this.options.effort==="xhigh"?"max":this.options.effort)/g'
 
 # Fix macOS Handoff API: invalidateCurrentActivity() and setUserActivity() are
 # macOS-only Electron APIs that crash on Linux. Replace with safe no-op fallbacks.
-if [ -f "$INDEX_JS" ] && grep -q 'cA\.app\.invalidateCurrentActivity()' "$INDEX_JS"; then
-  echo "Patching macOS Handoff APIs for Linux..."
-  sed -i 's/cA\.app\.invalidateCurrentActivity()/(cA.app.invalidateCurrentActivity||function(){})()/' "$INDEX_JS"
-  sed -i 's/cA\.app\.setUserActivity(adt,/((cA.app.setUserActivity||function(){}))(adt,/' "$INDEX_JS"
-fi
+patch_index "Patching macOS Handoff API invalidateCurrentActivity for Linux..." \
+  '[A-Za-z0-9_$]+\.app\.invalidateCurrentActivity\(\)' \
+  's/([A-Za-z0-9_$]+)\.app\.invalidateCurrentActivity\(\)/(\1.app.invalidateCurrentActivity||function(){})()/g'
+patch_index "Patching macOS Handoff API setUserActivity for Linux..." \
+  '[A-Za-z0-9_$]+\.app\.setUserActivity\([A-Za-z0-9_$]+,' \
+  's/([A-Za-z0-9_$]+)\.app\.setUserActivity\(([A-Za-z0-9_$]+),/((\1.app.setUserActivity||function(){}))(\2,/g'
 
 # Fix resource path lookup for i18n, shim-lib, icon, etc.
 # The asar uses `app.isPackaged ? process.resourcesPath : <asar-relative path>`.
@@ -174,10 +204,9 @@ fi
 # locales live at /usr/lib/electron39/locales/*.pak (wrong format, wrong path).
 # The fallback branch resolves to resources/ inside our asar, where launch.sh
 # populates resources/i18n/*.json. Always use the fallback so locale JSONs load.
-if [ -f "$INDEX_JS" ] && grep -qE '[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?process\.resourcesPath:' "$INDEX_JS"; then
-  echo "Patching resourcesPath lookups to use asar-internal resources/..."
-  sed -i -E 's/[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?process\.resourcesPath://g' "$INDEX_JS"
-fi
+patch_index "Patching resourcesPath lookups to use asar-internal resources/..." \
+  '[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath:' \
+  's/[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath://g'
 
 # Fix MCP node-host path resolution ("MCP Filesystem: Node host not found").
 # The MCP runtime computes its host paths as
@@ -192,10 +221,9 @@ fi
 # isPackaged-guarded asar-internal lookup. The resourcesPath patch above only
 # matches the bare `isPackaged?process.resourcesPath:` shape, not these join()
 # forms, so this is a separate pass.
-if [ -f "$INDEX_JS" ] && grep -qE '[a-zA-Z_$][a-zA-Z0-9_$]*\.app\.isPackaged\?[a-zA-Z_$][a-zA-Z0-9_$]*\.join\(process\.resourcesPath,"app\.asar"' "$INDEX_JS"; then
-  echo "Patching MCP node-host asar paths to use getAppPath()..."
-  sed -i -E 's/([a-zA-Z_$][a-zA-Z0-9_$]*)\.app\.isPackaged\?([a-zA-Z_$][a-zA-Z0-9_$]*)\.join\(process\.resourcesPath,"app\.asar"/\1.app.isPackaged?\2.join(\1.app.getAppPath()/g' "$INDEX_JS"
-fi
+patch_index "Patching MCP node-host asar paths to use getAppPath()..." \
+  '[A-Za-z0-9_$]+\.app\.isPackaged\?[A-Za-z0-9_$]+\.join\(process\.resourcesPath,"app\.asar"' \
+  's/([A-Za-z0-9_$]+)\.app\.isPackaged\?([A-Za-z0-9_$]+)\.join\(process\.resourcesPath,"app\.asar"/\1.app.isPackaged?\2.join(\1.app.getAppPath()/g'
 
 # Only repack if stub is newer than asar (or asar doesn't exist)
 # Repack if any file in the extracted tree is newer than the cached asar.

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -97,6 +97,22 @@ assert_grep  "$CHUNK" 'return"darwin-x64"'             "getHostPlatform throw ->
 refute_grep  "$CHUNK" 'error:`Unsupported platform'    "return-style platform gate neutralized"
 assert_parses "$CHUNK" "chunk parses after enable-cowork.py"
 
+# Exit-code contract that install.sh apply_patches relies on to log success
+# accurately: a file with the gate (or already patched) exits 0; a shim with no
+# gate exits non-zero. apply_patches only reports success if >=1 target exits 0.
+if python3 "$REPO_ROOT/enable-cowork.py" "$CHUNK" >/dev/null 2>&1; then
+  pass "re-running on an already-patched gate file exits 0 (idempotent)"
+else
+  fail "re-running on an already-patched gate file should exit 0"
+fi
+SHIM="$TMP/shim_index.js"
+printf '"use strict";\nrequire("./index.chunk-V9ybBkRT.js");\n' > "$SHIM"
+if python3 "$REPO_ROOT/enable-cowork.py" "$SHIM" >/dev/null 2>&1; then
+  fail "shim with no platform gate should exit non-zero"
+else
+  pass "shim with no platform gate exits non-zero (apply_patches won't false-succeed)"
+fi
+
 # ---------------------------------------------------------------------------
 section "3. index.js -> chunk discovery (install.sh / launch.sh)"
 # ---------------------------------------------------------------------------

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+# Regression tests for the Cowork patch machinery.
+#
+# Claude Desktop's main bundle is minified, and two things change every build:
+#   1. the minifier reassigns short identifiers (the IPC sender arg was `i` in
+#      older builds and is `n` now; validators can even contain `$`);
+#   2. newer builds split the Vite main entry so index.js becomes a thin shim
+#      that require()s the real code from an index.chunk-<hash>.js file.
+#
+# These tests pin both behaviours so a future build reshuffle can't silently
+# turn the patches into no-ops:
+#   - enable-cowork.py patches a chunk whose identifiers differ from anything
+#     hardcoded (platform gate, IPC origin guards, host-platform, return gate);
+#   - the index.js -> index.chunk discovery used by install.sh / launch.sh finds
+#     the chunk from the shim, and is a clean no-op on single-entry builds;
+#   - launch.sh's patch_index seds apply across a chunk with rotated identifiers.
+#
+# No network or Docker needed. Requires python3 and node.
+#
+#   ./tests/test-cowork-patch.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
+PASS=0; FAIL=0; SKIP=0
+pass() { echo -e "  ${GREEN}PASS${NC} $*"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $*"; FAIL=$((FAIL + 1)); }
+skip() { echo -e "  ${YELLOW}SKIP${NC} $*"; SKIP=$((SKIP + 1)); }
+section() { echo -e "\n${BOLD}=== $* ===${NC}"; }
+
+HAVE_NODE=0
+command -v node >/dev/null 2>&1 && HAVE_NODE=1
+
+# assert_grep <file> <ERE pattern> <label>   — pattern MUST be present
+assert_grep() { if grep -qE "$2" "$1"; then pass "$3"; else fail "$3"; fi; }
+# refute_grep <file> <ERE pattern> <label>   — pattern must be ABSENT
+refute_grep() { if grep -qE "$2" "$1"; then fail "$3"; else pass "$3"; fi; }
+# assert_parses <file> <label>
+assert_parses() {
+  if [[ "$HAVE_NODE" -eq 0 ]]; then skip "$2 (node not installed)"; return; fi
+  if node --check "$1" 2>/dev/null; then pass "$2"; else fail "$2 (node --check failed)"; fi
+}
+
+# The exact discovery used by install.sh apply_patches and launch.sh.
+discover_chunks() { grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$1" | sort -u; }
+
+# Write a chunk exercising every patch site, using identifiers that are NOT the
+# values any older hardcoded pattern used (function qZ9/var r; validator $m/arg
+# n; objects Zq/Yw/Xp/mB/kk/jn; setUserActivity arg qq).
+write_patch_fixture() {
+  cat > "$1" <<'EOF'
+"use strict";
+function qZ9(){const r=process.platform;if(r!=="darwin"&&r!=="win32")return{status:"unsupported",reason:"nope"};return{status:"supported"}}
+const gate=qZ9();
+function checkOrigin(n){if(!$m(n))throw new Error(`Incoming "doThing" call on interface "MyIface" from '${(i=n.senderFrame)==null?void 0:i.url}' did not pass origin validation`)}
+function hostPlat(){if(process.platform==="darwin")return"darwin-x64";throw new Error("Unsupported platform: "+process.platform)}
+function extInstall(){return{status:2,error:`Unsupported platform: ${process.platform} not allowed`}}
+const winOpts={show:!1,titleBarStyle:"hidden",titleBarOverlay:Ab,trafficLightPosition:Cd,webPreferences:{}};
+const aboutOpts={titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0};
+function guard(){return Zq.protocol==="file:"&&Yw.app.isPackaged===!0}
+function buildArgs(){Xp.push("--effort",this.options.effort)}
+function handoff(){mB.app.invalidateCurrentActivity();mB.app.setUserActivity(qq,{})}
+const res=kk.app.isPackaged?process.resourcesPath:someFallback;
+const host=kk.app.isPackaged?jn.join(process.resourcesPath,"app.asar","mcp-runtime","nodeHost.js"):jn.join(kk.app.getAppPath(),"nodeHost.js");
+EOF
+}
+
+# ---------------------------------------------------------------------------
+section "1. Static analysis"
+# ---------------------------------------------------------------------------
+if python3 -c "import ast; ast.parse(open('$REPO_ROOT/enable-cowork.py').read())" 2>/dev/null; then
+  pass "enable-cowork.py parses"; else fail "enable-cowork.py parses"; fi
+for s in launch.sh install.sh; do
+  if bash -n "$REPO_ROOT/$s" 2>/dev/null; then pass "$s syntax"; else fail "$s syntax"; fi
+done
+
+# ---------------------------------------------------------------------------
+section "2. enable-cowork.py on a chunk with rotated identifiers"
+# ---------------------------------------------------------------------------
+CHUNK="$TMP/index.chunk-V9ybBkRT.js"
+write_patch_fixture "$CHUNK"
+assert_parses "$CHUNK" "fixture chunk parses before patching"
+python3 "$REPO_ROOT/enable-cowork.py" "$CHUNK" >/dev/null 2>&1
+assert_grep  "$CHUNK" 'cowork-patched'                 "platform-gate marker present"
+assert_grep  "$CHUNK" 'cowork-ipc-patched'             "IPC marker present"
+assert_grep  "$CHUNK" 'cowork-platform-return-patched' "return-gate marker present"
+assert_grep  "$CHUNK" 'function qZ9\(\)\{return\{status:"supported"\}\}' "platform gate returns supported"
+# IPC guard: validator $m and sender arg n both preserved, file:// exempted
+assert_grep  "$CHUNK" 'if\(!\$m\(n\)&&!\(n\.senderFrame&&n\.senderFrame\.url&&n\.senderFrame\.url\.startsWith\("file://"\)\)\)' \
+             "IPC guard exempts file:// (rotated validator \$m + arg n)"
+assert_grep  "$CHUNK" 'return"darwin-x64"'             "getHostPlatform throw -> darwin-x64"
+refute_grep  "$CHUNK" 'error:`Unsupported platform'    "return-style platform gate neutralized"
+assert_parses "$CHUNK" "chunk parses after enable-cowork.py"
+
+# ---------------------------------------------------------------------------
+section "3. index.js -> chunk discovery (install.sh / launch.sh)"
+# ---------------------------------------------------------------------------
+mkdir -p "$TMP/build"
+printf '"use strict";\nrequire("./index.chunk-V9ybBkRT.js");\n' > "$TMP/build/index.js"
+: > "$TMP/build/index.chunk-V9ybBkRT.js"
+found="$(discover_chunks "$TMP/build/index.js")"
+[[ "$found" == "index.chunk-V9ybBkRT.js" ]] && pass "split-entry: chunk discovered from shim" \
+  || fail "split-entry: chunk discovered from shim (got: '$found')"
+# Single-entry build (no shim) -> discovery finds nothing (clean no-op)
+printf '"use strict";var x=1;\n' > "$TMP/build/single.js"
+[[ -z "$(discover_chunks "$TMP/build/single.js")" ]] && pass "single-entry: no chunk discovered (backward compatible)" \
+  || fail "single-entry: no chunk discovered"
+
+# ---------------------------------------------------------------------------
+section "4. launch.sh patch_index seds on a chunk with rotated identifiers"
+# ---------------------------------------------------------------------------
+# Extract the real patch_index() helper + every patch_index invocation verbatim
+# from launch.sh so this test tracks the shipped code, not a copy.
+BLOCK="$TMP/patch_block.sh"
+awk '/^patch_index\(\) \{/{f=1} f{print} /Only repack if stub/{exit}' "$REPO_ROOT/launch.sh" \
+  | sed '/# Only repack if stub/d' > "$BLOCK"
+NCALLS="$(grep -c '^patch_index ' "$BLOCK" || true)"
+if [[ "${NCALLS:-0}" -lt 1 ]]; then
+  fail "extracted patch_index block from launch.sh (found $NCALLS calls)"
+else
+  pass "extracted patch_index block from launch.sh ($NCALLS calls)"
+  LCHUNK="$TMP/launch_chunk.js"
+  write_patch_fixture "$LCHUNK"
+  ( INDEX_TARGETS=("$LCHUNK"); source "$BLOCK" ) >/dev/null 2>&1
+  refute_grep "$LCHUNK" 'titleBarStyle:"hidden"'                     "main-window titlebar removed"
+  refute_grep "$LCHUNK" 'titleBarStyle:"hiddenInset"'                "about-window titlebar removed"
+  assert_grep "$LCHUNK" 'return Zq\.protocol==="file:"\}'            "origin isPackaged requirement dropped for file://"
+  assert_grep "$LCHUNK" 'this\.options\.effort==="xhigh"\?"max"'     "--effort xhigh -> max"
+  assert_grep "$LCHUNK" '\(mB\.app\.invalidateCurrentActivity\|\|function\(\)\{\}\)\(\)' "Handoff invalidateCurrentActivity no-op fallback"
+  assert_grep "$LCHUNK" '\(mB\.app\.setUserActivity\|\|function\(\)\{\}\)\)\(qq,'          "Handoff setUserActivity no-op fallback"
+  refute_grep "$LCHUNK" 'kk\.app\.isPackaged\?process\.resourcesPath:' "resourcesPath fallback forced"
+  assert_grep "$LCHUNK" 'kk\.app\.isPackaged\?jn\.join\(kk\.app\.getAppPath\(\),"mcp-runtime"' "MCP node-host uses getAppPath()"
+  assert_parses "$LCHUNK" "chunk parses after launch.sh patches"
+fi
+
+# ---------------------------------------------------------------------------
+echo -e "\n${BOLD}Summary:${NC} ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}, ${YELLOW}${SKIP} skipped${NC}"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What does this change?

Follow-up to #157 (which fixed the launch **crash** on split-entry asars). This makes the actual Cowork patches apply on those builds.

Newer Claude Desktop builds (asar **1.19367.0+**) restructured the Vite main bundle in two ways that quietly broke patching:

1. **Code moved into a chunk.** `index.js` became a thin shim that `require()`s the real main code from an `index.chunk-<hash>.js` file. Both patch mechanisms (`enable-cowork.py` at install time, the `launch.sh` runtime seds) targeted only `.vite/build/index.js`, so every patch — platform gate, IPC origin guards, `--effort` remap, macOS Handoff shims, `resourcesPath`, MCP node-host path — silently **no-op'd**.
2. **Minifier identifier rotation.** Several patterns hardcoded minifier-assigned identifiers that change per build (the IPC sender arg went `i` → `n`; some validators contain `$`; objects like `O`/`cA`/`Ee` rotate).

### The fix

- **`enable-cowork.py`** — generalize the IPC origin-guard regex to match a rotated validator **and** sender arg (`[\w$]+`) and reuse the captured arg in the `file://` exemption, instead of hardcoding `i`.
- **`install.sh` (`apply_patches`) and `launch.sh`** — discover `index.js` **plus every `index.chunk-*.js` it `require()`s** and apply every grep-guarded patch across all of them (via a new `patch_index` helper in `launch.sh`); generalize the remaining hardcoded identifiers to `[A-Za-z0-9_$]+`.
- **`tests/test-cowork-patch.sh`** — new regression test (see Testing).
- **`COMPAT.md`** — record `1.19367.0` (first split-entry build) and `1.20186.0`, and advance the machine-readable last-tested marker.

This mirrors the approach in #152; the entry-routing half it also proposed already landed via #157, so this PR is the remaining chunk/identifier work. It does **not** close #156 — that tracks the AUR `PKGBUILD` split-bundle handling, which lives in the AUR repo.

## Type

- [x] Bug fix
- [x] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

No display or newer asar is available in this environment, so validation is by synthetic fixtures + regression against the vendored baseline, not a GUI session:

- **`tests/test-cowork-patch.sh` — 24/24 pass.** Builds a synthetic split-entry layout (an `index.js` shim + a chunk using identifiers that match nothing hardcoded: validator `$m`, sender arg `n`, function `qZ9`, objects `Zq`/`Xp`/`mB`/`kk`/`jn`) and asserts: chunk discovery finds it from the shim (and is a no-op on single-entry); `enable-cowork.py` applies all four patch types with correct output; `launch.sh`'s real `patch_index` block (extracted verbatim) applies all eight seds; every output still `node --check`s.
- **Strict-superset check on the real vendored `index.js`:** the generalized patterns match everything the old hardcoded ones did **plus** latent no-ops they missed on this very baseline — the old `\(i\)` IPC regex matched **0** sites (the baseline's arg is already `n`) while the generalized one matches and correctly rewrites all **341**, and the `--effort` remap (hardcoded `O.push`) was missing the baseline's `z.push`. Fully-patched real `index.js` still parses.
- `node --test tests/node/current-path/*.test.cjs` — **520 passed, 0 failed**.
- `bash -n` on `launch.sh`/`install.sh`, `python3 -c ast.parse` on `enable-cowork.py`.

- Distro / desktop: n/a (headless CI environment)
- Tested with `./install.sh --doctor`: not run (requires an installed app + display)
- Tested a full Cowork session: not run here; end-to-end launch + Cowork session on `1.19367.0` is reported by contributors in #152 / #154, and `1.20186.0` in #156

## Security impact

- [ ] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code — explanation below:

It touches the **IPC origin-validation** patch (`enable-cowork.py`). The semantics are unchanged from the existing patch: the original per-channel validator still runs for every non-`file://` origin (so `http://evil.com` is still rejected); only `file://` — our local renderer loaded from inside the asar — is exempted. The change is purely to *which* call sites are matched: the generalized regex now also matches sites whose minified sender-arg/validator names rotated, and the exemption reuses the **captured** arg rather than assuming `i`, so the injected `startsWith("file://")` check always references the correct variable. No new origins are trusted and no validator is removed. Aligns with the existing origin-exemption rationale documented in `enable-cowork.py` and OAUTH-COMPLIANCE.md.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — not runnable in this headless environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVUvcsKUc6vtuYs1PEYnQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVUvcsKUc6vtuYs1PEYnQu)_