### PR TITLE
docs: replace stale CLAUDE.md pointers with human-facing orientation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,51 @@ compatibility, fix bugs, or extend distro support are very welcome.
 
 - **Check open issues** -- someone may already be working on it
 - **Open an issue first** for non-trivial changes so we can align before you invest time
-- **Read [CLAUDE.md](CLAUDE.md)** -- it documents the architecture, critical path chains,
-  and things that are easy to break (especially auth and path translation)
+- **Get oriented** -- see "Orientation" below for what to read before touching the stubs
+
+## Orientation
+
+The layer stubs macOS-native modules so an unmodified Claude Desktop runs on Linux.
+Almost every bug lives in one of a few chains, so it's worth knowing which one you're in
+before you start:
+
+- **[README "Architecture"](README.md#-architecture)** -- how the stubs, the frame-fix
+  wrapper, and the repacked asar fit together, plus **path translation** and **mount
+  symlinks**, which are the two easiest things to break.
+- **[README "How It Works"](README.md#-how-it-works)** -- startup sequence, from launcher
+  through asar patching to a live Cowork session.
+- **[README "Project Structure"](README.md#-project-structure)** -- what each file does.
+- **[docs/OAUTH-COMPLIANCE.md](docs/OAUTH-COMPLIANCE.md)** -- the auth chain. Read this
+  before any change that touches env vars reaching a spawned process.
+- **[COMPAT.md](COMPAT.md)** -- which asar versions are known-good, and which contract
+  changes landed in which build. Bundle-version-specific breakage usually starts here.
+
+Two things that are easy to get wrong and are worth calling out up front:
+
+- **IPC contracts shift between asar builds.** Handler signatures and channel namespaces
+  change without notice. Prefer stubs that accept both the old and new shape so a user
+  rolling back an update isn't broken -- see `pickPathArg` in `stubs/cowork/spaces_store.js`.
+- **Path containment is not the same as path normalization.** Anything resolving a
+  renderer-supplied path must realpath it and prove containment before use, and must
+  fail closed on anything it can't prove -- including symlinks that don't resolve.
+
+## Agent-Assisted Contributions
+
+Contributions written with an AI coding agent are welcome, with two conditions:
+
+1. **You have read and understood the diff**, and can explain why each change is there.
+   Review load is the bottleneck in this project, not typing.
+2. **No agent instruction files in the repo.** `CLAUDE.md`, `AGENTS.md`, `.cursorrules`,
+   `.github/copilot-instructions.md` and equivalents are out of scope, and a PR adding
+   one will be asked to remove it.
+
+The second point is a security boundary, not a style preference. Agents read those files
+automatically and treat them with the authority of an instruction from the person running
+them -- so a file in a public repo becomes a way to steer any contributor's or maintainer's
+agent, and it's editable by anyone who can open a PR. Keeping the repo free of them means
+a checkout carries no instructions to a reader that a human wouldn't see in review.
+Documentation for humans belongs in `README.md`, `docs/`, or here. Keep your own agent
+config outside the repo (`~/.claude/`, or untracked and gitignored locally).
 
 ## What's Most Useful
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ compatibility, fix bugs, or extend distro support are very welcome.
 
 ## Orientation
 
-The layer stubs macOS-native modules so an unmodified Claude Desktop runs on Linux.
-Almost every bug lives in one of a few chains, so it's worth knowing which one you're in
-before you start:
+This project is a compatibility layer: it stubs macOS-native modules so an unmodified
+Claude Desktop runs on Linux. Almost every bug lives in one of a few chains, so it's
+worth knowing which one you're in before you start:
 
 - **[README "Architecture"](README.md#-architecture)** -- how the stubs, the frame-fix
   wrapper, and the repacked asar fit together, plus **path translation** and **mount

--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ claude-cowork-linux/
 ├── docs/
 │   ├── FAQ.md                         # Detailed troubleshooting guide
 │   ├── extensions.md                  # MCP and Chrome Extension integration overview
-│   ├── known-issues.md                # Safe Storage encryption, keyring setup
 │   └── safestorage-tokens.md          # How to persist tokens across restarts
 ├── config/
 │   └── hyprland/claude.conf           # Optional: Hyprland window rules
@@ -363,7 +362,8 @@ claude-cowork-linux/
 ├── PKGBUILD                           # Arch Linux AUR package definition
 ├── docs/releases/                     # Per-version release notes
 ├── docs/OAUTH-COMPLIANCE.md           # OAuth token handling audit
-├── CLAUDE.md                          # Project guide and critical paths
+├── COMPAT.md                          # Tested asar versions and known breakage
+├── CONTRIBUTING.md                    # Orientation, conventions, security-sensitive areas
 ├── README.md                          # This file
 └── LICENSE
 ```

--- a/docs/OAUTH-COMPLIANCE.md
+++ b/docs/OAUTH-COMPLIANCE.md
@@ -112,7 +112,9 @@ const CREDENTIAL_EXEMPT_KEYS = new Set(['CLAUDE_CODE_OAUTH_TOKEN']);
 - The token is forwarded only to the official, unmodified Claude Code CLI binary
 - No third-party application receives the OAuth token
 - `ANTHROPIC_AUTH_TOKEN` injection is explicitly blocked (it bypasses OAuth handling and
-  causes 401 errors — see CLAUDE.md)
+  causes 401 errors — see [docs/FAQ.md](FAQ.md#login-and-auth) under "OAuth 401 errors";
+  the allowlist that omits it
+  is `ENV_ALLOWLIST` in `stubs/cowork/env_filter.js`)
 
 ---
 


### PR DESCRIPTION
## What does this change?

`CONTRIBUTING.md` told contributors to read a `CLAUDE.md` that is no longer in the repo. The "read this before you start" step led nowhere, and the guidance it stood for — architecture, critical path chains, what's easy to break — had no home.

**Orientation section (replaces the dead pointer).** Links the README sections and docs that actually cover that ground: Architecture (incl. path translation and mount symlinks), How It Works, Project Structure, `OAUTH-COMPLIANCE.md` for the auth chain, and `COMPAT.md` for version-specific breakage. Plus the two failure modes this project keeps hitting, stated up front:

- IPC contracts shift between asar builds — prefer stubs that accept both the old and new shape so a user rolling back isn't broken (`pickPathArg` cited as the example).
- Path containment isn't path normalization — realpath, prove containment, fail closed on anything unprovable, *including symlinks that don't resolve*. That's the exact gap that made it through review in #160.

**Agent-assisted contributions policy.** States that agent instruction files (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md`) don't belong in the repo, with the reasoning: agents read them automatically and treat them with the authority of an instruction from the person running them, so a file in a public repo is a way to steer a contributor's or maintainer's agent — and it's editable by anyone who can open a PR. Documentation for humans goes in README/`docs/`/CONTRIBUTING; agent config stays outside the repo. Written so a contributor understands the boundary rather than just hitting a "remove this file" review comment.

**Two other stale references fixed.** The README file tree listed `CLAUDE.md` and a `docs/known-issues.md` that doesn't exist (replaced with `COMPAT.md` and `CONTRIBUTING.md`, which do). `OAUTH-COMPLIANCE.md` cited `CLAUDE.md` for why `ANTHROPIC_AUTH_TOKEN` is blocked — now points at the FAQ's "OAuth 401 errors" entry and the `ENV_ALLOWLIST` in `env_filter.js` that omits it.

The remaining `CLAUDE.md` mention in `session_orchestrator.js` is unrelated and left alone — it describes the user's own `~/.claude` global config, not a repo file.

## Type

- [ ] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor

## Testing

Docs only — no source changes. Suite still green at **540 tests, 0 failures**.

Every relative link and anchor in the three edited files was verified to resolve against the actual headings, which caught two mistakes before push: the FAQ section is "Login and Auth", not "Authentication", and image-prefixed headings take the `#-section` slug form (matching the README's own nav bar).

- Distro / desktop: n/a, documentation
- Tested with `./install.sh --doctor`: n/a
- Tested a full Cowork session: n/a

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning
- [ ] This change does touch security-sensitive code

No code changes. The `OAUTH-COMPLIANCE.md` edit only repoints a cross-reference; the described behavior is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119SjT5u1qHxgnMFcBCzMeG)_