### PR TITLE
fix(PKGBUILD): patch split-entry index.chunk so Cowork enables on asar 1.19367.0+

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Zack Fitch <zack@internetuniverse.org>
 pkgname=claude-cowork-linux
 pkgver=1.1.4010
-pkgrel=11
+pkgrel=12
 pkgdesc="Anthropic Claude Desktop with Cowork (local agent) support for Linux"
 arch=('x86_64')
 url="https://github.com/johnzfitch/claude-cowork-linux"
@@ -160,29 +160,72 @@ JSEOF
         echo "WARN: asar entry-point patch skipped (target not found)"
     fi
 
-    # Strip macOS titlebar opts (Vite ESM bypasses wrapper's require-Proxy).
-    if grep -q 'titleBarOverlay' "$_indexjs"; then
-        sed -i 's/titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_]\+,trafficLightPosition:[A-Za-z0-9_]\+,//g' "$_indexjs"
-        sed -i 's/titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g' "$_indexjs"
-    else
-        echo "WARN: titlebar patch skipped (target not found)"
+    # Locate the main-process code file(s). Newer Claude Desktop builds (asar
+    # 1.19367.0+) emit index.js as a thin entry shim that require()s the real
+    # code from an index.chunk-<hash>.js file (the <hash> rotates every build);
+    # older builds keep everything in index.js. Patches must hit whichever file
+    # actually holds the code, so collect index.js plus every chunk it require()s
+    # and apply each grep-guarded patch across all of them (a file lacking the
+    # pattern is simply skipped).
+    local _build_dir="${_ext}/.vite/build"
+    local -a _index_targets=()
+    if [ -f "$_indexjs" ]; then
+        _index_targets+=("$_indexjs")
+        local _chunk
+        while IFS= read -r _chunk; do
+            [ -n "$_chunk" ] && [ -f "$_build_dir/$_chunk" ] \
+                && _index_targets+=("$_build_dir/$_chunk")
+        done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$_indexjs" | sort -u)
     fi
 
+    # patch_index <log msg> <grep -E guard> <sed -E script>
+    # Runs the sed against every main-process code file matching the guard; logs
+    # once if any matched, warns once if none did. Minified identifiers are
+    # matched with [A-Za-z0-9_$]+ so the patches survive per-build var renaming.
+    patch_index() {
+        local msg="$1" pat="$2" script="$3" f matched=""
+        for f in "${_index_targets[@]}"; do
+            if grep -qE "$pat" "$f" 2>/dev/null; then
+                sed -i -E "$script" "$f"
+                matched=1
+            fi
+        done
+        if [ -n "$matched" ]; then
+            echo "$msg"
+        else
+            echo "WARN: patch skipped (target not found): $msg"
+        fi
+    }
+
+    # Strip macOS titlebar opts (Vite ESM bypasses wrapper's require-Proxy).
+    patch_index "Stripping macOS titlebar options (main window)..." \
+        'titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_$]+,trafficLightPosition:[A-Za-z0-9_$]+,' \
+        's/titleBarStyle:"hidden",titleBarOverlay:[A-Za-z0-9_$]+,trafficLightPosition:[A-Za-z0-9_$]+,//g'
+    patch_index "Stripping macOS titlebar options (about window)..." \
+        'titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0' \
+        's/titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g'
+
     # Drop isPackaged check on file:// preloads (else renderer shell never loads).
-    if grep -q 'e\.protocol==="file:"&&Ee\.app\.isPackaged===!0' "$_indexjs"; then
-        sed -i 's/e\.protocol==="file:"&&Ee\.app\.isPackaged===!0/e.protocol==="file:"/g' "$_indexjs"
-    else
-        echo "WARN: file:// preload patch skipped (target not found)"
-    fi
+    # The protocol/app identifiers are minified and rotate per build, so match
+    # with [A-Za-z0-9_$]+ rather than the old hardcoded e./Ee. names.
+    patch_index "Patching origin validation for file:// preloads..." \
+        '[A-Za-z0-9_$]+\.protocol==="file:"&&[A-Za-z0-9_$]+\.app\.isPackaged===!0' \
+        's/([A-Za-z0-9_$]+)\.protocol==="file:"&&[A-Za-z0-9_$]+\.app\.isPackaged===!0/\1.protocol==="file:"/g'
 
     # Add linux branch to getHostPlatform() (without this, the minified
     # platform switch throws "Unsupported platform: linux-x64" and the
     # ClaudeCode.prepare IPC fails -- Cowork tasks fail in the UI with a
     # generic "Something went wrong" banner).
