### PR TITLE
fix(compat): record a download URL for the last tested asar (#165)

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -38,9 +38,23 @@ build plus its checksum, so that if the latest CDN release regresses you
 can fetch the last tested version yourself and verify the bytes match
 what was exercised.
 
-| Asar     | CDN URL (Anthropic)                                                                                   | SHA-256 |
-|:---------|:------------------------------------------------------------------------------------------------------|:--------|
-| 1.6259.1 | `https://downloads.claude.ai/releases/darwin/universal/1.6259.1/Claude-5095e7dddcba4ca974d351ee397e17d204814f07.dmg` | `98c9de8dde01f083b73e7ef08cfaf7adfd2c1386e88d2995b4202dea1a31e898` |
+| Asar      | CDN URL (Anthropic)                                                                                   | SHA-256 |
+|:----------|:------------------------------------------------------------------------------------------------------|:--------|
+| 1.6259.1  | `https://downloads.claude.ai/releases/darwin/universal/1.6259.1/Claude-5095e7dddcba4ca974d351ee397e17d204814f07.dmg` | `98c9de8dde01f083b73e7ef08cfaf7adfd2c1386e88d2995b4202dea1a31e898` |
+| 1.19367.0 | `https://downloads.claude.ai/releases/darwin/universal/1.19367.0/Claude-1a5be1fbf83d1832486e03a667557c18f0a0ec7a.dmg` | `<pending>` |
+
+The URL for each release embeds a per-release hash, so it cannot be
+constructed from the version number -- a build has a pinnable URL only if
+someone recorded it here. `install.sh` reads this table: when you answer
+`t` ("show instructions for installing the tested version") at the
+download prompt, it prints the recorded URL and checksum for
+`LAST_TESTED_ASAR_VERSION` directly, and tells you plainly when there is
+no row rather than printing a placeholder you cannot fill in (#165).
+
+The 1.19367.0 URL was contributed in #165 and has not been re-fetched or
+checksummed by a maintainer; it is a `.dmg`, so the LZFSE note below may
+apply. If you download it, please compute the SHA-256 and open a PR
+filling in the `<pending>` cell.
 
 To pin and verify a tested version:
 
@@ -69,7 +83,17 @@ not an endorsement to redistribute. If a recorded SHA-256 shows
 ## Reporting a tested version
 
 Open a PR that bumps `LAST_TESTED_ASAR_VERSION` (the HTML comment line
-above) and adds a row to the table. In the PR body, include:
+above), adds a row to the tested-versions table, and **adds the archive
+you tested to the pinning table too** -- the CDN URL you downloaded from,
+plus `sha256sum` of that exact file.
+
+Without that row the next person has a version number recorded as working
+and no way to obtain it: the URL is not derivable from the version, and
+`install.sh`'s "install the tested version" path has nothing to print.
+That was #165. `tests/test-compat-pins.sh` checks that whatever
+`LAST_TESTED_ASAR_VERSION` points at has a pinning row.
+
+In the PR body, include:
 
 1. Distro and desktop environment (e.g. "Arch Linux + Hyprland (Wayland)").
 2. Electron version (`electron --version` from your install).

--- a/install.sh
+++ b/install.sh
@@ -149,13 +149,22 @@ compat_read_pin() {
     # the user to go find it (issue #165).
     local version="$1" field="$2" compat_file="${3:-}"
     [[ -n "$version" ]] || return 1
+
+    # Resolve the column explicitly: treating "anything that isn't sha256" as
+    # the URL would turn a caller typo into a plausible-looking wrong answer,
+    # which is the one failure mode this whole helper exists to avoid.
+    local col
+    case "$field" in
+        url)    col=3 ;;
+        sha256) col=4 ;;
+        *)      printf 'compat_read_pin: unknown field %s (want url|sha256)\n' "${field:-<empty>}" >&2
+                return 2 ;;
+    esac
+
     if [[ -z "$compat_file" ]]; then
         compat_file="$(dirname "$0")/COMPAT.md"
     fi
     [[ -f "$compat_file" ]] || return 1
