### PR TITLE
fix: support Claude Desktop 1.28929

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -5,8 +5,8 @@ to work with claude-cowork-linux. `install.sh` and the launcher grep the
 machine-readable lines below; the table further down is for humans.
 
 <!-- machine-readable; do not remove the next two lines -->
-<!-- LAST_TESTED_ASAR_VERSION=1.19367.0 -->
-<!-- LAST_TESTED_DATE=2026-07-15 -->
+<!-- LAST_TESTED_ASAR_VERSION=1.28929.0 -->
+<!-- LAST_TESTED_DATE=2026-08-14 -->
 
 ## Tested versions
 
@@ -20,6 +20,7 @@ machine-readable lines below; the table further down is for humans.
 | 1.22209.x | [PARTIAL]  | 2026-07-23 | Two contract changes land here, both handled in #160. CoworkSpaces file ops changed from `(path)` to `(spaceId, path)` (the stubs accept both shapes, so a rollback still works), and artifact/upload/attachment/transcript writes moved to a native safe-fs API (`openRootDir` + `*Beneath`), implemented for Linux in `stubs/@ant/claude-native/safe_fs.js`. Contributor-reported live; not exercised by a maintainer. |
 | 1.24012.9 | [PARTIAL]  | 2026-08-01 | Local MCP servers failed to connect ("Server disconnected" before any JSON-RPC): the bundle routes MCP spawns through the macOS disclaimer wrapper, which our unwrap rejected for user-installed binaries, and `realpath` walked npm-global shims out of the allowlist entirely (#164). Fixed by removing the unwrap's per-callsite carve-out so admission runs through the one shared rule, and by admitting user binaries the user declared as MCP servers instead of any file sitting in a user-writable directory. Contributor-reported; fix not exercised by a maintainer on this build. The 1.24012.1 `DeviceRegistry` blocker below is unrelated and still applies. |
 | 1.24012.1 | [PARTIAL]  | 2026-07-24 | Cowork sessions fail to link: the asar's own `DeviceRegistry.signCreateSessionBind` throws "device not registered (no row-PK for this account)", producing the "Couldn't link this session to a computer" banner. Not stubbable -- signing that binding here would forge a device-identity check (see #161). `BuddyBleTransport.reportState`, reported alongside it, is stubbed as a no-op. |
+| 1.28929.0 | [OK]       | 2026-08-14 | Adds `index2.chunk-*`, uses backticks and `let` in the Cowork platform gate, and distributes IPC guards across auxiliary chunks. Large internal MCP results also need host `Read` access to SDK-owned `.claude/projects/*/tool-results/*` files. Verified on Fedora 44 + GNOME Wayland with Electron 43.2.0: update/extract/repack, Cowork session start, tool permission prompts, and Visualize `read_me`/`show_widget` through iframe `firstrender` and `complete`. |
 
 Status legend:
 
@@ -42,6 +43,7 @@ what was exercised.
 |:----------|:------------------------------------------------------------------------------------------------------|:--------|
 | 1.6259.1  | `https://downloads.claude.ai/releases/darwin/universal/1.6259.1/Claude-5095e7dddcba4ca974d351ee397e17d204814f07.dmg` | `98c9de8dde01f083b73e7ef08cfaf7adfd2c1386e88d2995b4202dea1a31e898` |
 | 1.19367.0 | `https://downloads.claude.ai/releases/darwin/universal/1.19367.0/Claude-1a5be1fbf83d1832486e03a667557c18f0a0ec7a.dmg` | `<pending>` |
+| 1.28929.0 | `https://downloads.claude.ai/releases/darwin/universal/1.28929.0/Claude-d1a6bcd4ef8627d603a8290548a984220b6701cf.zip` | `d56ea682de438242b9fd142b0e4f8b55ba65c01a4ab22def02e881ef924bde8a` |
 
 The URL for each release embeds a per-release hash, so it cannot be
 constructed from the version number -- a build has a pinnable URL only if

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -162,7 +162,8 @@ JSEOF
 
     # Locate the main-process code file(s). Newer Claude Desktop builds (asar
     # 1.19367.0+) emit index.js as a thin entry shim that require()s the real
-    # code from an index.chunk-<hash>.js file (the <hash> rotates every build);
+    # code from index.chunk-<hash>.js and index2.chunk-<hash>.js files (the
+    # hash rotates every build);
     # older builds keep everything in index.js. Patches must hit whichever file
     # actually holds the code, so collect index.js plus every chunk it require()s
     # and apply each grep-guarded patch across all of them (a file lacking the
@@ -180,7 +181,7 @@ JSEOF
     while IFS= read -r _chunk; do
         [ -n "$_chunk" ] && [ -f "$_build_dir/$_chunk" ] \
             && _index_targets+=("$_build_dir/$_chunk")
-    done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$_indexjs" | sort -u)
+    done < <(grep -oE 'index2?\.chunk-[A-Za-z0-9_-]+\.js' "$_indexjs" | sort -u)
 
     # patch_index <log msg> <grep -E guard> <sed -E script>
     # Runs the sed against every main-process code file matching the guard; logs
@@ -273,7 +274,7 @@ JSEOF
         fi
     done
     if [ -z "$_any_patched" ]; then
-        echo "ERROR: cowork platform gate not found in index.js or any index.chunk-*.js" >&2
+        echo "ERROR: cowork platform gate not found in index.js or any index[2].chunk-*.js" >&2
         echo "       Claude Desktop's bundle layout may have changed; Cowork would not be enabled." >&2
         echo "       enable-cowork.py output follows:" >&2
         printf '%s' "$_miss_log" >&2

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -28,13 +28,16 @@ KNOWN_PATTERNS = [
 ]
 
 # Regex fallback: matches any function whose body starts with a platform check
-# and returns {status:"unsupported"} for non-darwin platforms
+# and returns {status:"unsupported"} for non-darwin platforms. Vite changed
+# minification style in Desktop 1.28929.0: the main-process gate moved to an
+# index2.chunk-* file and uses template-literal quotes (`darwin`) rather than
+# string quotes ("darwin"). Accept all three JavaScript quote styles.
 PLATFORM_GATE_RE = re.compile(
     r'function (\w+)\(\)\{'
-    r'(?:const \w+=process\.platform;)?'
+    r'(?:(?:const|let|var) \w+=process\.platform;)?'
     r'(?:return )?'
-    r'(?:if\(\w+!=="darwin"|\w+!=="darwin"\?)'
-    r'[^}]*status:"unsupported"'
+    r'(?:if\(\w+!==(["\'`])darwin\2|\w+!==(["\'`])darwin\3\?)'
+    r'[^}]*status:(["\'`])unsupported\4'
 )
 
 
@@ -85,7 +88,7 @@ def patch_file(filepath):
 
     if not func_name or not func_full:
         print(f"ERROR: Platform-gate function not found in {filepath}")
-        print("  Searched for known patterns (xPt, wj) and regex fallback.")
+        print("  Searched for known patterns (xPt, wj) and quote-agnostic regex fallback.")
         print("  The minified function name may have changed — inspect index.js for")
         print("  a function checking process.platform and returning {{status:\"unsupported\"}}.")
         return False
@@ -152,7 +155,7 @@ def patch_host_platform(filepath):
 # names like `$m` even contain `$`), so match both with [\w$]+ and reuse the
 # captured arg in the exemption rather than hardcoding it.
 IPC_ORIGIN_GUARD_RE = re.compile(
-    r'if\(!([\w$]+)\(([\w$]+)\)\)(throw new Error\(`[^`]*did not pass origin validation`\))'
+    r'if\(!([\w$]+)\(([\w$]+)\)\)(throw (?:new )?Error\(`[^`]*did not pass origin validation`\))'
 )
 IPC_PATCH_MARKER = '/*cowork-ipc-patched*/'
 
@@ -224,14 +227,64 @@ def patch_platform_return_gates(filepath):
     return True
 
 
+# Claude Code spools large MCP results beneath
+#   <config>/projects/<session>/tool-results/<tool-id>.json
+# and then asks the host Read tool to open that file. On Linux the desktop's
+# safe-path resolver rejects the session storage prefix as an "automount root"
+# before the normal allowed-root check runs. Only bypass that first resolver
+# for SDK-owned tool-result files; the existing containment check immediately
+# after this block still enforces the configured projects root.
+TOOL_RESULT_RESOLVE_RE = re.compile(
+    r'let ([\w$]+);try\{\1=await ([\w$]+)\.resolveFilePath\(([\w$]+),!0\)\}'
+)
+TOOL_RESULT_RESOLVE_MARKER = '/*cowork-tool-result-resolve-patched*/'
+
+
+def patch_tool_result_resolution(filepath):
+    """Allow host Read to consume SDK-spooled MCP tool-result files on Linux."""
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    if TOOL_RESULT_RESOLVE_MARKER in content:
+        print("  Tool-result path resolution: already patched")
+        return True
+
+    def replacement(match):
+        resolved, helpers, candidate = match.groups()
+        owned_result = (
+            f'/(?:^|\\/)\\.claude\\/projects\\/.+\\/tool-results\\/[^\\/]+$/.test({candidate})'
+        )
+        return (
+            f'let {resolved};if({owned_result}){resolved}={candidate};'
+            f'else try{{{resolved}=await {helpers}.resolveFilePath({candidate},!0)}}'
+        )
+
+    new_content, count = TOOL_RESULT_RESOLVE_RE.subn(replacement, content)
+    if count == 0:
+        print("  Tool-result path resolution: no matching sites found")
+        return True
+
+    new_content += TOOL_RESULT_RESOLVE_MARKER
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+
+    print(f"  Tool-result path resolution patched: {count} host-loop sites")
+    return True
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(1)
 
+    # The split bundle can place the Cowork platform gate and auxiliary patch
+    # sites in different chunks (Desktop 1.28929.0 does this for IPC origin
+    # guards). Always inspect every file passed by install.sh/launch.sh. Keep
+    # the exit-code contract tied to the platform gate so apply_patches still
+    # reports success only when the actual Cowork gate was found.
     success = patch_file(sys.argv[1])
-    if success:
-        patch_host_platform(sys.argv[1])
-        patch_ipc_origin_guards(sys.argv[1])
-        patch_platform_return_gates(sys.argv[1])
+    patch_host_platform(sys.argv[1])
+    patch_ipc_origin_guards(sys.argv[1])
+    patch_platform_return_gates(sys.argv[1])
+    patch_tool_result_resolution(sys.argv[1])
     sys.exit(0 if success else 1)

--- a/install.sh
+++ b/install.sh
@@ -804,7 +804,8 @@ apply_patches() {
     fi
 
     # Newer Claude Desktop builds emit index.js as a thin entry shim that
-    # require()s the real main code from an index.chunk-<hash>.js file, so the
+    # require()s the real main code from index.chunk-<hash>.js and, as of
+    # Desktop 1.28929.0, index2.chunk-<hash>.js files, so the
     # platform-gate / IPC / host-platform patterns live in the chunk, not in
     # index.js. Patch index.js plus every chunk it require()s; enable-cowork.py
     # is idempotent (marker-guarded) and reports "not found" harmlessly for
@@ -813,7 +814,7 @@ apply_patches() {
     local chunk
     while IFS= read -r chunk; do
         [[ -n "$chunk" && -f "$build_dir/$chunk" ]] && targets+=("$build_dir/$chunk")
-    done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$index_js" | sort -u)
+    done < <(grep -oE 'index2?\.chunk-[A-Za-z0-9_-]+\.js' "$index_js" | sort -u)
 
     # enable-cowork.py exits 0 when it finds (or has already patched) the
     # platform gate in a file, and 1 otherwise. On split-entry builds the gate
@@ -832,7 +833,7 @@ apply_patches() {
     if [[ -n "$any_patched" ]]; then
         log_success "Patches applied"
     else
-        log_warn "Cowork patch matched no target: the platform gate was not found in index.js or any index.chunk-*.js."
+        log_warn "Cowork patch matched no target: the platform gate was not found in index.js or any index[2].chunk-*.js."
         log_warn "The Claude Desktop bundle layout may have changed; Cowork may not be enabled. See the enable-cowork.py output above."
     fi
 }
@@ -1353,7 +1354,7 @@ doctor() {
         log_success "Extracted app: $app_dir"
         ok=$((ok + 1))
         # Check cowork patch
-        if grep -q 'cowork-patched' "$app_dir/.vite/build/index.js" 2>/dev/null; then
+        if grep -q 'cowork-patched' "$app_dir/.vite/build"/index*.js 2>/dev/null; then
             log_success "Cowork patch: applied"
             ok=$((ok + 1))
         else

--- a/launch.sh
+++ b/launch.sh
@@ -126,7 +126,8 @@ fi
 # ── Locate the main-process code file(s) ────────────────────────────────────
 # Vite compiles the main process into .vite/build/. Newer Claude Desktop builds
 # emit index.js as a thin entry shim that require()s the real code from an
-# index.chunk-<hash>.js file (the <hash> changes every build); older builds keep
+# index.chunk-<hash>.js and index2.chunk-<hash>.js files (the hash changes every
+# build); older builds keep
 # everything in index.js. The patches below must run against whichever file
 # actually holds the code, so collect index.js plus every chunk it require()s.
 # Applying each grep-guarded patch across all of them is safe: a file that lacks
@@ -138,7 +139,7 @@ if [ -f "$_BUILD_DIR/index.js" ]; then
   INDEX_TARGETS+=("$_BUILD_DIR/index.js")
   while IFS= read -r _chunk; do
     [ -n "$_chunk" ] && [ -f "$_BUILD_DIR/$_chunk" ] && INDEX_TARGETS+=("$_BUILD_DIR/$_chunk")
-  done < <(grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$_BUILD_DIR/index.js" | sort -u)
+  done < <(grep -oE 'index2?\.chunk-[A-Za-z0-9_-]+\.js' "$_BUILD_DIR/index.js" | sort -u)
 fi
 
 # patch_index "<log message>" "<grep -E guard>" "<sed -E script>"

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -47,7 +47,7 @@ assert_parses() {
 }
 
 # The exact discovery used by install.sh apply_patches and launch.sh.
-discover_chunks() { grep -oE 'index\.chunk-[A-Za-z0-9_-]+\.js' "$1" | sort -u; }
+discover_chunks() { grep -oE 'index2?\.chunk-[A-Za-z0-9_-]+\.js' "$1" | sort -u; }
 
 # Write a chunk exercising every patch site, using identifiers that are NOT the
 # values any older hardcoded pattern used (function qZ9/var r; validator $m/arg
@@ -58,8 +58,10 @@ write_patch_fixture() {
 function qZ9(){const r=process.platform;if(r!=="darwin"&&r!=="win32")return{status:"unsupported",reason:"nope"};return{status:"supported"}}
 const gate=qZ9();
 function checkOrigin(n){if(!$m(n))throw new Error(`Incoming "doThing" call on interface "MyIface" from '${(i=n.senderFrame)==null?void 0:i.url}' did not pass origin validation`)}
+function checkOriginNoNew(e){if(!tn(e))throw Error(`Incoming "getInitialLocale" call on interface "DesktopIntl" from '${e.senderFrame?.url}' did not pass origin validation`)}
 function hostPlat(){if(process.platform==="darwin")return"darwin-x64";throw new Error("Unsupported platform: "+process.platform)}
 function extInstall(){return{status:2,error:`Unsupported platform: ${process.platform} not allowed`}}
+async function hostRead(De){let ee;try{ee=await helpers.resolveFilePath(De,!0)}catch(e){return e}return ee}
 const winOpts={show:!1,titleBarStyle:"hidden",titleBarOverlay:Ab,trafficLightPosition:Cd,webPreferences:{}};
 const aboutOpts={titleBarStyle:"hiddenInset",autoHideMenuBar:!0,skipTaskbar:!0};
 function guard(){return Zq.protocol==="file:"&&Yw.app.isPackaged===!0}
@@ -68,6 +70,17 @@ function handoff(){mB.app.invalidateCurrentActivity();mB.app.setUserActivity(qq,
 function wrapSpawn(t){return process.platform!=="darwin"?t:{cmd:rpt(),args:[t.cmd,...t.args]}}
 const res=kk.app.isPackaged?process.resourcesPath:someFallback;
 const host=kk.app.isPackaged?jn.join(process.resourcesPath,"app.asar","mcp-runtime","nodeHost.js"):jn.join(kk.app.getAppPath(),"nodeHost.js");
+EOF
+}
+
+# Desktop 1.28929.0 moved the gate into index2.chunk-* and switched the
+# minifier's string style to backticks. Keep this fixture close to the real
+# bundle shape so quote-style or secondary-chunk regressions are caught.
+write_128929_fixture() {
+  cat > "$1" <<'EOF'
+"use strict";
+function Me(){let r=process.platform;if(r!==`darwin`&&r!==`win32`)return{status:`unsupported`,reason:`nope`,unsupportedCode:`unsupported_platform`};return{status:`supported`}}
+const support=Me();
 EOF
 }
 
@@ -90,13 +103,25 @@ python3 "$REPO_ROOT/enable-cowork.py" "$CHUNK" >/dev/null 2>&1
 assert_grep  "$CHUNK" 'cowork-patched'                 "platform-gate marker present"
 assert_grep  "$CHUNK" 'cowork-ipc-patched'             "IPC marker present"
 assert_grep  "$CHUNK" 'cowork-platform-return-patched' "return-gate marker present"
+assert_grep  "$CHUNK" 'cowork-tool-result-resolve-patched' "tool-result resolver marker present"
 assert_grep  "$CHUNK" 'function qZ9\(\)\{return\{status:"supported"\}\}' "platform gate returns supported"
 # IPC guard: validator $m and sender arg n both preserved, file:// exempted
 assert_grep  "$CHUNK" 'if\(!\$m\(n\)&&!\(n\.senderFrame&&n\.senderFrame\.url&&n\.senderFrame\.url\.startsWith\("file://"\)\)\)' \
              "IPC guard exempts file:// (rotated validator \$m + arg n)"
+assert_grep  "$CHUNK" 'if\(!tn\(e\)&&!\(e\.senderFrame&&e\.senderFrame\.url&&e\.senderFrame\.url\.startsWith\("file://"\)\)\)' \
+             "IPC guard supports throw Error without new (1.28929)"
 assert_grep  "$CHUNK" 'return"darwin-x64"'             "getHostPlatform throw -> darwin-x64"
 refute_grep  "$CHUNK" 'error:`Unsupported platform'    "return-style platform gate neutralized"
+assert_grep  "$CHUNK" '\.claude\\/projects.*tool-results.*\.test\(De\)\)ee=De;else try' \
+             "SDK-spooled tool results bypass the automount resolver"
 assert_parses "$CHUNK" "chunk parses after enable-cowork.py"
+
+CHUNK2="$TMP/index2.chunk-DOB7tBaF.js"
+write_128929_fixture "$CHUNK2"
+python3 "$REPO_ROOT/enable-cowork.py" "$CHUNK2" >/dev/null 2>&1
+assert_grep "$CHUNK2" 'cowork-patched' "1.28929 index2 gate marker present"
+assert_grep "$CHUNK2" 'function Me\(\)\{return\{status:"supported"\}\}' "1.28929 backtick gate returns supported"
+assert_parses "$CHUNK2" "1.28929 index2 chunk parses after patch"
 
 # Exit-code contract that install.sh apply_patches relies on to log success
 # accurately: a file with the gate (or already patched) exits 0; a shim with no
@@ -107,22 +132,30 @@ else
   fail "re-running on an already-patched gate file should exit 0"
 fi
 SHIM="$TMP/shim_index.js"
-printf '"use strict";\nrequire("./index.chunk-V9ybBkRT.js");\n' > "$SHIM"
+cat > "$SHIM" <<'EOF'
+"use strict";
+require("./index.chunk-V9ybBkRT.js");
+function auxOnly(e){if(!tn(e))throw Error(`Incoming "auxOnly" call on interface "Aux" from '${e.senderFrame?.url}' did not pass origin validation`)}
+async function readSpooled(p){let out;try{out=await safe.resolveFilePath(p,!0)}catch(e){return e}return out}
+EOF
 if python3 "$REPO_ROOT/enable-cowork.py" "$SHIM" >/dev/null 2>&1; then
   fail "shim with no platform gate should exit non-zero"
 else
   pass "shim with no platform gate exits non-zero (apply_patches won't false-succeed)"
 fi
+assert_grep "$SHIM" 'cowork-ipc-patched' "auxiliary patches run even when platform gate is in another chunk"
+assert_grep "$SHIM" 'cowork-tool-result-resolve-patched' "tool-result auxiliary patch runs without a platform gate"
 
 # ---------------------------------------------------------------------------
 section "3. index.js -> chunk discovery (install.sh / launch.sh)"
 # ---------------------------------------------------------------------------
 mkdir -p "$TMP/build"
-printf '"use strict";\nrequire("./index.chunk-V9ybBkRT.js");\n' > "$TMP/build/index.js"
+printf '"use strict";\nrequire("./index.chunk-V9ybBkRT.js");\nrequire("./index2.chunk-DOB7tBaF.js");\n' > "$TMP/build/index.js"
 : > "$TMP/build/index.chunk-V9ybBkRT.js"
+: > "$TMP/build/index2.chunk-DOB7tBaF.js"
 found="$(discover_chunks "$TMP/build/index.js")"
-[[ "$found" == "index.chunk-V9ybBkRT.js" ]] && pass "split-entry: chunk discovered from shim" \
-  || fail "split-entry: chunk discovered from shim (got: '$found')"
+[[ "$found" == $'index.chunk-V9ybBkRT.js\nindex2.chunk-DOB7tBaF.js' ]] && pass "split-entry: index and index2 chunks discovered from shim" \
+  || fail "split-entry: index and index2 chunks discovered from shim (got: '$found')"
 # Single-entry build (no shim) -> discovery finds nothing (clean no-op)
 printf '"use strict";var x=1;\n' > "$TMP/build/single.js"
 [[ -z "$(discover_chunks "$TMP/build/single.js")" ]] && pass "single-entry: no chunk discovered (backward compatible)" \
@@ -192,7 +225,7 @@ fi
 # Source-level guards: the recipe must discover chunks and run enable-cowork.py
 # across every discovered target, never regress to the index.js-only invocation.
 if grep -qF 'chunk-[A-Za-z0-9_-]+' "$REPO_ROOT/PKGBUILD"; then
-  pass "PKGBUILD: discovers index.chunk-*.js from the shim"
+  pass "PKGBUILD: discovers index[2].chunk-*.js from the shim"
 else
   fail "PKGBUILD: chunk discovery missing"
 fi


### PR DESCRIPTION
## What changed

- Discover and patch both `index.chunk-*` and `index2.chunk-*` main-process bundles in the installer, launcher, and PKGBUILD.
- Generalize the Cowork platform-gate matcher for `let`/`var` declarations and single, double, or template-literal quotes.
- Apply auxiliary IPC and platform patches even when the Cowork platform gate lives in a different chunk.
- Accept both `throw Error(...)` and `throw new Error(...)` IPC origin guards.
- Allow host `Read` to consume SDK-spooled MCP results under `.claude/projects/*/tool-results/*` while retaining the subsequent projects-root containment check.
- Record Claude Desktop `1.28929.0` as tested with its CDN URL and SHA-256.

## Why

Claude Desktop `1.28929.0` changed the Vite bundle layout and minified syntax. The Cowork gate moved to `index2.chunk-*`, while IPC guard sites remained distributed across other chunks. The existing patcher therefore reported that it could not find the platform gate and skipped auxiliary patches.

After those fixes, Visualize exposed a second Linux-specific failure: large MCP results are spooled to SDK-owned tool-result files, but the host safe-path resolver rejects the session storage prefix as an automount root before the normal allowed-root check runs. This prevented `visualize.read_me` from reaching `visualize.show_widget` reliably.

## Impact

Claude Desktop `1.28929.0` now installs and launches with Cowork enabled. Internal MCP Apps such as Visualize can read their spooled instructions and render their iframe widgets on Linux.

Verified on Fedora 44 with GNOME Wayland and Electron 43.2.0. The Visualize iframe reported both `firstrender` and `complete`.

## Checks

- `tests/test-cowork-patch.sh`: 43 passed, 0 failed
- `tests/test-compat-pins.sh`: 11 passed, 0 failed
- `node --test tests/node/current-path/*.test.cjs`: 559 passed, 0 failed
- `git diff --check`

`tests/test-install-paths.sh` still has its existing archive-harness failures: it checks the removed `fetch-dmg.py` and sends the current ZIP release through the DMG/7z extraction path. Those failures are outside this patch.