+    # This inline pass targets index.js only: its insert hardcodes the arch
+    # variable name (A), which is minifier-assigned and unsafe to splice into a
+    # chunk where it may differ. On split-entry builds this switch lives in the
+    # chunk, where enable-cowork.py's host-platform patch (run across all targets
+    # below) handles it instead — so finding nothing here is expected, not a bug.
     if grep -q 'win32-arm64":"win32-x64";throw new Error' "$_indexjs"; then
         sed -i 's|win32-arm64":"win32-x64";throw new Error|win32-arm64":"win32-x64";if(process.platform==="linux")return A==="arm64"?"linux-arm64":"linux-x64";throw new Error|' "$_indexjs"
+        echo "Patched getHostPlatform() linux branch in index.js"
     else
-        echo "WARN: linux-x64 platform patch skipped (target not found)"
+        echo "Note: inline getHostPlatform patch not applied to index.js (handled by enable-cowork.py on split-entry builds)"
     fi
 
     # Duplicate i18n JSONs into resources/i18n/ (bundle reads from both paths).
@@ -204,10 +247,26 @@ JSEOF
         echo "WARN: bash/sh allowlist patch skipped (target not found or already patched)"
     fi
 
-    # Apply cowork patch
-    echo "Applying cowork patch..."
-    python "${_repo}/enable-cowork.py" \
-        "${srcdir}/linux-app-extracted/.vite/build/index.js"
+    # Apply cowork patch. On split-entry builds the platform gate, IPC origin
+    # guards, and host-platform code live in the chunk (not index.js), so run
+    # enable-cowork.py across index.js plus every discovered chunk. The script is
+    # idempotent (marker-guarded) and exits non-zero when a file lacks the
+    # platform gate (expected for the shim and unrelated chunks), so require at
+    # least one target to patch successfully; otherwise fail the build loudly
+    # rather than ship a package where Cowork is silently not enabled.
+    echo "Applying cowork patch to ${#_index_targets[@]} file(s)..."
+    local _t _any_patched=""
+    for _t in "${_index_targets[@]}"; do
+        if python "${_repo}/enable-cowork.py" "$_t"; then
+            _any_patched=1
+        fi
+    done
+    if [ -z "$_any_patched" ]; then
+        echo "ERROR: cowork platform gate not found in index.js or any index.chunk-*.js" >&2
+        echo "       Claude Desktop's bundle layout may have changed; Cowork would not be enabled." >&2
+        return 1
+    fi
+    echo "Cowork patches applied"
 
     # Repack into app.asar
     echo "Repacking app.asar..."

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -169,14 +169,18 @@ JSEOF
     # pattern is simply skipped).
     local _build_dir="${_ext}/.vite/build"
     local -a _index_targets=()
-    if [ -f "$_indexjs" ]; then
-        _index_targets+=("$_indexjs")
-        local _chunk
-        while IFS= read -r _chunk; do
-            [ -n "$_chunk" ] && [ -f "$_build_dir/$_chunk" ] \
-                && _index_targets+=("$_build_dir/$_chunk")
-        done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$_indexjs" | sort -u)
+    if [ ! -f "$_indexjs" ]; then
+        echo "ERROR: main-process entry not found at $_indexjs" >&2
+        echo "       The extracted Claude Desktop bundle layout may have changed;" >&2
+        echo "       cannot locate the code to patch, so Cowork could not be enabled." >&2
+        return 1
     fi
+    _index_targets+=("$_indexjs")
+    local _chunk
+    while IFS= read -r _chunk; do
+        [ -n "$_chunk" ] && [ -f "$_build_dir/$_chunk" ] \
+            && _index_targets+=("$_build_dir/$_chunk")
+    done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$_indexjs" | sort -u)
 
     # patch_index <log msg> <grep -E guard> <sed -E script>
     # Runs the sed against every main-process code file matching the guard; logs