-
-    local col=3
-    [[ "$field" == "sha256" ]] && col=4
 
     local value
     value=$(awk -F'|' -v want="$version" -v col="$col" '
@@ -561,8 +570,9 @@ get_archive() {
                         echo ""
                         echo "  - Check the \"Pinning a tested version\" table for a nearby build:"
                         echo "    https://github.com/johnzfitch/claude-cowork-linux/blob/master/COMPAT.md"
-                        echo "  - If you already have the archive, point the installer at it:"
-                        echo "    CLAUDE_ARCHIVE=/path/to/Claude.dmg bash install.sh"
+                        echo "  - If you already have the archive, point the installer at it"
+                        echo "    (.zip or .dmg -- 7z reads both):"
+                        echo "    CLAUDE_ARCHIVE=/path/to/Claude.zip bash install.sh"
                         echo "  - If you find the URL, please open a PR adding it to that table."
                     fi
                     echo ""

--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,56 @@ compat_read_last_tested() {
     printf '1.6259.1'
 }
 
+compat_read_pin() {
+    # compat_read_pin <version> <url|sha256> [compat_file]
+    #
+    # Reads one cell out of the "Pinning a tested version" table in COMPAT.md:
+    # the Anthropic CDN URL, or the recorded SHA-256, for <version>. Prints
+    # nothing and returns 1 when the version has no row yet, or when the cell
+    # is still the `<pending>` placeholder.
+    #
+    # The CDN URL embeds a per-release hash, so it cannot be derived from the
+    # version number -- it only exists if someone recorded it. Reading the
+    # table here means the installer can print the real URL instead of telling
+    # the user to go find it (issue #165).
+    local version="$1" field="$2" compat_file="${3:-}"
+    [[ -n "$version" ]] || return 1
+    if [[ -z "$compat_file" ]]; then
+        compat_file="$(dirname "$0")/COMPAT.md"
+    fi
+    [[ -f "$compat_file" ]] || return 1
+
+    local col=3
+    [[ "$field" == "sha256" ]] && col=4
+
+    local value
+    value=$(awk -F'|' -v want="$version" -v col="$col" '
+        /^\|/ {
+            key = $2
+            gsub(/[[:space:]`]/, "", key)
+            if (key != want) next
+            if (NF <= 3) next
+            url = $3
+            gsub(/[[:space:]`]/, "", url)
+            # Both tables in COMPAT.md are keyed by version, so match on the
+            # shape of the row rather than its position: only the pinning
+            # table carries a URL in column 3 (the status table has [OK] and
+            # a date there).
+            if (url !~ /^https?:\/\//) next
+            if (col == 3) { print url; exit }
+            if (NF <= 4) next
+            cell = $4
+            gsub(/[[:space:]`]/, "", cell)
+            # `<pending>` (or any other placeholder) is not a usable value.
+            if (cell == "" || substr(cell, 1, 1) == "<") next
+            print cell
+            exit
+        }' "$compat_file")
+
+    [[ -n "$value" ]] || return 1
+    printf '%s' "$value"
+}
+
 compat_version_is_newer() {
     # Returns 0 (true) if $1 > $2 by semver-ish ordering (sort -V).
     # Returns 1 otherwise (equal or older).
@@ -471,21 +521,50 @@ get_archive() {
                     # Tell the user how to get the tested version. We do NOT
                     # download or redistribute the archive ourselves -- the
                     # user fetches it from Anthropic's CDN and passes it to us.
-                    # COMPAT.md records the CDN URL + SHA-256 for tested builds.
+                    # COMPAT.md records the CDN URL + SHA-256 for tested builds;
+                    # print the recorded ones inline rather than sending the
+                    # user off to find the row by hand (issue #165).
+                    local pin_url="" pin_sha="" pin_file
+                    pin_url=$(compat_read_pin "$last_tested" url "$script_dir/COMPAT.md") || pin_url=""
+                    pin_sha=$(compat_read_pin "$last_tested" sha256 "$script_dir/COMPAT.md") || pin_sha=""
+                    # Keep the archive's real extension: 7z reads both, but a
+                    # .zip saved as .dmg is confusing to anyone debugging later.
+                    pin_file="Claude-${last_tested}.dmg"
+                    [[ "$pin_url" == *.zip ]] && pin_file="Claude-${last_tested}.zip"
                     echo ""
                     echo "  To install the tested version ($last_tested):"
                     echo ""
-                    echo "  1. COMPAT.md lists the Anthropic CDN URL and SHA-256 for"
-                    echo "     tested builds under \"Pinning a tested version\":"
-                    echo "     https://github.com/johnzfitch/claude-cowork-linux/blob/master/COMPAT.md"
-                    echo ""
-                    echo "  2. Download it from that URL and verify the checksum"
-                    echo "     (-o names the file predictably; -fLO keeps the hash name):"
-                    echo "     curl -fL -o Claude-${last_tested}.dmg \"<CDN URL from COMPAT.md>\""
-                    echo "     sha256sum Claude-${last_tested}.dmg"
-                    echo ""
-                    echo "  3. Re-run the installer with the verified file:"
-                    echo "     CLAUDE_ARCHIVE=\"\$PWD/Claude-${last_tested}.dmg\" bash install.sh"
+                    if [[ -n "$pin_url" ]]; then
+                        echo "  1. Download it from Anthropic's CDN (-o names the file"
+                        echo "     predictably; -fLO would keep the long hash name):"
+                        echo "     curl -fL -o $pin_file \\"
+                        echo "       \"$pin_url\""
+                        echo ""
+                        if [[ -n "$pin_sha" ]]; then
+                            echo "  2. Verify the bytes match what was tested:"
+                            echo "     echo \"$pin_sha  $pin_file\" | sha256sum -c"
+                        else
+                            echo "  2. No SHA-256 is recorded for $last_tested yet. Compute it and"
+                            echo "     open a PR filling it into COMPAT.md so the next person can verify:"
+                            echo "     sha256sum $pin_file"
+                        fi
+                        echo ""
+                        echo "  3. Re-run the installer with the archive:"
+                        echo "     CLAUDE_ARCHIVE=\"\$PWD/$pin_file\" bash install.sh"
+                    else
+                        # No row recorded. The CDN URL embeds a per-release hash,
+                        # so we cannot construct one -- say so instead of printing
+                        # a placeholder the user has no way to fill in.
+                        echo "  COMPAT.md has no recorded CDN URL for $last_tested, and the URL"
+                        echo "  embeds a per-release hash that cannot be derived from the version"
+                        echo "  number. Options:"
+                        echo ""
+                        echo "  - Check the \"Pinning a tested version\" table for a nearby build:"
+                        echo "    https://github.com/johnzfitch/claude-cowork-linux/blob/master/COMPAT.md"
+                        echo "  - If you already have the archive, point the installer at it:"
+                        echo "    CLAUDE_ARCHIVE=/path/to/Claude.dmg bash install.sh"
+                        echo "  - If you find the URL, please open a PR adding it to that table."
+                    fi
                     echo ""
                     die "Install paused. Re-run with CLAUDE_ARCHIVE set."
                     ;;

--- a/tests/test-compat-pins.sh
+++ b/tests/test-compat-pins.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Tests for the COMPAT.md pinning-table lookup used by install.sh.
+#
+# install.sh's "install the tested version" path (answer `t` at the download
+# prompt) prints the Anthropic CDN URL and SHA-256 recorded for
+# LAST_TESTED_ASAR_VERSION. Those live in the "Pinning a tested version" table
+# in COMPAT.md, and the URL embeds a per-release hash, so it cannot be
+# reconstructed if the row is missing -- a version recorded as tested with no
+# pinning row leaves the user with nothing to download (issue #165).
+#
+# These tests pin both halves of that contract:
+#   - compat_read_pin() parses the table (and correctly refuses `<pending>`);
+#   - COMPAT.md actually carries a row for LAST_TESTED_ASAR_VERSION.
+#
+# The function is extracted verbatim from install.sh rather than copied, so the
+# test tracks the shipped code. No network needed.
+#
+#   ./tests/test-compat-pins.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BOLD='\033[1m'; NC='\033[0m'
+PASS=0; FAIL=0
+pass() { echo -e "  ${GREEN}PASS${NC} $*"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $*"; FAIL=$((FAIL + 1)); }
+section() { echo -e "\n${BOLD}=== $* ===${NC}"; }
+
+# assert_eq <got> <want> <label>
+assert_eq() {
+  if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (got '$1', want '$2')"; fi
+}
+
+# ---------------------------------------------------------------------------
+section "1. Extract compat_read_pin() from install.sh"
+# ---------------------------------------------------------------------------
+HELPERS="$TMP/helpers.sh"
+awk '/^compat_read_pin\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' \
+  "$REPO_ROOT/install.sh" > "$HELPERS"
+if grep -q '^compat_read_pin() {' "$HELPERS" && grep -q '^}$' "$HELPERS"; then
+  pass "extracted compat_read_pin() from install.sh"
+else
+  fail "compat_read_pin() not found in install.sh"
+  echo -e "\n${BOLD}Summary:${NC} ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+  exit 1
+fi
+# shellcheck source=/dev/null
+source "$HELPERS"
+
+# ---------------------------------------------------------------------------
+section "2. Table parsing"
+# ---------------------------------------------------------------------------
+FIXTURE="$TMP/COMPAT.md"
+cat > "$FIXTURE" <<'EOF'
+# Compatibility
+
+<!-- LAST_TESTED_ASAR_VERSION=1.19367.0 -->
+
+| Asar      | Status | Date       | Notes |
+|:----------|:-------|:-----------|:------|
+| 1.6259.1  | [OK]   | 2026-05-14 | baseline |
+
+| Asar      | CDN URL (Anthropic) | SHA-256 |
+|:----------|:--------------------|:--------|
+| 1.6259.1  | `https://downloads.claude.ai/releases/darwin/universal/1.6259.1/Claude-abc.dmg` | `98c9de8d` |
+| 1.19367.0 | `https://downloads.claude.ai/releases/darwin/universal/1.19367.0/Claude-def.dmg` | `<pending>` |
+EOF
+
+got="$(compat_read_pin 1.6259.1 url "$FIXTURE")"
+assert_eq "$got" \
+  "https://downloads.claude.ai/releases/darwin/universal/1.6259.1/Claude-abc.dmg" \
+  "url looked up by version"
+
+got="$(compat_read_pin 1.6259.1 sha256 "$FIXTURE")"
+assert_eq "$got" "98c9de8d" "sha256 looked up by version"
+
+# A `<pending>` checksum must read as absent, not be echoed at the user as if
+# it were a real hash to compare against.
+if compat_read_pin 1.19367.0 sha256 "$FIXTURE" >/dev/null 2>&1; then
+  fail "<pending> sha256 must not be returned"
+else
+  pass "<pending> sha256 reported as missing"
+fi
+
+# ...but the URL on that same row is real and must still resolve.
+got="$(compat_read_pin 1.19367.0 url "$FIXTURE")"
+assert_eq "$got" \
+  "https://downloads.claude.ai/releases/darwin/universal/1.19367.0/Claude-def.dmg" \
+  "url still returned when its row's sha256 is <pending>"
+
+# Unknown version, and the status table's own rows (same file, 4 columns, no
+# URL cell) must not produce a bogus hit.
+if compat_read_pin 9.9.9 url "$FIXTURE" >/dev/null 2>&1; then
+  fail "unknown version must return non-zero"
+else
+  pass "unknown version returns non-zero"
+fi
+if compat_read_pin 1.6259.1 url "$TMP/does-not-exist.md" >/dev/null 2>&1; then
+  fail "missing COMPAT.md must return non-zero"
+else
+  pass "missing COMPAT.md returns non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+section "3. The real COMPAT.md pins its own LAST_TESTED_ASAR_VERSION"
+# ---------------------------------------------------------------------------
+COMPAT="$REPO_ROOT/COMPAT.md"
+last_tested="$(grep -oE '^<!-- LAST_TESTED_ASAR_VERSION=[^[:space:]]+ -->$' "$COMPAT" \
+  | head -1 | sed -E 's/.*=([^[:space:]]+) -->/\1/')"
+if [[ -n "$last_tested" ]]; then
+  pass "LAST_TESTED_ASAR_VERSION present ($last_tested)"
+else
+  fail "LAST_TESTED_ASAR_VERSION missing from COMPAT.md"
+fi
+
+# The whole point of #165: a version recorded as tested that has no pinning row
+# cannot be obtained by anyone. A `<pending>` SHA-256 is fine -- a missing URL
+# is not.
+if url="$(compat_read_pin "$last_tested" url "$COMPAT")"; then
+  pass "pinning table has a CDN URL for $last_tested"
+  case "$url" in
+    https://downloads.claude.ai/releases/darwin/universal/"$last_tested"/*)
+      pass "recorded URL points at the $last_tested release path" ;;
+    *)
+      fail "recorded URL is not a $last_tested CDN path: $url" ;;
+  esac
+else
+  fail "no CDN URL recorded for $last_tested -- see 'Reporting a tested version' in COMPAT.md"
+fi
+
+# ---------------------------------------------------------------------------
+echo -e "\n${BOLD}Summary:${NC} ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test-compat-pins.sh
+++ b/tests/test-compat-pins.sh
@@ -92,6 +92,15 @@ assert_eq "$got" \
   "https://downloads.claude.ai/releases/darwin/universal/1.19367.0/Claude-def.dmg" \
   "url still returned when its row's sha256 is <pending>"
 
+# A misspelled field must fail loudly rather than fall through to the URL
+# column: silently answering a different question than the caller asked is the
+# failure mode this helper exists to prevent.
+if got="$(compat_read_pin 1.6259.1 sha "$FIXTURE" 2>/dev/null)"; then
+  fail "unknown field must return non-zero"
+else
+  assert_eq "$got" "" "unknown field prints nothing on stdout"
+fi
+
 # Unknown version, and the status table's own rows (same file, 4 columns, no
 # URL cell) must not produce a bogus hit.
 if compat_read_pin 9.9.9 url "$FIXTURE" >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #165.

## What does this change?

COMPAT.md recorded `1.19367.0` as the last tested build but pinned a CDN URL only for `1.6259.1`. That gap isn't cosmetic: the CDN URL embeds a per-release hash (`Claude-1a5be1fb….dmg`), so it can't be reconstructed from the version number. A build recorded as tested with no pinning row is a build nobody can obtain.

`install.sh` made it worse by pointing at a page that didn't have the answer. Answering `t` at the download prompt ("show instructions for installing the tested version") printed:

```
curl -fL -o Claude-1.19367.0.dmg "<CDN URL from COMPAT.md>"
```

— a placeholder the user had no way to fill in, followed by `die "Install paused."`. That is what #165 hit.

Three parts:

- **Record the URL.** Adds the `1.19367.0` row to the pinning table, using the URL contributed in #165. SHA-256 is `<pending>`: I could not fetch the archive to checksum it (`downloads.claude.ai` is not reachable from this environment), and recording an unverified hash would be worse than recording none.
- **Read the table from the installer.** New `compat_read_pin()` looks up the URL and checksum for `LAST_TESTED_ASAR_VERSION` and prints real commands — `curl -fL -o … "<actual URL>"` and `echo "<sha>  <file>" | sha256sum -c`. When no row exists it says so and explains why it can't generate one, instead of emitting a placeholder. A `<pending>` checksum reads as absent, so the user is never handed a placeholder to verify against; the file extension follows the recorded URL rather than assuming `.dmg`.
- **Keep it from recurring.** "Reporting a tested version" now asks for the pinning row alongside the status row, and `tests/test-compat-pins.sh` asserts that whatever `LAST_TESTED_ASAR_VERSION` points at actually has one.

One implementation note: both tables in COMPAT.md are keyed by version, so a naive column lookup finds the *status* table's `1.6259.1` row first and returns `[OK]` as the URL. The test caught exactly that on the first run. The lookup now matches on row shape — a URL in column 3 — rather than position.

## Type

- [x] Bug fix
- [x] Documentation

## Testing

- `tests/test-compat-pins.sh` — 10/10 (new)
- `tests/test-cowork-patch.sh` — 35/35 (unchanged, no regression)
- `bash -n install.sh` clean
- Lookups exercised against the real COMPAT.md: `1.19367.0` → URL resolves, SHA-256 correctly reports absent; `1.6259.1` → both resolve

Not exercised: a live `install.sh` run through the `t` branch, since it requires the download prompt and CDN access this environment doesn't have. The code path is pure string formatting over the two verified lookups.

- Distro / desktop: n/a (installer/doc change, verified via test suite)
- Tested with `./install.sh --doctor`: not run — this change doesn't touch any path `--doctor` inspects
- Tested a full Cowork session: n/a

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning

Reading two cells out of a markdown table and printing them. Worth noting the project's line is unchanged: we still never host or download the archive on the user's behalf here — the `t` branch prints commands for the user to run against Anthropic's own CDN, and now encourages checksum verification more strongly than before by generating a `sha256sum -c` line when a hash is recorded.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — not applicable, see above

### Note for whoever lands #167

That PR bumps `LAST_TESTED_ASAR_VERSION` to `1.26832.0`, which has no pinning row — so the new test will fail on the merge of both. The fix is one line: the contributor downloaded that archive, so they have the URL and can `sha256sum` it. Raised on #167.

---
_Generated by [Claude Code](https://claude.ai/code/session_017xeiMD8yoYLoAGawK1AYcc)_