@@ -251,19 +255,28 @@ JSEOF
     # guards, and host-platform code live in the chunk (not index.js), so run
     # enable-cowork.py across index.js plus every discovered chunk. The script is
     # idempotent (marker-guarded) and exits non-zero when a file lacks the
-    # platform gate (expected for the shim and unrelated chunks), so require at
-    # least one target to patch successfully; otherwise fail the build loudly
-    # rather than ship a package where Cowork is silently not enabled.
+    # platform gate (expected for the shim and chunks without it). Capture each
+    # run's output: print it when the file was patched, but suppress the script's
+    # "Platform-gate function not found" noise for the expected misses so a
+    # successful build log stays clean. Require at least one target to patch;
+    # otherwise fail the build loudly — surfacing the stashed output to diagnose
+    # a bundle-layout change — rather than ship a package with Cowork disabled.
     echo "Applying cowork patch to ${#_index_targets[@]} file(s)..."
-    local _t _any_patched=""
+    local _t _out _any_patched="" _miss_log=""
     for _t in "${_index_targets[@]}"; do
-        if python "${_repo}/enable-cowork.py" "$_t"; then
+        if _out="$(python "${_repo}/enable-cowork.py" "$_t" 2>&1)"; then
             _any_patched=1
+            [ -n "$_out" ] && printf '%s\n' "$_out"
+        else
+            echo "  Skipped ${_t##*/} (no platform gate; patched in another target)"
+            _miss_log+="--- ${_t##*/} ---"$'\n'"$_out"$'\n'
         fi
     done
     if [ -z "$_any_patched" ]; then
         echo "ERROR: cowork platform gate not found in index.js or any index.chunk-*.js" >&2
         echo "       Claude Desktop's bundle layout may have changed; Cowork would not be enabled." >&2
+        echo "       enable-cowork.py output follows:" >&2
+        printf '%s' "$_miss_log" >&2
         return 1
     fi
     echo "Cowork patches applied"

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -155,5 +155,42 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+section "5. PKGBUILD build() patches reach the chunk (AUR path, issue #156)"
+# ---------------------------------------------------------------------------
+# The AUR PKGBUILD applies the same class of patches as launch.sh, but in its
+# own build() function. It regressed once (issue #156): it patched index.js
+# only and hardcoded minified identifiers, silently disabling Cowork on
+# split-entry builds. Extract its patch_index() helper + invocations verbatim
+# and exercise them on a chunk with rotated identifiers so the drift can't recur.
+PKGBLOCK="$TMP/pkg_patch_block.sh"
+awk '/^    patch_index\(\) \{/{inf=1} inf{print} inf&&/^    \}/{inf=0}' "$REPO_ROOT/PKGBUILD" > "$PKGBLOCK"
+grep -A2 '^    patch_index "' "$REPO_ROOT/PKGBUILD" | grep -v '^--$' >> "$PKGBLOCK"
+PKCALLS="$(grep -c '^    patch_index ' "$PKGBLOCK" || true)"
+if [[ "${PKCALLS:-0}" -lt 1 ]]; then
+  fail "extracted patch_index block from PKGBUILD (found $PKCALLS calls)"
+else
+  pass "extracted patch_index block from PKGBUILD ($PKCALLS calls)"
+  PKCHUNK="$TMP/pkg_chunk.js"
+  write_patch_fixture "$PKCHUNK"
+  ( _index_targets=("$PKCHUNK"); source "$PKGBLOCK" ) >/dev/null 2>&1
+  refute_grep "$PKCHUNK" 'titleBarStyle:"hidden"'          "PKGBUILD: main-window titlebar removed (chunk)"
+  refute_grep "$PKCHUNK" 'titleBarStyle:"hiddenInset"'     "PKGBUILD: about-window titlebar removed (chunk)"
+  assert_grep "$PKCHUNK" 'return Zq\.protocol==="file:"\}' "PKGBUILD: origin isPackaged dropped for file:// (chunk)"
+  assert_parses "$PKCHUNK" "PKGBUILD: chunk parses after patch_index seds"
+fi
+# Source-level guards: the recipe must discover chunks and run enable-cowork.py
+# across every discovered target, never regress to the index.js-only invocation.
+if grep -qF 'chunk-[A-Za-z0-9_-]+' "$REPO_ROOT/PKGBUILD"; then
+  pass "PKGBUILD: discovers index.chunk-*.js from the shim"
+else
+  fail "PKGBUILD: chunk discovery missing"
+fi
+if grep -q 'enable-cowork.py" "$_t"' "$REPO_ROOT/PKGBUILD"; then
+  pass "PKGBUILD: runs enable-cowork.py across every discovered target"
+else
+  fail "PKGBUILD: enable-cowork.py not run per-target (regressed to index.js only?)"
+fi
+
+# ---------------------------------------------------------------------------
 echo -e "\n${BOLD}Summary:${NC} ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}, ${YELLOW}${SKIP} skipped${NC}"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What does this change?

Brings the AUR `PKGBUILD`'s `build()` up to date with the split-entry bundle layout that landed for `install.sh`/`launch.sh` in #157/#158. Claude Desktop **1.19367.0+** splits the Vite main bundle: `index.js` becomes a thin entry shim that `require()`s the real code from an `index.chunk-<hash>.js` file. The recipe patched `index.js` only, with minified identifiers (`e.`/`Ee.`) hardcoded, so on current builds:

- `enable-cowork.py` ran on the shim and failed with *"Platform-gate function not found"* → a package with Cowork disabled (or an aborted build);
- the inline titlebar and `file://` preload seds silently no-op'd.

This is the AUR-specific gap reported in **#156** (reproduced on `1.20186.0`), which the `install.sh`/`launch.sh` fixes did not cover because the recipe invokes neither installer nor launcher.

The fix mirrors the merged chunk-discovery approach:

- discover `index.js` plus every `index.chunk-*.js` it `require()`s;
- apply the titlebar + `file://` patches across all targets via a `patch_index` helper, generalizing hardcoded identifiers to `[A-Za-z0-9_$]+`;
- run `enable-cowork.py` across every target and require **≥1 platform-gate match**, failing the build loudly rather than shipping a package where Cowork is silently not enabled.

Single-entry builds are unchanged: discovery finds no chunk, and the inline `getHostPlatform` pass (whose insert hardcodes the arch var `A`, unsafe to splice into a chunk) still targets `index.js` only — on split builds `enable-cowork.py`'s host-platform patch covers it in the chunk. `pkgrel` bumped 11 → 12.

## Type

- [x] Bug fix
- [x] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

Verified against the repo's fixture-based regression suite (no network/Docker/asar needed):

- Added **Section 5** to `tests/test-cowork-patch.sh` that extracts the `PKGBUILD`'s `patch_index` helper + invocations *verbatim* and exercises them on a chunk with rotated identifiers, plus source-level guards against regressing to the `index.js`-only invocation. Full suite: **33 passed, 0 failed, 0 skipped**.
- Standalone fixtures for split-entry (patches reach the chunk; shim untouched), single-entry (legacy behavior incl. the inline `linux-x64` branch preserved), and layout-changed (build aborts loudly) all pass.
- `bash -n PKGBUILD` and `python3 -m py_compile enable-cowork.py` clean.

- Distro / desktop: not run here — this environment has no Arch/`makepkg` or Claude Desktop asar. End-to-end verification on real `1.20186.0` (clean `makepkg`, 724 IPC guards patched, packaged markers present, `[cowork-startup] all rails engaged`) is documented in #156.
- Tested with `./install.sh --doctor`: not run (this PR only touches `PKGBUILD`, not `install.sh`).
- Tested a full Cowork session: not run here (see #156 for the reporter's end-to-end run).

## Security impact

- [ ] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code — explanation below:

The `file://` preload patch relaxes an origin-validation check. This is **not a new relaxation** — it is the same patch the recipe already applied to `index.js`, now generalized (identifier-agnostic) and applied to the chunk where the code moved. It only drops the `isPackaged` requirement for `file://` origins (our own asar-internal renderer); the underlying IPC origin validator is untouched here and, via the unchanged `enable-cowork.py`, still validates all non-`file://` origins. No change to `filterEnv`, `spawn`, `AuthRequest`, `isPathSafe`, or credential handling.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — not run in this environment (no Arch/asar); change is `PKGBUILD`-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016jYLytbs1cx6FcjyHDHMzw)_