### PR TITLE
fix(#170): one shared patch pass list, plus the silent-failure bugs it surfaced

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = claude-cowork-linux
 	pkgdesc = Anthropic Claude Desktop with Cowork (local agent) support for Linux
 	pkgver = 1.1.4010
-	pkgrel = 12
+	pkgrel = 13
 	url = https://github.com/johnzfitch/claude-cowork-linux
 	arch = x86_64
 	license = custom:proprietary

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -8,6 +8,7 @@ pkgbase = claude-cowork-linux
 	makedepends = p7zip
 	makedepends = asar
 	makedepends = curl
+	makedepends = python
 	depends = electron
 	depends = nodejs
 	depends = curl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,19 @@ jobs:
       - name: Compat pin consistency
         run: bash tests/test-compat-pins.sh
 
-      # Extracts the patch_index blocks from launch.sh and PKGBUILD and runs
-      # them against fixtures, including the backtick/let/index2 shapes from
-      # #166 and the minified-name fallback.
+      # Exercises the shared patch-index.sh pass list against fixtures, including
+      # the backtick/let/index2 shapes from #166 and the minified-name fallback,
+      # and guards that launch.sh and PKGBUILD still both source that one list.
       - name: Cowork patch passes
         run: bash tests/test-cowork-patch.sh
+
+      # Stage 1 of the install harness is pure static analysis -- no network, no
+      # Docker, no Arch -- so it can run here even though stages 2-8 cannot.
+      # Nothing ran this file at all, which is how it came to py_compile
+      # fetch-dmg.py for however many months after that script became
+      # fetch-dmg.js. A harness nobody runs rots into a harness nobody can run.
+      - name: Install harness static analysis
+        run: bash tests/test-install-paths.sh 1
 
   python:
     name: enable-cowork.py syntax

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Zack Fitch <zack@internetuniverse.org>
 pkgname=claude-cowork-linux
 pkgver=1.1.4010
-pkgrel=12
+pkgrel=13
 pkgdesc="Anthropic Claude Desktop with Cowork (local agent) support for Linux"
 arch=('x86_64')
 url="https://github.com/johnzfitch/claude-cowork-linux"
@@ -160,63 +160,42 @@ JSEOF
         echo "WARN: asar entry-point patch skipped (target not found)"
     fi
 
-    # Locate the main-process code file(s). Newer Claude Desktop builds (asar
-    # 1.19367.0+) emit index.js as a thin entry shim that require()s the real
-    # code from an index.chunk-<hash>.js file (the <hash> rotates every build);
-    # older builds keep everything in index.js. Patches must hit whichever file
-    # actually holds the code, so collect index.js plus every chunk it require()s
-    # and apply each grep-guarded patch across all of them (a file lacking the
-    # pattern is simply skipped).
+    # Apply the main-process patch passes. The pass list itself lives in the
+    # repo's patch-index.sh, which launch.sh sources too — one definition, so
+    # the recipe cannot fall behind the launcher again. It did: build() applied
+    # 3 of the 9 passes, and because /usr/bin/claude-cowork execs electron
+    # directly against the packaged asar and never runs launch.sh, AUR users
+    # silently lost the MCP node-host, resourcesPath, Handoff and --effort
+    # fixes — most visibly as "MCP Filesystem: Node host not found" (#170).
+    #
+    # patch_index_apply_all discovers index.js plus every index*.chunk-*.js in
+    # the build dir and leaves them in INDEX_TARGETS, which the enable-cowork.py
+    # loop below reuses.
     local _build_dir="${_ext}/.vite/build"
-    local -a _index_targets=()
     if [ ! -f "$_indexjs" ]; then
         echo "ERROR: main-process entry not found at $_indexjs" >&2
         echo "       The extracted Claude Desktop bundle layout may have changed;" >&2
         echo "       cannot locate the code to patch, so Cowork could not be enabled." >&2
         return 1
     fi
-    _index_targets+=("$_indexjs")
-    # Every index*.chunk-*.js in the build dir, not just the ones index.js names:
-    # chunks require() each other transitively, so the shim's direct requires are
-    # an incomplete list. Each patch is grep-guarded, so extra files are free.
-    local _chunk
-    while IFS= read -r _chunk; do
-        [ -n "$_chunk" ] && _index_targets+=("$_chunk")
-    done < <(find "$_build_dir" -maxdepth 1 -name 'index*.chunk-*.js' -type f | sort)
-
-    # patch_index <log msg> <grep -E guard> <sed -E script>
-    # Runs the sed against every main-process code file matching the guard; logs
-    # once if any matched, warns once if none did. Minified identifiers are
-    # matched with [A-Za-z0-9_$]+ so the patches survive per-build var renaming.
-    patch_index() {
-        local msg="$1" pat="$2" script="$3" f matched=""
-        for f in "${_index_targets[@]}"; do
-            if grep -qE "$pat" "$f" 2>/dev/null; then
-                sed -i -E "$script" "$f"
-                matched=1
-            fi
-        done
-        if [ -n "$matched" ]; then
-            echo "$msg"
-        else
-            echo "WARN: patch skipped (target not found): $msg"
-        fi
-    }
-
-    # Strip macOS titlebar opts (Vite ESM bypasses wrapper's require-Proxy).
-    patch_index "Stripping macOS titlebar options (main window)..." \
-        'titleBarStyle:["`]hidden["`],titleBarOverlay:[A-Za-z0-9_$!.]+,trafficLightPosition:[A-Za-z0-9_$!.]+,' \
-        's/titleBarStyle:["`]hidden["`],titleBarOverlay:[A-Za-z0-9_$!.]+,trafficLightPosition:[A-Za-z0-9_$!.]+,//g'
-    patch_index "Stripping macOS titlebar options (about window)..." \
-        'titleBarStyle:["`]hiddenInset["`],autoHideMenuBar:!0,skipTaskbar:!0' \
-        's/titleBarStyle:["`]hiddenInset["`],autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g'
-
-    # Drop isPackaged check on file:// preloads (else renderer shell never loads).
-    # The protocol/app identifiers are minified and rotate per build, so match
-    # with [A-Za-z0-9_$]+ rather than the old hardcoded e./Ee. names.
-    patch_index "Patching origin validation for file:// preloads..." \
-        '[A-Za-z0-9_$]+\.protocol===["`]file:["`]&&[A-Za-z0-9_$.]+\.app\.isPackaged===!0' \
-        's/([A-Za-z0-9_$]+)\.protocol===["`]file:["`]&&[A-Za-z0-9_$.]+\.app\.isPackaged===!0/\1.protocol==="file:"/g'
+    if [ ! -f "${_repo}/patch-index.sh" ]; then
+        echo "ERROR: patch-index.sh not found in ${_repo}" >&2
+        echo "       It carries every main-process patch pass; packaging without" >&2
+        echo "       it would ship an app with macOS titlebars, no local MCP" >&2
+        echo "       servers, and a renderer shell that never loads." >&2
+        return 1
+    fi
+    # shellcheck source=patch-index.sh
+    source "${_repo}/patch-index.sh"
+    # Fail the build on a chunk that no longer parses. launch.sh only warns --
+    # refusing to start an app that would otherwise work is worse than a warning
+    # -- but a package that opens a blank window should never leave the builder.
+    PATCH_INDEX_STRICT_SYNTAX=1
+    if ! patch_index_apply_all "$_build_dir"; then
+        echo "ERROR: a patched main-process chunk failed node --check." >&2
+        echo "       Packaging it would ship an app that opens a blank window." >&2
+        return 1
+    fi
 
     # Add linux branch to getHostPlatform() (without this, the minified
     # platform switch throws "Unsupported platform: linux-x64" and the
@@ -263,9 +242,9 @@ JSEOF
     # successful build log stays clean. Require at least one target to patch;
     # otherwise fail the build loudly — surfacing the stashed output to diagnose
     # a bundle-layout change — rather than ship a package with Cowork disabled.
-    echo "Applying cowork patch to ${#_index_targets[@]} file(s)..."
+    echo "Applying cowork patch to ${#INDEX_TARGETS[@]} file(s)..."
     local _t _out _any_patched="" _miss_log=""
-    for _t in "${_index_targets[@]}"; do
+    for _t in "${INDEX_TARGETS[@]}"; do
         if _out="$(python "${_repo}/enable-cowork.py" "$_t" 2>&1)"; then
             _any_patched=1
             [ -n "$_out" ] && printf '%s\n' "$_out"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -18,6 +18,12 @@ makedepends=(
     'p7zip'
     'asar'
     'curl'
+    # build() runs `python "${_repo}/enable-cowork.py"` unconditionally, so this
+    # is a hard build dependency. It was listed only in optdepends, which meant
+    # a clean-chroot build (the way AUR packages are supposed to be built) had
+    # no python and failed inside the patch loop -- and the recipe reported it
+    # as "the bundle layout may have changed" rather than a missing dependency.
+    'python'
 )
 optdepends=(
     'xdg-utils: for opening URLs'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -262,6 +262,18 @@ JSEOF
     fi
     echo "Cowork patches applied"
 
+    # Re-check syntax before packing. patch_index_apply_all already ran this,
+    # but three things rewrite these files AFTER it: the inline getHostPlatform
+    # sed above, and enable-cowork.py's own passes (several of which are
+    # markerless and substitute globally). Without this second call the
+    # "never ship a blank window" guarantee stops at the sed passes and misses
+    # the patcher entirely.
+    if ! PATCH_INDEX_STRICT_SYNTAX=1 patch_index_verify_syntax; then
+        echo "ERROR: a main-process chunk failed node --check after enable-cowork.py." >&2
+        echo "       Packaging it would ship an app that opens a blank window." >&2
+        return 1
+    fi
+
     # Repack into app.asar
     echo "Repacking app.asar..."
     asar pack "${srcdir}/linux-app-extracted" "${srcdir}/app.asar"

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -16,6 +16,8 @@ Example:
 
 import sys
 import re
+import shutil
+import subprocess
 
 # Minifiers emit string literals as either double quotes or template literals;
 # 1.26832.0 switched the main bundle wholesale from "darwin" to `darwin`. Match
@@ -112,8 +114,22 @@ def patch_file(filepath):
     return True
 
 # `new` is optional: 1.26832.0 emits a bare `throw Error(...)` here.
+#
+# The argument is matched with a paren-aware sub-pattern, not [^)]*. A bare
+# [^)]* stops at the FIRST ')', so a message built with a call in it --
+#   throw new Error("Unsupported platform: "+getPlatformName())
+# -- matched only up to `getPlatformName(`, and substituting the replacement
+# left the call's closing paren behind as `return"darwin-x64")`. That is a
+# syntax error, and patch_host_platform still returned True, so the whole script
+# printed SUCCESS and exited 0 on a bundle it had just corrupted. Template
+# literals interpolating a call, e.g. `${a.it()}`, hit the same shape.
+#
+# (?:[^()]|\([^()]*\))* allows one level of nesting, which covers a call in the
+# message. Deeper nesting still won't match -- that fails closed (no
+# substitution) rather than producing invalid JS.
+_ERR_ARG = r'(?:[^()]|\([^()]*\))*'
 HOST_PLATFORM_THROW_RE = re.compile(
-    r'throw (?:new )?Error\([^)]*Unsupported platform[^)]*\)'
+    r'throw (?:new )?Error\(' + _ERR_ARG + r'Unsupported platform' + _ERR_ARG + r'\)'
 )
 
 
@@ -236,6 +252,34 @@ def patch_platform_return_gates(filepath):
     return True
 
 
+def _warn_if_unparseable(filepath):
+    """Warn loudly if the patched file is no longer valid JavaScript.
+
+    Best-effort: silently skipped when node isn't on PATH, since node is a
+    hard dependency of the packaging path but not of this script.
+    """
+    node = shutil.which('node')
+    if not node:
+        return
+    try:
+        result = subprocess.run(
+            [node, '--check', filepath],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return
+    if result.returncode != 0:
+        detail = (result.stderr or '').strip().splitlines()
+        print(
+            f"ERROR: {filepath} is not valid JavaScript after patching.\n"
+            "       A patch pattern matched more or less than intended. This file\n"
+            "       would load as a blank window; do not ship it.",
+            file=sys.stderr,
+        )
+        for line in detail[:5]:
+            print(f"       {line}", file=sys.stderr)
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__)
@@ -253,6 +297,20 @@ if __name__ == "__main__":
     patch_host_platform(target)
     patch_ipc_origin_guards(target)
     patch_platform_return_gates(target)
+
+    # Every pass above is a regex substitution into minified JS, so a pattern
+    # that matches slightly more or less than intended produces a file that is
+    # no longer valid JavaScript. That used to be invisible: the passes report
+    # success from having substituted something, not from the result parsing,
+    # so a corrupted bundle still printed SUCCESS and exited 0, and surfaced
+    # much later as a blank window with no clue which pass did it.
+    #
+    # Deliberately does NOT change the exit code. Both callers treat non-zero as
+    # "no platform gate in this file", which is an expected, silent condition for
+    # most chunks -- failing that way would hide the corruption rather than
+    # surface it. Warn on stderr instead: install.sh lets it through, and
+    # PKGBUILD captures 2>&1 and prints it for any file it patched.
+    _warn_if_unparseable(target)
 
     # Exit code still reports only the platform gate: install.sh uses it to
     # decide whether Cowork was actually enabled across the whole bundle.

--- a/install.sh
+++ b/install.sh
@@ -835,7 +835,12 @@ apply_patches() {
         return
     fi
     if [[ -z "$patch_script" ]]; then
-        die "enable-cowork.py not found in $script_dir or $INSTALL_DIR. Cowork cannot be enabled; re-run from a complete checkout."
+        log_error "enable-cowork.py not found in $script_dir or $INSTALL_DIR."
+        log_error "Cowork will NOT be enabled. This usually means \$INSTALL_DIR is a"
+        log_error "checkout that could no longer fast-forward (a pinned CLAUDE_REPO_REF"
+        log_error "leaves it on a detached HEAD, and local edits block the pull)."
+        log_error "Fix it with: git -C \"$INSTALL_DIR\" checkout master && git -C \"$INSTALL_DIR\" pull"
+        return 0
     fi
 
     # Newer Claude Desktop builds emit index.js as a thin entry shim that
@@ -856,13 +861,28 @@ apply_patches() {
     elif [[ -f "$INSTALL_DIR/patch-index.sh" ]]; then
         discovery="$INSTALL_DIR/patch-index.sh"
     fi
-    if [[ -z "$discovery" ]]; then
-        die "patch-index.sh not found in $script_dir or $INSTALL_DIR. Cowork cannot be enabled; re-run from a complete checkout."
+    local -a targets=()
+    if [[ -n "$discovery" ]]; then
+        # shellcheck source=patch-index.sh
+        source "$discovery"
+        patch_index_collect_targets "$build_dir"
+        targets=("${INDEX_TARGETS[@]+"${INDEX_TARGETS[@]}"}")
+    else
+        # Degrade, never abort. This runs AFTER the destructive `asar extract`
+        # above, so dying here would leave a half-installed tree and skip the
+        # rest of main() -- launcher, sentinel, doctor. master had no external
+        # dependency here at all, so aborting would make a run master completes
+        # into a hard failure. Warn loudly and fall back to the same find(1).
+        log_warn "patch-index.sh not found in $script_dir or $INSTALL_DIR; using inline chunk discovery."
+        log_warn "Your \$INSTALL_DIR checkout is stale (a pinned CLAUDE_REPO_REF leaves it"
+        log_warn "on a detached HEAD, and local edits block the pull). Repair it with:"
+        log_warn "  git -C \"$INSTALL_DIR\" checkout master && git -C \"$INSTALL_DIR\" pull"
+        targets=("$index_js")
+        local _chunk
+        while IFS= read -r _chunk; do
+            [[ -n "$_chunk" ]] && targets+=("$_chunk")
+        done < <(find "$build_dir" -maxdepth 1 -name 'index*.chunk-*.js' -type f | sort)
     fi
-    # shellcheck source=patch-index.sh
-    source "$discovery"
-    patch_index_collect_targets "$build_dir"
-    local -a targets=("${INDEX_TARGETS[@]+"${INDEX_TARGETS[@]}"}")
 
     # enable-cowork.py exits 0 when it finds (or has already patched) the
     # platform gate in a file, and 1 otherwise. On split-entry builds the gate

--- a/install.sh
+++ b/install.sh
@@ -752,12 +752,16 @@ install_stubs() {
     # from the install dir (via claude-desktop launcher) use current code
     if [[ "$stub_src" != "$INSTALL_DIR" && -d "$INSTALL_DIR" ]]; then
         log_info "Syncing stubs and launch scripts to install dir..."
-        cp -rf "$stub_src/stubs" "$INSTALL_DIR/"
-        cp -f "$stub_src/launch.sh" "$INSTALL_DIR/launch.sh"
-        cp -f "$stub_src/launch-devtools.sh" "$INSTALL_DIR/launch-devtools.sh"
-        # launch.sh sources this for its patch passes and refuses to start
-        # without it, so it has to travel with launch.sh (#170).
-        cp -f "$stub_src/patch-index.sh" "$INSTALL_DIR/patch-index.sh"
+        # Name the missing file. Under `set -e` a bare cp failure aborts the
+        # install anyway, but with "cp: cannot stat ..." and no hint that the
+        # checkout is incomplete. patch-index.sh matters most: launch.sh sources
+        # it for its patch passes and refuses to start without it (#170), so a
+        # silent miss here would surface as a launcher that aborts every time.
+        local _f
+        for _f in launch.sh launch-devtools.sh patch-index.sh; do
+            [[ -f "$stub_src/$_f" ]] || die "$_f missing from $stub_src. Re-run from a complete checkout."
+            cp -f "$stub_src/$_f" "$INSTALL_DIR/$_f"
+        done
     fi
 
     log_success "Stubs installed"
@@ -815,9 +819,16 @@ apply_patches() {
         patch_script="$INSTALL_DIR/enable-cowork.py"
     fi
 
-    if [[ -z "$patch_script" || ! -f "$index_js" ]]; then
-        log_warn "Patch script or index.js not found, skipping patches"
+    # A missing index.js means there is nothing to patch yet, which is a
+    # legitimate state; a missing script of OURS means a broken checkout, and
+    # continuing would hand the user an install where Cowork was silently never
+    # enabled. Those deserve different answers, so don't fold them together.
+    if [[ ! -f "$index_js" ]]; then
+        log_warn "index.js not found at $index_js, skipping patches"
         return
+    fi
+    if [[ -z "$patch_script" ]]; then
+        die "enable-cowork.py not found in $script_dir or $INSTALL_DIR. Cowork cannot be enabled; re-run from a complete checkout."
     fi
 
     # Newer Claude Desktop builds emit index.js as a thin entry shim that
@@ -839,8 +850,7 @@ apply_patches() {
         discovery="$INSTALL_DIR/patch-index.sh"
     fi
     if [[ -z "$discovery" ]]; then
-        log_warn "patch-index.sh not found, skipping patches"
-        return
+        die "patch-index.sh not found in $script_dir or $INSTALL_DIR. Cowork cannot be enabled; re-run from a complete checkout."
     fi
     # shellcheck source=patch-index.sh
     source "$discovery"

--- a/install.sh
+++ b/install.sh
@@ -757,6 +757,13 @@ install_stubs() {
         # checkout is incomplete. patch-index.sh matters most: launch.sh sources
         # it for its patch passes and refuses to start without it (#170), so a
         # silent miss here would surface as a launcher that aborts every time.
+        # The stubs/ tree has to come along too. launch.sh re-syncs from
+        # $INSTALL_DIR/stubs into the extracted app on every start, and the
+        # launcher's protocol-forwarder search looks under it, so leaving it
+        # behind means an update installs fresh stubs and then has the old ones
+        # copied back over them on the next launch.
+        [[ -d "$stub_src/stubs" ]] || die "stubs/ missing from $stub_src. Re-run from a complete checkout."
+        cp -rf "$stub_src/stubs" "$INSTALL_DIR/"
         local _f
         for _f in launch.sh launch-devtools.sh patch-index.sh; do
             [[ -f "$stub_src/$_f" ]] || die "$_f missing from $stub_src. Re-run from a complete checkout."

--- a/install.sh
+++ b/install.sh
@@ -755,6 +755,9 @@ install_stubs() {
         cp -rf "$stub_src/stubs" "$INSTALL_DIR/"
         cp -f "$stub_src/launch.sh" "$INSTALL_DIR/launch.sh"
         cp -f "$stub_src/launch-devtools.sh" "$INSTALL_DIR/launch-devtools.sh"
+        # launch.sh sources this for its patch passes and refuses to start
+        # without it, so it has to travel with launch.sh (#170).
+        cp -f "$stub_src/patch-index.sh" "$INSTALL_DIR/patch-index.sh"
     fi
 
     log_success "Stubs installed"
@@ -825,14 +828,24 @@ apply_patches() {
     # index.js. Patch index.js plus every chunk it require()s; enable-cowork.py
     # is idempotent (marker-guarded) and reports "not found" harmlessly for
     # files that don't contain a given pattern.
-    # Take every index*.chunk-*.js in the build dir, not just the ones index.js
-    # names: chunks require() each other transitively, so the shim's direct
-    # requires are an incomplete list.
-    local -a targets=("$index_js")
-    local chunk
-    while IFS= read -r chunk; do
-        [[ -n "$chunk" ]] && targets+=("$chunk")
-    done < <(find "$build_dir" -maxdepth 1 -name 'index*.chunk-*.js' -type f | sort)
+    #
+    # Discovery comes from patch-index.sh rather than a private copy of the same
+    # find(1): launch.sh and PKGBUILD already share it, and a third copy is a
+    # third thing to forget when the bundle layout moves again (#170).
+    local discovery=""
+    if [[ -f "$script_dir/patch-index.sh" ]]; then
+        discovery="$script_dir/patch-index.sh"
+    elif [[ -f "$INSTALL_DIR/patch-index.sh" ]]; then
+        discovery="$INSTALL_DIR/patch-index.sh"
+    fi
+    if [[ -z "$discovery" ]]; then
+        log_warn "patch-index.sh not found, skipping patches"
+        return
+    fi
+    # shellcheck source=patch-index.sh
+    source "$discovery"
+    patch_index_collect_targets "$build_dir"
+    local -a targets=("${INDEX_TARGETS[@]+"${INDEX_TARGETS[@]}"}")
 
     # enable-cowork.py exits 0 when it finds (or has already patched) the
     # platform gate in a file, and 1 otherwise. On split-entry builds the gate

--- a/launch-devtools.sh
+++ b/launch-devtools.sh
@@ -44,6 +44,38 @@ if [ -d "stubs/cowork" ]; then
   cp -f stubs/cowork/*.js "linux-app-extracted/cowork/"
 fi
 
+# Apply the main-process patches and repack, the other half of "mirrors
+# launch.sh". Without this every cp above was thrown away: electron is handed
+# .asar-cache/app.asar, which is whatever launch.sh last packed, so editing a
+# stub and running this script debugged the PREVIOUS build. For a debugging
+# tool that is the worst possible failure — it looks like your change had no
+# effect.
+if [ -d "linux-app-extracted" ]; then
+  if [ -f "$SCRIPT_DIR/patch-index.sh" ]; then
+    # shellcheck source=patch-index.sh
+    source "$SCRIPT_DIR/patch-index.sh"
+    patch_index_apply_all "linux-app-extracted/.vite/build"
+  else
+    echo "WARNING: patch-index.sh not found; launching without the main-process patches" >&2
+  fi
+
+  if command -v asar >/dev/null 2>&1; then
+    mkdir -p "$(dirname "$ASAR_FILE")"
+    echo "Repacking app.asar..."
+    if ! asar pack linux-app-extracted "$ASAR_FILE"; then
+      echo "ERROR: asar pack failed; refusing to launch against a stale $ASAR_FILE" >&2
+      exit 1
+    fi
+  else
+    echo "WARNING: asar not installed; launching against the existing $ASAR_FILE" >&2
+  fi
+fi
+
+if [ ! -f "$ASAR_FILE" ]; then
+  echo "ERROR: $ASAR_FILE not found. Run ./launch.sh once to build it." >&2
+  exit 1
+fi
+
 # Enable logging and DevTools
 export ELECTRON_ENABLE_LOGGING=1
 export CLAUDE_ENABLE_LOGGING=1

--- a/launch-devtools.sh
+++ b/launch-devtools.sh
@@ -54,6 +54,8 @@ if [ -d "linux-app-extracted" ]; then
   if [ -f "$SCRIPT_DIR/patch-index.sh" ]; then
     # shellcheck source=patch-index.sh
     source "$SCRIPT_DIR/patch-index.sh"
+    # Same reasoning as launch.sh: persistent tree, so a miss is the norm here.
+    PATCH_INDEX_WARN_ON_MISS=0
     patch_index_apply_all "linux-app-extracted/.vite/build"
   else
     echo "WARNING: patch-index.sh not found; launching without the main-process patches" >&2

--- a/launch-devtools.sh
+++ b/launch-devtools.sh
@@ -50,7 +50,28 @@ fi
 # stub and running this script debugged the PREVIOUS build. For a debugging
 # tool that is the worst possible failure — it looks like your change had no
 # effect.
+#
+# Only repack a tree launch.sh has ALREADY prepared. launch.sh does more than
+# patch: it rewrites package.json's entry point to frame-fix-entry.js, mirrors
+# the i18n JSONs, swaps in the Linux pty.node, and installs the plugin shim.
+# Repacking without those produces an asar that loads .vite/build/index.pre.js
+# directly, so the frame-fix wrapper never runs and the app comes up broken.
+# Copying that list here is precisely how launch.sh and PKGBUILD drifted apart
+# (#170), so require the prepared state and point at launch.sh instead.
+if [ ! -f "$ASAR_FILE" ]; then
+  echo "ERROR: $ASAR_FILE not found. Run ./launch.sh once to build it." >&2
+  exit 1
+fi
+
 if [ -d "linux-app-extracted" ]; then
+  if ! grep -q '"main":[[:space:]]*"frame-fix-entry.js"' "linux-app-extracted/package.json" 2>/dev/null; then
+    echo "ERROR: linux-app-extracted has not been prepared by launch.sh." >&2
+    echo "       Its package.json entry point is still the stock one, so a repack" >&2
+    echo "       here would produce an asar that never loads frame-fix-wrapper." >&2
+    echo "       Run ./launch.sh once first." >&2
+    exit 1
+  fi
+
   if [ -f "$SCRIPT_DIR/patch-index.sh" ]; then
     # shellcheck source=patch-index.sh
     source "$SCRIPT_DIR/patch-index.sh"
@@ -71,11 +92,6 @@ if [ -d "linux-app-extracted" ]; then
   else
     echo "WARNING: asar not installed; launching against the existing $ASAR_FILE" >&2
   fi
-fi
-
-if [ ! -f "$ASAR_FILE" ]; then
-  echo "ERROR: $ASAR_FILE not found. Run ./launch.sh once to build it." >&2
-  exit 1
 fi
 
 # Enable logging and DevTools

--- a/launch.sh
+++ b/launch.sh
@@ -123,161 +123,24 @@ if [ -f "$PKG_JSON" ] && grep -q '"main":.*index\.pre\.js"' "$PKG_JSON"; then
   sed -i 's|"main":.*"\.vite/build/index\.pre\.js"|"main": "frame-fix-entry.js"|' "$PKG_JSON"
 fi
 
-# ── Locate the main-process code file(s) ────────────────────────────────────
-# Vite compiles the main process into .vite/build/. Newer Claude Desktop builds
-# emit index.js as a thin entry shim that require()s the real code from an
-# index.chunk-<hash>.js file (the <hash> changes every build, and 1.26832.0 adds a
-# parallel index2.chunk-<hash>.js series that holds the Cowork gate); older builds keep
-# everything in index.js. The patches below must run against whichever file
-# actually holds the code, so collect index.js plus every chunk it require()s.
-# Applying each grep-guarded patch across all of them is safe: a file that lacks
-# the pattern is skipped. This also survives minifier identifier rotation because
-# the patterns below match on stable API/string tokens, not minified var names.
-# Collect index.js plus *every* index*.chunk-*.js in the build dir, not just the
-# ones index.js names: chunks are also require()d transitively by other chunks
-# (on 1.26832.0 the --effort builder lives in index2.chunk-Cqfh0Vpp.js, which the
-# shim never references), so following only the shim's direct requires misses
-# them. Every patch below is grep-guarded, so listing a chunk that lacks the
-# pattern costs nothing.
-_BUILD_DIR="linux-app-extracted/.vite/build"
-INDEX_TARGETS=()
-if [ -f "$_BUILD_DIR/index.js" ]; then
-  INDEX_TARGETS+=("$_BUILD_DIR/index.js")
-  while IFS= read -r _chunk; do
-    [ -n "$_chunk" ] && INDEX_TARGETS+=("$_chunk")
-  done < <(find "$_BUILD_DIR" -maxdepth 1 -name 'index*.chunk-*.js' -type f | sort)
+# ── Main-process patches ────────────────────────────────────────────────────
+# The sed passes that make the minified main-process bundle work on Linux live
+# in patch-index.sh, not here. launch.sh and PKGBUILD's build() both source that
+# one file, so the two entry points cannot drift apart again (#170: launch.sh
+# had grown to 9 passes while the AUR recipe still applied 3, and AUR users
+# silently lost the MCP node-host and resourcesPath fixes).
+if [ ! -f "$SCRIPT_DIR/patch-index.sh" ]; then
+  echo "ERROR: patch-index.sh not found next to launch.sh ($SCRIPT_DIR)." >&2
+  echo "       It carries every main-process patch pass. Launching without it" >&2
+  echo "       would start an unpatched app: macOS titlebars, no local MCP" >&2
+  echo "       servers, and a renderer shell that never loads. Re-run" >&2
+  echo "       install.sh to restore it." >&2
+  exit 1
 fi
+# shellcheck source=patch-index.sh
+source "$SCRIPT_DIR/patch-index.sh"
 
-# patch_index "<log message>" "<grep -E guard>" "<sed -E script>"
-# Runs the sed against every main-process code file matching the guard; logs once
-# if any file matched. Minified identifiers are matched with [A-Za-z0-9_$]+ so the
-# patches keep working when a new build reshuffles variable names.
-patch_index() {
-  local msg="$1" pat="$2" script="$3" f matched=""
-  for f in "${INDEX_TARGETS[@]}"; do
-    if grep -qE "$pat" "$f" 2>/dev/null; then
-      sed -i -E "$script" "$f"
-      matched=1
-    fi
-  done
-  [ -n "$matched" ] && echo "$msg"
-}
-
-# Fix window decorations: remove macOS-specific titlebar options from the windows.
-# The Vite bundle bypasses the frame-fix-wrapper's require interception, so we patch directly.
-patch_index "Patching macOS titlebar options for Linux (main window)..." \
-  'titleBarStyle:["`]hidden["`],titleBarOverlay:[A-Za-z0-9_$!.]+,trafficLightPosition:[A-Za-z0-9_$!.]+,' \
-  's/titleBarStyle:["`]hidden["`],titleBarOverlay:[A-Za-z0-9_$!.]+,trafficLightPosition:[A-Za-z0-9_$!.]+,//g'
-patch_index "Patching macOS titlebar options for Linux (about window)..." \
-  'titleBarStyle:["`]hiddenInset["`],autoHideMenuBar:!0,skipTaskbar:!0' \
-  's/titleBarStyle:["`]hiddenInset["`],autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g'
-
-# Fix origin validation: the asar's nue() function rejects file:// preloads
-# when app.isPackaged is false (which it always is when running via `electron .asar`).
-# This causes the mainWindow/findInPage preloads to crash before exposing `process`
-# via contextBridge, breaking the renderer shell. Drop the isPackaged requirement
-# for file:// origins — the content is inside our asar, so there's no security risk.
-patch_index "Patching origin validation for file:// preloads..." \
-  '[A-Za-z0-9_$]+\.protocol===["`]file:["`]&&[A-Za-z0-9_$.]+\.app\.isPackaged===!0' \
-  's/([A-Za-z0-9_$]+)\.protocol===["`]file:["`]&&[A-Za-z0-9_$.]+\.app\.isPackaged===!0/\1.protocol==="file:"/g'
-
-# Fix preload origin validation: the mainView.js preload's h() guard checks
-# if window.location.href origin matches claude.ai/preview.claude.ai etc.
-# On Linux with file:// protocol, origin is "null" and h() returns false,
-# preventing CoworkSpaces (and other IPC bridges) from being exposed to the
-# renderer. This causes the Projects page to be empty and spaces to not persist.
-# Patch: add file:// protocol as an allowed origin.
-MAINVIEW_JS="linux-app-extracted/.vite/build/mainView.js"
-if [ -f "$MAINVIEW_JS" ] && ! grep -qE 'e\.protocol===["`]file:["`]' "$MAINVIEW_JS"; then
-  echo "Patching preload origin validation for file:// protocol..."
-  sed -i -E 's/e\.hostname===["`]localhost["`]/&||e.protocol==="file:"/g' "$MAINVIEW_JS"
-fi
-
-# Fix --effort xhigh: Claude Desktop may pass --effort xhigh but the SDK binary
-# only supports low/medium/high/max. Remap xhigh -> max in the CLI arg builder.
-patch_index "Patching --effort xhigh -> max..." \
-  '[A-Za-z0-9_$]+\.push\(["`]--effort["`],this\.options\.effort\)' \
-  's/([A-Za-z0-9_$]+)\.push\(["`]--effort["`],this\.options\.effort\)/\1.push("--effort",this.options.effort==="xhigh"?"max":this.options.effort)/g'
-
-# NOTE: do not "simplify" the disclaimer wrapper away by patching the bundle's
-#   f(t){return process.platform!=="darwin"?t:{cmd:disclaimerBin(),args:[t.cmd,...t.args]}}
-# to its non-darwin (identity) branch. It looks like dead weight we only incur
-# because we spoof platform, but on Linux that wrap is load-bearing: it is the
-# only chokepoint where our spawn interception sees the bundle's own spawn
-# decisions, and the unwrap substitutes OUR resolved Claude binary for whatever
-# path the asar chose (claude-code-vm/<ver>/claude, a macOS .app path). Taking
-# the identity branch hands the SDK the asar's path unchanged and regresses
-# #132. See resolveDisclaimerCommand in stubs/cowork/exec_capability_registry.js.
-
-# Fix macOS Handoff API: invalidateCurrentActivity() and setUserActivity() are
-# macOS-only Electron APIs that crash on Linux. Replace with safe no-op fallbacks.
-patch_index "Patching macOS Handoff API invalidateCurrentActivity for Linux..." \
-  '[A-Za-z0-9_$]+\.app\.invalidateCurrentActivity\(\)' \
-  's/([A-Za-z0-9_$]+)\.app\.invalidateCurrentActivity\(\)/(\1.app.invalidateCurrentActivity||function(){})()/g'
-patch_index "Patching macOS Handoff API setUserActivity for Linux..." \
-  '[A-Za-z0-9_$]+\.app\.setUserActivity\([A-Za-z0-9_$]+,' \
-  's/([A-Za-z0-9_$]+)\.app\.setUserActivity\(([A-Za-z0-9_$]+),/((\1.app.setUserActivity||function(){}))(\2,/g'
-
-# Fix resource path lookup for i18n, shim-lib, icon, etc.
-# The asar uses `app.isPackaged ? process.resourcesPath : <asar-relative path>`.
-# On Arch Linux, `process.resourcesPath` is the system electron's dir
-# (e.g., /usr/lib/electron39/resources/), which only has default_app.asar —
-# locales live at /usr/lib/electron39/locales/*.pak (wrong format, wrong path).
-# The fallback branch resolves to resources/ inside our asar, where launch.sh
-# populates resources/i18n/*.json. Always use the fallback so locale JSONs load.
-patch_index "Patching resourcesPath lookups to use asar-internal resources/..." \
-  '[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath:' \
-  's/[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath://g'
-
-# Fix MCP node-host path resolution ("MCP Filesystem: Node host not found").
-# The MCP runtime computes its host paths as
-#   app.isPackaged ? join(process.resourcesPath,"app.asar",...) : join(getAppPath(),...)
-# but frame-fix-wrapper.js overrides process.resourcesPath to
-# ~/.config/Claude/cowork-resources (so the disclaimer/Helpers dir is writable),
-# and that location has no app.asar — so the packaged branch resolves to a
-# nonexistent nodeHost.js/directMcpHost.js and the MCP server fails to start.
-# getAppPath() already points inside the running asar (and equals
-# resources/app.asar on a stock build), so rewrite the packaged branch to use
-# it. Covers nodeHost.js, directMcpHost.js, and the asar-root helper — every
-# isPackaged-guarded asar-internal lookup. The resourcesPath patch above only
-# matches the bare `isPackaged?process.resourcesPath:` shape, not these join()
-# forms, so this is a separate pass.
-patch_index "Patching MCP node-host asar paths to use getAppPath()..." \
-  '[A-Za-z0-9_$]+\.app\.isPackaged\?[A-Za-z0-9_$.]+\.join\(process\.resourcesPath,["`]app\.asar["`]' \
-  's/([A-Za-z0-9_$]+)\.app\.isPackaged\?([A-Za-z0-9_$.]+)\.join\(process\.resourcesPath,["`]app\.asar["`]/\1.app.isPackaged?\2.join(\1.app.getAppPath()/g'
-
-# Catch-all for the same join with NO isPackaged guard (reported by @shawnyeager
-# on #167). shellPathWorker.js is resolved unconditionally:
-#   function v(){return o.default.join(process.resourcesPath,`app.asar`,`.vite`,`build`,`shell-path-worker`,`shellPathWorker.js`)}
-# The guarded pass above can't reach it, so it keeps resolving through the
-# overridden process.resourcesPath (~/.config/Claude/cowork-resources), which has
-# no app.asar — breaking login-shell PATH priming.
-#
-# This must run AFTER the guarded pass: that pass has already rewritten its own
-# sites away from `process.resourcesPath,app.asar`, so this only touches what it
-# missed. The main-process chunks are CJS with require in scope, so require the
-# app lazily rather than assuming a minified electron binding is in scope here.
-patch_index "Patching unguarded resourcesPath+app.asar joins to use getAppPath()..." \
-  'process\.resourcesPath,["`]app\.asar["`]' \
-  's/process\.resourcesPath,["`]app\.asar["`]/require("electron").app.getAppPath()/g'
-
-# Syntax-check every patched chunk before repacking. We now rewrite ~300 files
-# instead of 2, and patch_host_platform in particular is markerless and subs
-# globally, so a malformed rewrite would otherwise surface as a blank window at
-# launch with no clue which pass produced it. node --check is cheap next to the
-# repack and names the offending file. Warn rather than abort: a syntax error in
-# a chunk we never patched shouldn't block a launch that would otherwise work.
-if command -v node >/dev/null 2>&1; then
-  _bad=0
-  for _f in "${INDEX_TARGETS[@]}"; do
-    [ -f "$_f" ] || continue
-    if ! node --check "$_f" 2>/dev/null; then
-      echo "WARNING: $_f fails node --check after patching" >&2
-      _bad=$((_bad + 1))
-    fi
-  done
-  [ "$_bad" -gt 0 ] && echo "WARNING: $_bad patched chunk(s) failed syntax check" >&2
-fi
+patch_index_apply_all "linux-app-extracted/.vite/build"
 
 # Only repack if stub is newer than asar (or asar doesn't exist)
 # Repack if any file in the extracted tree is newer than the cached asar.

--- a/launch.sh
+++ b/launch.sh
@@ -140,6 +140,15 @@ fi
 # shellcheck source=patch-index.sh
 source "$SCRIPT_DIR/patch-index.sh"
 
+# The launcher re-patches a PERSISTENT tree on every start, so from the second
+# launch onward every pass legitimately matches nothing -- it already did its
+# work. Warning there would print ~9 WARN lines on every launch of a perfectly
+# healthy install, which is noise AND actively harmful: it makes a real #166
+# silent-no-op indistinguishable from the normal steady state. PKGBUILD keeps
+# the warning because build() always starts from a fresh `asar extract`, where a
+# miss really does mean a pattern stopped matching.
+PATCH_INDEX_WARN_ON_MISS=0
+
 patch_index_apply_all "linux-app-extracted/.vite/build"
 
 # Only repack if stub is newer than asar (or asar doesn't exist)

--- a/launch.sh
+++ b/launch.sh
@@ -157,7 +157,18 @@ else
 fi
 if [ "$_needs_repack" = true ]; then
   echo "Repacking app.asar..."
-  asar pack linux-app-extracted "$ASAR_FILE"
+  # Stop on failure. launch.sh has no `set -e`, so an asar pack that died
+  # (asar not installed, disk full, a partially-written target) used to fall
+  # straight through to launching electron against whatever was there before —
+  # a stale asar, or none at all. The stale case is the dangerous one: the app
+  # comes up looking fine, running the previous build, with the failure already
+  # scrolled off.
+  if ! asar pack linux-app-extracted "$ASAR_FILE"; then
+    echo "ERROR: asar pack failed." >&2
+    echo "       Refusing to launch against a stale or missing $ASAR_FILE." >&2
+    echo "       Is the 'asar' command installed, and is there free disk space?" >&2
+    exit 1
+  fi
 else
   echo "Using cached app.asar (no changes)"
 fi

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -156,7 +156,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     share="$out/share/claude-cowork-linux"
     mkdir -p "$share"
     cp -r tree/linux-app-extracted "$share/"
-    cp launch.sh launch-devtools.sh enable-cowork.py COMPAT.md "$share/"
+    cp launch.sh launch-devtools.sh patch-index.sh enable-cowork.py COMPAT.md "$share/"
     cp -r stubs "$share/"
 
     icns="$share/linux-app-extracted/resources/electron.icns"

--- a/patch-index.sh
+++ b/patch-index.sh
@@ -19,9 +19,27 @@
 # launch.sh and PKGBUILD used to carry two hand-maintained copies of the pass
 # list. They drifted: launch.sh grew to 9 passes while PKGBUILD's build() stayed
 # at 3. Because /usr/bin/claude-cowork execs electron directly against the
-# packaged asar and never calls launch.sh, AUR users silently lost the other
-# six -- most visibly the MCP node-host path fix, which surfaces as
-# "MCP Filesystem: Node host not found" and no local MCP servers.
+# packaged asar and never calls launch.sh, AUR users silently lost the other six.
+#
+# Two of those six actually regressed the AUR build:
+#   - the unguarded `process.resourcesPath,"app.asar"` join, which left
+#     shellPathWorker.js resolving to a nonexistent file and broke login-shell
+#     PATH priming;
+#   - the mainView.js preload-origin patch, which left CoworkSpaces unexposed to
+#     the renderer (empty Projects page, spaces not persisting).
+#
+# The other four did not, and it is worth saying so here so nobody re-adds them
+# expecting a fix. The resourcesPath and MCP node-host passes are both gated on
+# app.isPackaged, and both launchers start electron with a *path argument*, so
+# process.defaultApp is true, isPackaged is false, and those seds rewrite a
+# branch that is never taken (see the same note at the resourcesPath pass
+# below). The Handoff pair and the --effort remap are independently covered by
+# frame-fix-wrapper.js and session_orchestrator.js, which PKGBUILD does install.
+#
+# In particular this is NOT the cause of "MCP Filesystem: Node host not found".
+# #170 said it was; that was reasoning from "the pass is missing" to "the symptom
+# must occur" without checking the branch was reachable, and the issue title
+# still carries it.
 #
 # The drift was invisible because both builds "worked". Keeping one list makes
 # it unrepresentable rather than merely tested for.

--- a/patch-index.sh
+++ b/patch-index.sh
@@ -37,17 +37,22 @@
 #       Logs once if any file matched; warns once if none did. Always returns 0.
 #
 #   patch_index_verify_syntax
-#       node --check every file in INDEX_TARGETS, warning (not failing) on a
-#       parse error. Always returns 0.
+#       node --check every file in INDEX_TARGETS. Warns and returns 0 by
+#       default; returns 1 on a parse error when PATCH_INDEX_STRICT_SYNTAX=1.
 #
 #   patch_index_apply_all <build_dir>
 #       collect targets -> every pass, in order -> mainView.js -> verify syntax.
-#       Always returns 0.
+#       Returns 0, except that it propagates a strict-mode syntax failure.
 #
-# Every function returns 0 unconditionally. PKGBUILD's build() runs under
-# makepkg's `set -e`, so a function whose last command is a failing test (the
-# `[ -n "$matched" ] && echo` shape launch.sh used) would abort the package
-# build the first time a pass legitimately found nothing.
+# RETURN CONTRACT
+# ---------------
+# The syntax check is the ONLY thing that can make any of these return non-zero,
+# and only when the caller opts in with PATCH_INDEX_STRICT_SYNTAX=1. Everything
+# else returns 0 unconditionally -- in particular a pass that matches nothing is
+# not an error. PKGBUILD's build() runs under makepkg's `set -e`, so a function
+# whose last command is a failing test (the `[ -n "$matched" ] && echo` shape
+# launch.sh used) would abort the package build the first time a pass
+# legitimately found nothing.
 #
 # ADDING A PASS
 # -------------

--- a/patch-index.sh
+++ b/patch-index.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+# ============================================================
+# Shared main-process patch passes (single source of truth)
+# ============================================================
+#
+# This file is SOURCED, never executed. It is the one definition of the sed
+# passes applied to Claude Desktop's minified main-process bundle, plus the
+# chunk-discovery and syntax-check machinery around them.
+#
+# Consumers:
+#   - launch.sh          sources this and calls patch_index_apply_all before repacking
+#   - PKGBUILD build()   sources this and calls patch_index_apply_all at build time
+#   - install.sh         gets these passes by invoking launch.sh at run time, and
+#                        copies this file into $INSTALL_DIR alongside launch.sh
+#   - tests/test-cowork-patch.sh sources this directly to exercise the passes
+#
+# WHY THIS FILE EXISTS (issue #170)
+# --------------------------------
+# launch.sh and PKGBUILD used to carry two hand-maintained copies of the pass
+# list. They drifted: launch.sh grew to 9 passes while PKGBUILD's build() stayed
+# at 3. Because /usr/bin/claude-cowork execs electron directly against the
+# packaged asar and never calls launch.sh, AUR users silently lost the other
+# six -- most visibly the MCP node-host path fix, which surfaces as
+# "MCP Filesystem: Node host not found" and no local MCP servers.
+#
+# The drift was invisible because both builds "worked". Keeping one list makes
+# it unrepresentable rather than merely tested for.
+#
+# CONTRACT
+# --------
+#   patch_index_collect_targets <build_dir>
+#       Populates the global INDEX_TARGETS array with the main-process code
+#       files to patch. Returns 0 even when nothing is found.
+#
+#   patch_index "<log message>" "<grep -E guard>" "<sed -E script>"
+#       Applies the sed to every file in INDEX_TARGETS matching the guard.
+#       Logs once if any file matched; warns once if none did. Always returns 0.
+#
+#   patch_index_verify_syntax
+#       node --check every file in INDEX_TARGETS, warning (not failing) on a
+#       parse error. Always returns 0.
+#
+#   patch_index_apply_all <build_dir>
+#       collect targets -> every pass, in order -> mainView.js -> verify syntax.
+#       Always returns 0.
+#
+# Every function returns 0 unconditionally. PKGBUILD's build() runs under
+# makepkg's `set -e`, so a function whose last command is a failing test (the
+# `[ -n "$matched" ] && echo` shape launch.sh used) would abort the package
+# build the first time a pass legitimately found nothing.
+#
+# ADDING A PASS
+# -------------
+# Add it to patch_index_apply_all below and nowhere else. Both consumers pick
+# it up automatically. Mind the ordering note on the last two passes.
+
+# Warn when a pass matches nothing. Silent no-ops are this project's worst
+# failure mode -- #166 shipped a build where every pattern missed and the
+# install still reported success -- so the noisier of the two historical
+# behaviours is the one worth keeping. Set to 0 to silence.
+: "${PATCH_INDEX_WARN_ON_MISS:=1}"
+
+# ── Locate the main-process code file(s) ────────────────────────────────────
+# Vite compiles the main process into .vite/build/. Newer Claude Desktop builds
+# emit index.js as a thin entry shim that require()s the real code from an
+# index.chunk-<hash>.js file (the <hash> changes every build, and 1.26832.0 adds a
+# parallel index2.chunk-<hash>.js series that holds the Cowork gate); older builds keep
+# everything in index.js. The patches below must run against whichever file
+# actually holds the code, so collect index.js plus every chunk it require()s.
+# Applying each grep-guarded patch across all of them is safe: a file that lacks
+# the pattern is skipped. This also survives minifier identifier rotation because
+# the patterns below match on stable API/string tokens, not minified var names.
+# Collect index.js plus *every* index*.chunk-*.js in the build dir, not just the
+# ones index.js names: chunks are also require()d transitively by other chunks
+# (on 1.26832.0 the --effort builder lives in index2.chunk-Cqfh0Vpp.js, which the
+# shim never references), so following only the shim's direct requires misses
+# them. Every patch below is grep-guarded, so listing a chunk that lacks the
+# pattern costs nothing.
+patch_index_collect_targets() {
+  local build_dir="$1" chunk
+  INDEX_TARGETS=()
+  if [ -f "$build_dir/index.js" ]; then
+    INDEX_TARGETS+=("$build_dir/index.js")
+    while IFS= read -r chunk; do
+      [ -n "$chunk" ] && INDEX_TARGETS+=("$chunk")
+    done < <(find "$build_dir" -maxdepth 1 -name 'index*.chunk-*.js' -type f | sort)
+  fi
+  return 0
+}
+
+# patch_index "<log message>" "<grep -E guard>" "<sed -E script>"
+# Runs the sed against every main-process code file matching the guard; logs once
+# if any file matched. Minified identifiers are matched with [A-Za-z0-9_$]+ so the
+# patches keep working when a new build reshuffles variable names.
+patch_index() {
+  local msg="$1" pat="$2" script="$3" f matched=""
+  for f in "${INDEX_TARGETS[@]+"${INDEX_TARGETS[@]}"}"; do
+    if grep -qE "$pat" "$f" 2>/dev/null; then
+      sed -i -E "$script" "$f"
+      matched=1
+    fi
+  done
+  if [ -n "$matched" ]; then
+    echo "$msg"
+  elif [ "$PATCH_INDEX_WARN_ON_MISS" != "0" ]; then
+    echo "WARN: patch skipped (target not found): $msg" >&2
+  fi
+  return 0
+}
+
+# Syntax-check every patched chunk before repacking. We now rewrite ~300 files
+# instead of 2, and patch_host_platform in particular is markerless and subs
+# globally, so a malformed rewrite would otherwise surface as a blank window at
+# launch with no clue which pass produced it. node --check is cheap next to the
+# repack and names the offending file. Warn rather than abort: a syntax error in
+# a chunk we never patched shouldn't block a launch that would otherwise work.
+#
+# PATCH_INDEX_STRICT_SYNTAX=1 turns the warning into a failure. A build step
+# should stop rather than ship a package that opens a blank window; a launcher
+# should not refuse to start an app that would otherwise work.
+patch_index_verify_syntax() {
+  command -v node >/dev/null 2>&1 || return 0
+  local f bad=0
+  for f in "${INDEX_TARGETS[@]+"${INDEX_TARGETS[@]}"}"; do
+    [ -f "$f" ] || continue
+    if ! node --check "$f" 2>/dev/null; then
+      echo "WARNING: $f fails node --check after patching" >&2
+      bad=$((bad + 1))
+    fi
+  done
+  if [ "$bad" -gt 0 ]; then
+    echo "WARNING: $bad patched chunk(s) failed syntax check" >&2
+    [ "${PATCH_INDEX_STRICT_SYNTAX:-0}" = "1" ] && return 1
+  fi
+  return 0
+}
+
+# patch_index_apply_all <build_dir>
+# The full pass list, in order. This is the single source of truth: launch.sh
+# and PKGBUILD both call exactly this.
+patch_index_apply_all() {
+  local build_dir="$1"
+
+  patch_index_collect_targets "$build_dir"
+
+  # Fix window decorations: remove macOS-specific titlebar options from the windows.
+  # The Vite bundle bypasses the frame-fix-wrapper's require interception, so we patch directly.
+  patch_index "Patching macOS titlebar options for Linux (main window)..." \
+    'titleBarStyle:["`]hidden["`],titleBarOverlay:[A-Za-z0-9_$!.]+,trafficLightPosition:[A-Za-z0-9_$!.]+,' \
+    's/titleBarStyle:["`]hidden["`],titleBarOverlay:[A-Za-z0-9_$!.]+,trafficLightPosition:[A-Za-z0-9_$!.]+,//g'
+  patch_index "Patching macOS titlebar options for Linux (about window)..." \
+    'titleBarStyle:["`]hiddenInset["`],autoHideMenuBar:!0,skipTaskbar:!0' \
+    's/titleBarStyle:["`]hiddenInset["`],autoHideMenuBar:!0,skipTaskbar:!0/autoHideMenuBar:!0/g'
+
+  # Fix origin validation: the asar's nue() function rejects file:// preloads
+  # when app.isPackaged is false (which it always is when running via `electron .asar`).
+  # This causes the mainWindow/findInPage preloads to crash before exposing `process`
+  # via contextBridge, breaking the renderer shell. Drop the isPackaged requirement
+  # for file:// origins — the content is inside our asar, so there's no security risk.
+  patch_index "Patching origin validation for file:// preloads..." \
+    '[A-Za-z0-9_$]+\.protocol===["`]file:["`]&&[A-Za-z0-9_$.]+\.app\.isPackaged===!0' \
+    's/([A-Za-z0-9_$]+)\.protocol===["`]file:["`]&&[A-Za-z0-9_$.]+\.app\.isPackaged===!0/\1.protocol==="file:"/g'
+
+  # Fix --effort xhigh: Claude Desktop may pass --effort xhigh but the SDK binary
+  # only supports low/medium/high/max. Remap xhigh -> max in the CLI arg builder.
+  patch_index "Patching --effort xhigh -> max..." \
+    '[A-Za-z0-9_$]+\.push\(["`]--effort["`],this\.options\.effort\)' \
+    's/([A-Za-z0-9_$]+)\.push\(["`]--effort["`],this\.options\.effort\)/\1.push("--effort",this.options.effort==="xhigh"?"max":this.options.effort)/g'
+
+  # NOTE: do not "simplify" the disclaimer wrapper away by patching the bundle's
+  #   f(t){return process.platform!=="darwin"?t:{cmd:disclaimerBin(),args:[t.cmd,...t.args]}}
+  # to its non-darwin (identity) branch. It looks like dead weight we only incur
+  # because we spoof platform, but on Linux that wrap is load-bearing: it is the
+  # only chokepoint where our spawn interception sees the bundle's own spawn
+  # decisions, and the unwrap substitutes OUR resolved Claude binary for whatever
+  # path the asar chose (claude-code-vm/<ver>/claude, a macOS .app path). Taking
+  # the identity branch hands the SDK the asar's path unchanged and regresses
+  # #132. See resolveDisclaimerCommand in stubs/cowork/exec_capability_registry.js.
+
+  # Fix macOS Handoff API: invalidateCurrentActivity() and setUserActivity() are
+  # macOS-only Electron APIs that crash on Linux. Replace with safe no-op fallbacks.
+  patch_index "Patching macOS Handoff API invalidateCurrentActivity for Linux..." \
+    '[A-Za-z0-9_$]+\.app\.invalidateCurrentActivity\(\)' \
+    's/([A-Za-z0-9_$]+)\.app\.invalidateCurrentActivity\(\)/(\1.app.invalidateCurrentActivity||function(){})()/g'
+  patch_index "Patching macOS Handoff API setUserActivity for Linux..." \
+    '[A-Za-z0-9_$]+\.app\.setUserActivity\([A-Za-z0-9_$]+,' \
+    's/([A-Za-z0-9_$]+)\.app\.setUserActivity\(([A-Za-z0-9_$]+),/((\1.app.setUserActivity||function(){}))(\2,/g'
+
+  # Fix resource path lookup for i18n, shim-lib, icon, etc.
+  # The asar uses `app.isPackaged ? process.resourcesPath : <asar-relative path>`.
+  # On Arch Linux, `process.resourcesPath` is the system electron's dir
+  # (e.g., /usr/lib/electron39/resources/), which only has default_app.asar —
+  # locales live at /usr/lib/electron39/locales/*.pak (wrong format, wrong path).
+  # The fallback branch resolves to resources/ inside our asar, where launch.sh
+  # populates resources/i18n/*.json. Always use the fallback so locale JSONs load.
+  patch_index "Patching resourcesPath lookups to use asar-internal resources/..." \
+    '[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath:' \
+    's/[A-Za-z0-9_$]+\.app\.isPackaged\?process\.resourcesPath://g'
+
+  # Fix MCP node-host path resolution ("MCP Filesystem: Node host not found").
+  # The MCP runtime computes its host paths as
+  #   app.isPackaged ? join(process.resourcesPath,"app.asar",...) : join(getAppPath(),...)
+  # but frame-fix-wrapper.js overrides process.resourcesPath to
+  # ~/.config/Claude/cowork-resources (so the disclaimer/Helpers dir is writable),
+  # and that location has no app.asar — so the packaged branch resolves to a
+  # nonexistent nodeHost.js/directMcpHost.js and the MCP server fails to start.
+  # getAppPath() already points inside the running asar (and equals
+  # resources/app.asar on a stock build), so rewrite the packaged branch to use
+  # it. Covers nodeHost.js, directMcpHost.js, and the asar-root helper — every
+  # isPackaged-guarded asar-internal lookup. The resourcesPath patch above only
+  # matches the bare `isPackaged?process.resourcesPath:` shape, not these join()
+  # forms, so this is a separate pass.
+  patch_index "Patching MCP node-host asar paths to use getAppPath()..." \
+    '[A-Za-z0-9_$]+\.app\.isPackaged\?[A-Za-z0-9_$.]+\.join\(process\.resourcesPath,["`]app\.asar["`]' \
+    's/([A-Za-z0-9_$]+)\.app\.isPackaged\?([A-Za-z0-9_$.]+)\.join\(process\.resourcesPath,["`]app\.asar["`]/\1.app.isPackaged?\2.join(\1.app.getAppPath()/g'
+
+  # Catch-all for the same join with NO isPackaged guard (reported by @shawnyeager
+  # on #167). shellPathWorker.js is resolved unconditionally:
+  #   function v(){return o.default.join(process.resourcesPath,`app.asar`,`.vite`,`build`,`shell-path-worker`,`shellPathWorker.js`)}
+  # The guarded pass above can't reach it, so it keeps resolving through the
+  # overridden process.resourcesPath (~/.config/Claude/cowork-resources), which has
+  # no app.asar — breaking login-shell PATH priming.
+  #
+  # This must run AFTER the guarded pass: that pass has already rewritten its own
+  # sites away from `process.resourcesPath,app.asar`, so this only touches what it
+  # missed. The main-process chunks are CJS with require in scope, so require the
+  # app lazily rather than assuming a minified electron binding is in scope here.
+  patch_index "Patching unguarded resourcesPath+app.asar joins to use getAppPath()..." \
+    'process\.resourcesPath,["`]app\.asar["`]' \
+    's/process\.resourcesPath,["`]app\.asar["`]/require("electron").app.getAppPath()/g'
+
+  # Fix preload origin validation: the mainView.js preload's h() guard checks
+  # if window.location.href origin matches claude.ai/preview.claude.ai etc.
+  # On Linux with file:// protocol, origin is "null" and h() returns false,
+  # preventing CoworkSpaces (and other IPC bridges) from being exposed to the
+  # renderer. This causes the Projects page to be empty and spaces to not persist.
+  # Patch: add file:// protocol as an allowed origin.
+  #
+  # Separate from patch_index because it targets a preload bundle, not the
+  # main-process chunks in INDEX_TARGETS.
+  local mainview_js="$build_dir/mainView.js"
+  if [ -f "$mainview_js" ] && ! grep -qE 'e\.protocol===["`]file:["`]' "$mainview_js"; then
+    echo "Patching preload origin validation for file:// protocol..."
+    sed -i -E 's/e\.hostname===["`]localhost["`]/&||e.protocol==="file:"/g' "$mainview_js"
+  fi
+
+  patch_index_verify_syntax || return 1
+  return 0
+}

--- a/patch-index.sh
+++ b/patch-index.sh
@@ -113,12 +113,17 @@ patch_index() {
   return 0
 }
 
-# Syntax-check every patched chunk before repacking. We now rewrite ~300 files
-# instead of 2, and patch_host_platform in particular is markerless and subs
-# globally, so a malformed rewrite would otherwise surface as a blank window at
-# launch with no clue which pass produced it. node --check is cheap next to the
-# repack and names the offending file. Warn rather than abort: a syntax error in
-# a chunk we never patched shouldn't block a launch that would otherwise work.
+# Syntax-check every patched chunk before repacking. We rewrite ~300 files
+# instead of 2, and the last pass in particular is markerless and substitutes
+# globally on a bare `process.resourcesPath,"app.asar"` token, so a malformed
+# rewrite would otherwise surface as a blank window at launch with no clue which
+# pass produced it. node --check is cheap next to the repack and names the
+# offending file. Warn rather than abort: a syntax error in a chunk we never
+# patched shouldn't block a launch that would otherwise work.
+#
+# This covers the passes above only. A caller that mutates the same files
+# afterwards (PKGBUILD runs enable-cowork.py after this) should call this again
+# once it is done.
 #
 # PATCH_INDEX_STRICT_SYNTAX=1 turns the warning into a failure. A build step
 # should stop rather than ship a package that opens a blank window; a launcher
@@ -243,10 +248,20 @@ patch_index_apply_all() {
   #
   # Separate from patch_index because it targets a preload bundle, not the
   # main-process chunks in INDEX_TARGETS.
+  # Guard on the SUBSTITUTION target, not just on the marker. sed -i rewrites the
+  # file whether or not the pattern matched, so a miss still bumps mtime -- and
+  # since a miss also leaves the marker absent, the old shape re-ran on every
+  # launch, bumped mtime every launch, and made launch.sh's "is anything newer
+  # than the cached asar" check true forever. That repacked the whole ~300-file
+  # asar on every start while printing "Patching..." as though it had worked.
   local mainview_js="$build_dir/mainView.js"
   if [ -f "$mainview_js" ] && ! grep -qE 'e\.protocol===["`]file:["`]' "$mainview_js"; then
-    echo "Patching preload origin validation for file:// protocol..."
-    sed -i -E 's/e\.hostname===["`]localhost["`]/&||e.protocol==="file:"/g' "$mainview_js"
+    if grep -qE 'e\.hostname===["`]localhost["`]' "$mainview_js"; then
+      sed -i -E 's/e\.hostname===["`]localhost["`]/&||e.protocol==="file:"/g' "$mainview_js"
+      echo "Patching preload origin validation for file:// protocol..."
+    elif [ "$PATCH_INDEX_WARN_ON_MISS" != "0" ]; then
+      echo "WARN: patch skipped (target not found): preload origin validation for file:// protocol" >&2
+    fi
   fi
 
   patch_index_verify_syntax || return 1

--- a/stubs/cowork/ipc_overrides.js
+++ b/stubs/cowork/ipc_overrides.js
@@ -330,8 +330,13 @@ function whichApplicationForFile(filename) {
 }
 
 // -- Override registry --
-// Keys are matched via channel.includes(key). This handles the
-// _$_Namespace_$_Method pattern regardless of UUID prefix.
+// Keys are matched via channel.endsWith(key) (see matchOverride below). This
+// handles the _$_Namespace_$_Method pattern regardless of UUID prefix.
+//
+// endsWith, not includes: anchoring at the end means a key can only be shadowed
+// by another key that is a suffix of it, which is checkable by inspecting this
+// table. Under includes, any key appearing anywhere in a longer channel name
+// would match, so an unrelated channel could pick up a handler.
 
 function createOverrideRegistry(getProcessState) {
   return {

--- a/stubs/cowork/linux_ipc_stubs.js
+++ b/stubs/cowork/linux_ipc_stubs.js
@@ -2,13 +2,22 @@
 
 // Canonical IPC stub responses for Linux.
 //
-// Three insertion points in frame-fix-wrapper.js reference these values:
-//   1. getSyntheticIPCResponse()   — _invokeHandlers.has() fallback + ipcMain.handle() intercept
-//   2. getLinuxIpcOverrides()      — webContents.ipc handler replacement (per-window)
-//   3. Inline ClaudeVM/ClaudeCode  — ipcMain.handle() intercept inside require('electron') hook
+// The single production consumer is ipc_overrides.js, which imports the
+// CLAUDE_CODE_*, CLAUDE_VM_* and *_GRANTED values for its override registry.
 //
-// The insertion TIMING stays where it is (each fires at a different point
-// in the Electron lifecycle). Only the DATA is consolidated here.
+// This header used to name three insertion points in frame-fix-wrapper.js —
+// getSyntheticIPCResponse(), getLinuxIpcOverrides() and an inline
+// ClaudeVM/ClaudeCode intercept. None of them exist any more; the generic
+// early-init fallback in particular was removed deliberately, because a
+// catch-all that classified an unknown method and answered it from a default
+// table is exactly how a security question gets forged an answer (see the
+// DeviceRegistry note in ipc_overrides.js).
+//
+// Consequence worth knowing before you reuse them: COMPUTER_USE_TCC_DENIED and
+// COMPUTER_USE_TCC_REQUEST_DENIED existed for that removed early path and now
+// have no production consumer — only a shape assertion in
+// tests/node/current-path/audit_regression.test.cjs. They are kept as the
+// deny-side counterparts, not because anything returns them today.
 
 const STUB_CLAUDE_CODE_VERSION = '2.1.72';
 
@@ -27,7 +36,8 @@ const CLAUDE_VM_RUNNING_STATUS = 'ready';
 
 const CLAUDE_VM_DOWNLOAD_STATUS = 'ready';
 
-// getSyntheticIPCResponse uses denial stubs (fires early, before asar init)
+// Denial stubs for the removed early-init path — see the header. No production
+// consumer today; kept as the deny-side counterparts.
 const COMPUTER_USE_TCC_DENIED = Object.freeze({
   accessibility: 'denied',
   screenCapture: 'denied',
@@ -41,7 +51,18 @@ const COMPUTER_USE_TCC_REQUEST_DENIED = Object.freeze({
   canPrompt: false,
 });
 
-// getLinuxIpcOverrides — deny by default (Linux has no TCC UI to prompt the user)
+// The live pair, imported by ipc_overrides.js for ComputerUseTcc_$_getState
+// and the three ComputerUseTcc_$_request* channels.
+//
+// Both DENY, despite the _GRANTED names. The suffix is vestigial: it once
+// distinguished these from the *_DENIED constants above, back when the removed
+// early-init path answered before the asar was up. What actually separates the
+// two sets now is response shape — these carry { granted } / { granted, status },
+// the DENIED ones carry { accessibility, screenCapture, canPrompt }.
+//
+// Do not "fix" the values to match the names: Linux has no TCC UI to prompt the
+// user with, so granting screen capture or accessibility here would assert a
+// consent the user was never asked for.
 const COMPUTER_USE_TCC_GRANTED = Object.freeze({ granted: false, status: 'denied' });
 const COMPUTER_USE_TCC_REQUEST_GRANTED = Object.freeze({ granted: false });
 

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -14,7 +14,9 @@
 #     hardcoded (platform gate, IPC origin guards, host-platform, return gate);
 #   - the index.js -> index.chunk discovery used by install.sh / launch.sh finds
 #     the chunk from the shim, and is a clean no-op on single-entry builds;
-#   - launch.sh's patch_index seds apply across a chunk with rotated identifiers.
+#   - patch-index.sh's seds apply across a chunk with rotated identifiers, and
+#     both consumers (launch.sh, PKGBUILD) still source that one shared list
+#     rather than growing private copies that drift apart (#170).
 #
 # No network or Docker needed. Requires python3 and node.
 #
@@ -111,7 +113,7 @@ section "1. Static analysis"
 # ---------------------------------------------------------------------------
 if python3 -c "import ast; ast.parse(open('$REPO_ROOT/enable-cowork.py').read())" 2>/dev/null; then
   pass "enable-cowork.py parses"; else fail "enable-cowork.py parses"; fi
-for s in launch.sh install.sh; do
+for s in launch.sh install.sh patch-index.sh; do
   if bash -n "$REPO_ROOT/$s" 2>/dev/null; then pass "$s syntax"; else fail "$s syntax"; fi
 done
 
@@ -181,21 +183,33 @@ printf '"use strict";var x=1;\n' > "$TMP/build_single/index.js"
   || fail "single-entry: no chunk discovered"
 
 # ---------------------------------------------------------------------------
-section "4. launch.sh patch_index seds on a chunk with rotated identifiers"
+section "4. shared patch-index.sh passes on a chunk with rotated identifiers"
 # ---------------------------------------------------------------------------
-# Extract the real patch_index() helper + every patch_index invocation verbatim
-# from launch.sh so this test tracks the shipped code, not a copy.
-BLOCK="$TMP/patch_block.sh"
-awk '/^patch_index\(\) \{/{f=1} f{print} /Only repack if stub/{exit}' "$REPO_ROOT/launch.sh" \
-  | sed '/# Only repack if stub/d' > "$BLOCK"
-NCALLS="$(grep -c '^patch_index ' "$BLOCK" || true)"
-if [[ "${NCALLS:-0}" -lt 1 ]]; then
-  fail "extracted patch_index block from launch.sh (found $NCALLS calls)"
+# launch.sh and PKGBUILD both source patch-index.sh, so there is one pass list
+# to exercise rather than two near-copies. Source the shipped file directly --
+# no awk extraction, so the test cannot drift from the code the way the two
+# hand-maintained blocks drifted from each other (#170).
+#
+# Drive it through patch_index_apply_all against a real build directory so the
+# chunk discovery and the node --check verification are exercised too, not just
+# the seds.
+SHARED="$REPO_ROOT/patch-index.sh"
+if [[ ! -f "$SHARED" ]]; then
+  fail "patch-index.sh exists at repo root"
 else
-  pass "extracted patch_index block from launch.sh ($NCALLS calls)"
-  LCHUNK="$TMP/launch_chunk.js"
+  pass "patch-index.sh exists at repo root"
+  NPASSES="$(grep -c '^  patch_index "' "$SHARED" || true)"
+  if [[ "${NPASSES:-0}" -lt 9 ]]; then
+    fail "patch-index.sh defines all 9 passes (found $NPASSES)"
+  else
+    pass "patch-index.sh defines all 9 passes ($NPASSES)"
+  fi
+
+  LBUILD="$TMP/shared_build"
+  mkdir -p "$LBUILD"
+  LCHUNK="$LBUILD/index.js"
   write_patch_fixture "$LCHUNK"
-  ( INDEX_TARGETS=("$LCHUNK"); source "$BLOCK" ) >/dev/null 2>&1
+  ( source "$SHARED"; patch_index_apply_all "$LBUILD" ) >/dev/null 2>&1
   refute_grep "$LCHUNK" 'titleBarStyle:"hidden"'                     "main-window titlebar removed"
   refute_grep "$LCHUNK" 'titleBarStyle:"hiddenInset"'                "about-window titlebar removed"
   assert_grep "$LCHUNK" 'return Zq\.protocol==="file:"\}'            "origin isPackaged requirement dropped for file://"
@@ -212,52 +226,109 @@ else
   # chose. Patching it away regresses #132, silently and only at session spawn.
   assert_grep "$LCHUNK" 'function wrapSpawn\(t\)\{return process\.platform!=="darwin"\?t:\{cmd:rpt\(\)' \
               "disclaimer wrap site left intact (removing it would regress #132)"
-  assert_parses "$LCHUNK" "chunk parses after launch.sh patches"
+  assert_parses "$LCHUNK" "chunk parses after the shared passes"
+
+  # Discovery must reach index*.chunk-*.js siblings, not just index.js.
+  DBUILD="$TMP/discovery_build"
+  mkdir -p "$DBUILD"
+  echo '"use strict";' > "$DBUILD/index.js"
+  write_patch_fixture "$DBUILD/index2.chunk-Cqfh0Vpp.js"
+  ( source "$SHARED"; patch_index_apply_all "$DBUILD" ) >/dev/null 2>&1
+  assert_grep "$DBUILD/index2.chunk-Cqfh0Vpp.js" 'this\.options\.effort==="xhigh"\?"max"' \
+              "passes reach a chunk the shim never require()s"
+
+  # Idempotency: a second run must not corrupt an already-patched tree.
+  BEFORE="$(cat "$LCHUNK")"
+  ( source "$SHARED"; patch_index_apply_all "$LBUILD" ) >/dev/null 2>&1
+  if [[ "$BEFORE" == "$(cat "$LCHUNK")" ]]; then
+    pass "re-running the passes on a patched tree is a no-op"
+  else
+    fail "re-running the passes on a patched tree changed it again"
+  fi
+
+  # PKGBUILD builds with PATCH_INDEX_STRICT_SYNTAX=1 so a chunk that no longer
+  # parses fails the build instead of shipping a blank-window package; launch.sh
+  # leaves it unset so a bad chunk only warns rather than blocking a launch.
+  if [[ "$HAVE_NODE" -eq 0 ]]; then
+    skip "syntax gate strict/warn split (node not installed)"
+  else
+    BADBUILD="$TMP/bad_build"
+    mkdir -p "$BADBUILD"
+    printf 'function f({ // unbalanced\n' > "$BADBUILD/index.js"
+    if ( source "$SHARED"; PATCH_INDEX_STRICT_SYNTAX=1; \
+         patch_index_apply_all "$BADBUILD" ) >/dev/null 2>&1; then
+      fail "strict syntax gate fails the build on an unparseable chunk"
+    else
+      pass "strict syntax gate fails the build on an unparseable chunk"
+    fi
+    if ( source "$SHARED"; patch_index_apply_all "$BADBUILD" ) >/dev/null 2>&1; then
+      pass "default syntax check warns without failing"
+    else
+      fail "default syntax check warns without failing"
+    fi
+  fi
+
+  # patch_index must return 0 when nothing matched. PKGBUILD's build() runs
+  # under makepkg's `set -e`, so a non-zero return from a legitimately-missing
+  # pass would abort the package build.
+  if ( set -e; source "$SHARED"; INDEX_TARGETS=(); \
+       PATCH_INDEX_WARN_ON_MISS=0 patch_index "x" 'nomatch' 's/a/b/' ) >/dev/null 2>&1; then
+    pass "patch_index returns 0 on no match (safe under PKGBUILD's set -e)"
+  else
+    fail "patch_index returns non-zero on no match (would abort makepkg build)"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
-section "5. PKGBUILD build() patches reach the chunk (AUR path, issue #156)"
+section "5. both consumers use the shared list (drift guard, issue #170)"
 # ---------------------------------------------------------------------------
-# The AUR PKGBUILD applies the same class of patches as launch.sh, but in its
-# own build() function. It regressed once (issue #156): it patched index.js
-# only and hardcoded minified identifiers, silently disabling Cowork on
-# split-entry builds. Extract its patch_index() helper + invocations verbatim
-# and exercise them on a chunk with rotated identifiers so the drift can't recur.
-PKGBLOCK="$TMP/pkg_patch_block.sh"
-awk '/^    patch_index\(\) \{/{inf=1} inf{print} inf&&/^    \}/{inf=0}' "$REPO_ROOT/PKGBUILD" > "$PKGBLOCK"
-grep -A2 '^    patch_index "' "$REPO_ROOT/PKGBUILD" | grep -v '^--$' >> "$PKGBLOCK"
-PKCALLS="$(grep -c '^    patch_index ' "$PKGBLOCK" || true)"
-if [[ "${PKCALLS:-0}" -lt 1 ]]; then
-  fail "extracted patch_index block from PKGBUILD (found $PKCALLS calls)"
+# launch.sh grew to 9 passes while PKGBUILD's build() stayed at 3, and because
+# /usr/bin/claude-cowork execs electron directly against the packaged asar and
+# never runs launch.sh, AUR users silently lost six of them. The fix is one
+# shared list; these assertions are what keep it one.
+for _consumer in launch.sh PKGBUILD; do
+  if grep -qE 'source .*patch-index\.sh' "$REPO_ROOT/$_consumer"; then
+    pass "$_consumer sources patch-index.sh"
+  else
+    fail "$_consumer sources patch-index.sh"
+  fi
+  if grep -qE '(^|[^_])patch_index_apply_all ' "$REPO_ROOT/$_consumer"; then
+    pass "$_consumer calls patch_index_apply_all"
+  else
+    fail "$_consumer calls patch_index_apply_all"
+  fi
+  # A local redefinition is exactly how the two lists drifted apart before.
+  if grep -qE '^\s*patch_index\(\) \{' "$REPO_ROOT/$_consumer"; then
+    fail "$_consumer defines its own patch_index() (drift risk)"
+  else
+    pass "$_consumer does not redefine patch_index()"
+  fi
+  if grep -qE '^\s*patch_index "' "$REPO_ROOT/$_consumer"; then
+    fail "$_consumer still carries inline patch_index calls (drift risk)"
+  else
+    pass "$_consumer carries no inline patch_index calls"
+  fi
+done
+
+# launch.sh refuses to start without it, so install.sh must ship it alongside.
+if grep -q 'patch-index.sh' "$REPO_ROOT/install.sh"; then
+  pass "install.sh copies patch-index.sh into the install dir"
 else
-  pass "extracted patch_index block from PKGBUILD ($PKCALLS calls)"
-  PKCHUNK="$TMP/pkg_chunk.js"
-  write_patch_fixture "$PKCHUNK"
-  ( _index_targets=("$PKCHUNK"); source "$PKGBLOCK" ) >/dev/null 2>&1
-  refute_grep "$PKCHUNK" 'titleBarStyle:"hidden"'          "PKGBUILD: main-window titlebar removed (chunk)"
-  refute_grep "$PKCHUNK" 'titleBarStyle:"hiddenInset"'     "PKGBUILD: about-window titlebar removed (chunk)"
-  assert_grep "$PKCHUNK" 'return Zq\.protocol==="file:"\}' "PKGBUILD: origin isPackaged dropped for file:// (chunk)"
-  assert_grep "$PKCHUNK" 'function wrapSpawn\(t\)\{return process\.platform!=="darwin"\?t:\{cmd:rpt\(\)' \
-              "PKGBUILD: disclaimer wrap site left intact (chunk)"
-  assert_parses "$PKCHUNK" "PKGBUILD: chunk parses after patch_index seds"
+  fail "install.sh does not copy patch-index.sh (installed launcher would abort)"
 fi
-# Source-level guards: the recipe must discover chunks and run enable-cowork.py
-# across every discovered target, never regress to the index.js-only invocation.
-# Either mechanism counts: following the shim's require()s (the historical
-# approach) or globbing the build dir for index*.chunk-*.js (which also reaches
-# chunks required transitively rather than by the shim directly).
-if grep -qF 'chunk-[A-Za-z0-9_-]+' "$REPO_ROOT/PKGBUILD" \
-   || grep -qF "name 'index*.chunk-*.js'" "$REPO_ROOT/PKGBUILD"; then
-  pass "PKGBUILD: discovers index*.chunk-*.js chunks"
+
+# Source-level guards: chunk discovery now lives in the shared script, and the
+# recipe must still run enable-cowork.py across every discovered target.
+if grep -qF "name 'index*.chunk-*.js'" "$REPO_ROOT/patch-index.sh"; then
+  pass "shared script discovers index*.chunk-*.js chunks"
 else
-  fail "PKGBUILD: chunk discovery missing"
+  fail "shared script: chunk discovery missing"
 fi
 if grep -q 'enable-cowork.py" "$_t"' "$REPO_ROOT/PKGBUILD"; then
   pass "PKGBUILD: runs enable-cowork.py across every discovered target"
 else
   fail "PKGBUILD: enable-cowork.py not run per-target (regressed to index.js only?)"
 fi
-
 # ---------------------------------------------------------------------------
 section "6. backtick-literal bundle (asar 1.26832.0 shapes, issue #166)"
 # ---------------------------------------------------------------------------
@@ -299,11 +370,13 @@ fi
 assert_grep "$BTGATE" 'function zQ7x\(\)\{return\{status:"supported"\}\}' "backtick: unknown-named gate rewritten"
 assert_parses "$BTGATE" "backtick: unknown-named gate parses after patching"
 
-# launch.sh patch_index passes against the same shapes.
-if [[ -f "$BLOCK" ]]; then
-  BTL="$TMP/backtick_launch.js"
+# The shared patch passes against the same shapes.
+if [[ -f "$SHARED" ]]; then
+  BTBUILD="$TMP/backtick_build"
+  mkdir -p "$BTBUILD"
+  BTL="$BTBUILD/index.js"
   write_patch_fixture_backtick "$BTL"
-  ( INDEX_TARGETS=("$BTL"); source "$BLOCK" ) >/dev/null 2>&1
+  ( source "$SHARED"; patch_index_apply_all "$BTBUILD" ) >/dev/null 2>&1
   refute_grep "$BTL" 'titleBarStyle:`hidden`'          "backtick: main-window titlebar removed (!1 / dotted value)"
   refute_grep "$BTL" 'titleBarStyle:`hiddenInset`'     "backtick: about-window titlebar removed"
   assert_grep "$BTL" 'return Zq\.protocol==="file:"\}' "backtick: origin isPackaged dropped (r.default arg)"
@@ -317,7 +390,7 @@ if [[ -f "$BLOCK" ]]; then
   assert_grep "$BTL" 'shell-path-worker'                  "backtick: shellPathWorker site still resolves a path"
   assert_grep "$BTL" 'function wrapSpawn\(t\)\{return process\.platform!==`darwin`\?t:\{cmd:rpt\(\)' \
               "backtick: disclaimer wrap site left intact (#132)"
-  assert_parses "$BTL" "backtick: chunk parses after launch.sh patches"
+  assert_parses "$BTL" "backtick: chunk parses after the shared passes"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -359,6 +359,46 @@ else
   fail "install.sh does not sync stubs/ (updates would run against stale stubs)"
 fi
 
+# The launchers re-patch a PERSISTENT tree, so from the second launch onward
+# every pass legitimately matches nothing. Without WARN_ON_MISS=0 that is ~9 WARN
+# lines on every launch of a healthy install -- noise, and it makes a real #166
+# silent-no-op indistinguishable from the steady state. PKGBUILD must NOT set it:
+# build() always starts from a fresh extract, where a miss is real signal.
+for _launcher in launch.sh launch-devtools.sh; do
+  if grep -qE '^\s*PATCH_INDEX_WARN_ON_MISS=0' "$REPO_ROOT/$_launcher"; then
+    pass "$_launcher silences warn-on-miss (persistent tree)"
+  else
+    fail "$_launcher does not silence warn-on-miss (9 WARNs per launch)"
+  fi
+done
+if grep -qE '^\s*PATCH_INDEX_WARN_ON_MISS=' "$REPO_ROOT/PKGBUILD"; then
+  fail "PKGBUILD overrides warn-on-miss (fresh extract per build -- a miss is real signal)"
+else
+  pass "PKGBUILD keeps warn-on-miss (fresh extract per build)"
+fi
+
+# Behavioural: a second pass over an already-patched tree must be silent under
+# the launcher setting, and must still warn under the default.
+if [[ -f "$SHARED" ]]; then
+  WBUILD="$TMP/warn_build"
+  mkdir -p "$WBUILD"
+  write_patch_fixture_backtick "$WBUILD/index.js"
+  printf 'function h(e){return e.hostname===`localhost`}\n' > "$WBUILD/mainView.js"
+  ( source "$SHARED"; patch_index_apply_all "$WBUILD" ) >/dev/null 2>&1
+  _w_default="$( ( source "$SHARED"; patch_index_apply_all "$WBUILD" ) 2>&1 >/dev/null | grep -c 'WARN' )"
+  _w_quiet="$( ( source "$SHARED"; PATCH_INDEX_WARN_ON_MISS=0; patch_index_apply_all "$WBUILD" ) 2>&1 >/dev/null | grep -c 'WARN' )"
+  if [[ "$_w_quiet" -eq 0 ]]; then
+    pass "re-patch is silent under the launcher setting"
+  else
+    fail "re-patch emitted $_w_quiet WARNs under the launcher setting"
+  fi
+  if [[ "$_w_default" -gt 0 ]]; then
+    pass "re-patch still warns under the default ($_w_default) -- #166 signal intact"
+  else
+    fail "default no longer warns on a miss (#166 signal lost)"
+  fi
+fi
+
 # Source-level guards: chunk discovery now lives in the shared script, and the
 # recipe must still run enable-cowork.py across every discovered target.
 if grep -qF "name 'index*.chunk-*.js'" "$REPO_ROOT/patch-index.sh"; then

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -348,6 +348,17 @@ else
   fail "install.sh does not copy patch-index.sh (installed launcher would abort)"
 fi
 
+# ...and the stubs/ tree, which is easy to lose when this block is refactored.
+# launch.sh re-syncs from $INSTALL_DIR/stubs into the extracted app on every
+# start and the launcher's protocol-forwarder search looks under it, so dropping
+# it means an update installs fresh stubs and then has the stale ones copied
+# back over them on the next launch. That is invisible at install time.
+if grep -qE 'cp -rf? "\$stub_src/stubs" "\$INSTALL_DIR/"' "$REPO_ROOT/install.sh"; then
+  pass "install.sh syncs the stubs/ tree into the install dir"
+else
+  fail "install.sh does not sync stubs/ (updates would run against stale stubs)"
+fi
+
 # Source-level guards: chunk discovery now lives in the shared script, and the
 # recipe must still run enable-cowork.py across every discovered target.
 if grep -qF "name 'index*.chunk-*.js'" "$REPO_ROOT/patch-index.sh"; then

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -399,6 +399,20 @@ if [[ -f "$SHARED" ]]; then
   fi
 fi
 
+# launch-devtools.sh repacks now, so it must refuse a tree launch.sh has not
+# prepared -- repacking a stock package.json yields an asar that loads
+# index.pre.js directly and never runs frame-fix-wrapper. The guard has to come
+# BEFORE the repack, or it can never fire (the repack creates the file the
+# earlier existence check looks for).
+_dv="$REPO_ROOT/launch-devtools.sh"
+_guard_line="$(grep -n 'not been prepared by launch.sh' "$_dv" | head -1 | cut -d: -f1)"
+_repack_line="$(grep -n 'asar pack linux-app-extracted' "$_dv" | head -1 | cut -d: -f1)"
+if [[ -n "$_guard_line" && -n "$_repack_line" && "$_guard_line" -lt "$_repack_line" ]]; then
+  pass "launch-devtools.sh checks for a launch.sh-prepared tree before repacking"
+else
+  fail "launch-devtools.sh repacks without (or before) the prepared-tree check"
+fi
+
 # Source-level guards: chunk discovery now lives in the shared script, and the
 # recipe must still run enable-cowork.py across every discovered target.
 if grep -qF "name 'index*.chunk-*.js'" "$REPO_ROOT/patch-index.sh"; then

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -401,6 +401,58 @@ fi
 assert_grep "$BTGATE" 'function zQ7x\(\)\{return\{status:"supported"\}\}' "backtick: unknown-named gate rewritten"
 assert_parses "$BTGATE" "backtick: unknown-named gate parses after patching"
 
+# getHostPlatform throw whose message contains a call. HOST_PLATFORM_THROW_RE
+# used [^)]*, which stops at the FIRST ')', so the match ended inside the call
+# and the substitution left its closing paren behind as `return"darwin-x64")`.
+# enable-cowork.py reported SUCCESS and exited 0 on a file it had just made
+# unparseable. Every fixture above happens to use a paren-free message, which is
+# why nothing caught it.
+PARENGATE="$TMP/host_platform_paren.js"
+cat > "$PARENGATE" <<'EOF'
+"use strict";
+function ke(){let t=process.platform;if(t!==`darwin`&&t!==`win32`)return{status:`unsupported`,reason:`nope`};return{status:`supported`}}
+function hostPlat(){if(process.platform==="darwin")return"darwin-x64";throw new Error("Unsupported platform: "+getPlatformName())}
+EOF
+python3 "$REPO_ROOT/enable-cowork.py" "$PARENGATE" >/dev/null 2>&1
+refute_grep "$PARENGATE" 'throw new Error\("Unsupported platform'  "paren: getHostPlatform throw rewritten"
+refute_grep "$PARENGATE" 'return"darwin-x64"\)'                    "paren: no dangling paren left behind"
+assert_parses "$PARENGATE" "paren: chunk still parses after patching"
+
+# Nesting deeper than the pattern handles must fail CLOSED — leave the throw
+# alone — rather than emit invalid JS.
+DEEPGATE="$TMP/host_platform_deep.js"
+cat > "$DEEPGATE" <<'EOF'
+"use strict";
+function ke(){let t=process.platform;if(t!==`darwin`&&t!==`win32`)return{status:`unsupported`,reason:`nope`};return{status:`supported`}}
+function hostPlat(){throw new Error("Unsupported platform: "+fmt(name(x)))}
+EOF
+python3 "$REPO_ROOT/enable-cowork.py" "$DEEPGATE" >/dev/null 2>&1
+assert_parses "$DEEPGATE" "deep nesting: fails closed, chunk still parses"
+
+# The corruption guard must actually fire, on stderr, without changing the
+# exit code — both callers read non-zero as "no platform gate here", so failing
+# that way would hide the corruption instead of surfacing it.
+BADJS="$TMP/unparseable.js"
+cat > "$BADJS" <<'EOF'
+"use strict";
+function ke(){let t=process.platform;if(t!==`darwin`&&t!==`win32`)return{status:`unsupported`,reason:`nope`};return{status:`supported`}}
+function oops(){ return 1)  }
+EOF
+BADERR="$(python3 "$REPO_ROOT/enable-cowork.py" "$BADJS" 2>&1 >/dev/null)"
+BADRC=$?
+if [[ "$HAVE_NODE" -eq 0 ]]; then
+  skip "corruption guard warns on stderr (node not installed)"
+elif [[ "$BADERR" == *"not valid JavaScript after patching"* ]]; then
+  pass "corruption guard warns on stderr"
+else
+  fail "corruption guard silent on an unparseable file"
+fi
+if [[ "$BADRC" -eq 0 ]]; then
+  pass "corruption guard leaves the exit-code contract alone"
+else
+  fail "corruption guard changed the exit code (callers read non-zero as 'no gate here')"
+fi
+
 # The shared patch passes against the same shapes.
 if [[ -f "$SHARED" ]]; then
   BTBUILD="$TMP/backtick_build"

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -246,6 +246,37 @@ else
     fail "re-running the passes on a patched tree changed it again"
   fi
 
+  # mainView.js: on a miss the pass must leave the file completely alone. sed -i
+  # rewrites regardless of whether the pattern matched, and a miss also leaves
+  # the marker absent — so the old shape re-ran every launch, bumped mtime every
+  # launch, and made launch.sh's "anything newer than the cached asar?" check
+  # true forever, repacking the whole asar on every start. Pin mtime, not just
+  # content: content was already unchanged, which is why this went unnoticed.
+  MVBUILD="$TMP/mainview_build"
+  mkdir -p "$MVBUILD"
+  echo '"use strict";' > "$MVBUILD/index.js"
+  # identifier is `q`, not `e`, so the substitution cannot match
+  printf 'function h(q){return q.hostname===`localhost`}\n' > "$MVBUILD/mainView.js"
+  touch -d '2020-01-01 00:00:00' "$MVBUILD/mainView.js"
+  MV_BEFORE="$(stat -c %Y "$MVBUILD/mainView.js")"
+  ( source "$SHARED"; patch_index_apply_all "$MVBUILD" ) >/dev/null 2>&1
+  if [[ "$MV_BEFORE" == "$(stat -c %Y "$MVBUILD/mainView.js")" ]]; then
+    pass "mainView.js untouched when the substitution target is absent"
+  else
+    fail "mainView.js rewritten on a miss (bumps mtime, forces a repack every launch)"
+  fi
+  # And it must still patch when the target IS present, and be idempotent after.
+  printf 'function h(e){return e.hostname===`localhost`}\n' > "$MVBUILD/mainView.js"
+  ( source "$SHARED"; patch_index_apply_all "$MVBUILD" ) >/dev/null 2>&1
+  assert_grep "$MVBUILD/mainView.js" 'e\.protocol==="file:"' "mainView.js patched when the target is present"
+  MV_PATCHED="$(stat -c %Y "$MVBUILD/mainView.js")"
+  ( source "$SHARED"; patch_index_apply_all "$MVBUILD" ) >/dev/null 2>&1
+  if [[ "$MV_PATCHED" == "$(stat -c %Y "$MVBUILD/mainView.js")" ]]; then
+    pass "mainView.js untouched on a second run (marker holds)"
+  else
+    fail "mainView.js rewritten on a second run"
+  fi
+
   # PKGBUILD builds with PATCH_INDEX_STRICT_SYNTAX=1 so a chunk that no longer
   # parses fails the build instead of shipping a blank-window package; launch.sh
   # leaves it unset so a bad chunk only warns rather than blocking a launch.

--- a/tests/test-install-paths.sh
+++ b/tests/test-install-paths.sh
@@ -11,7 +11,7 @@
 #
 # Stages:
 #   1  Static analysis (bash -n, python -c)
-#   2  fetch-dmg.py output modes
+#   2  fetch-dmg.js output modes
 #   3  DMG download + extraction
 #   4  Stub baking + patching
 #   5  asar repack
@@ -129,18 +129,37 @@ stage_1() {
         fail "install.sh syntax check"
     fi
 
+    # launch.sh was missing from this list entirely, which is odd for a harness
+    # named after install paths: it is what every install actually execs.
+    if bash -n "$REPO_ROOT/launch.sh" 2>/dev/null; then
+        pass "launch.sh syntax OK"
+    else
+        fail "launch.sh syntax check"
+    fi
+
     if bash -n "$REPO_ROOT/PKGBUILD" 2>/dev/null; then
         pass "PKGBUILD syntax OK"
     else
         fail "PKGBUILD syntax check"
     fi
 
-    # Python syntax checks
-    if python3 -c "import py_compile; py_compile.compile('$REPO_ROOT/fetch-dmg.py', doraise=True)" 2>/dev/null; then
-        pass "fetch-dmg.py syntax OK"
+    if bash -n "$REPO_ROOT/patch-index.sh" 2>/dev/null; then
+        pass "patch-index.sh syntax OK"
     else
-        fail "fetch-dmg.py syntax check"
+        fail "patch-index.sh syntax check"
     fi
+
+    # fetch-dmg was rewritten from Python to Node; stage 2 already exercises its
+    # output modes by name. Check the file that exists, with the right tool.
+    if ! command -v node >/dev/null 2>&1; then
+        skip "fetch-dmg.js syntax (node not installed)"
+    elif node --check "$REPO_ROOT/fetch-dmg.js" 2>/dev/null; then
+        pass "fetch-dmg.js syntax OK"
+    else
+        fail "fetch-dmg.js syntax check"
+    fi
+
+    # Python syntax checks
 
     if python3 -c "import py_compile; py_compile.compile('$REPO_ROOT/enable-cowork.py', doraise=True)" 2>/dev/null; then
         pass "enable-cowork.py syntax OK"
@@ -150,7 +169,7 @@ stage_1() {
 }
 
 # ============================================================
-# Stage 2: fetch-dmg.py output modes
+# Stage 2: fetch-dmg.js output modes
 # ============================================================
 
 stage_2() {
@@ -552,7 +571,9 @@ stage_8() {
 
 main() {
     local start_stage="${1:-1}"
-    local end_stage="${2:-8}"
+    # A single argument selects exactly that stage, as the usage block above
+    # promises; it used to default end_stage to 8 and run N through 8.
+    local end_stage="${2:-${1:-8}}"
 
     echo -e "${BOLD}Claude Cowork Linux — Install Path Test Harness${NC}"
     echo -e "Repo: $REPO_ROOT"


### PR DESCRIPTION
## What does this change?

Closes #170, and fixes four more bugs of the same family found while tracing it. The theme throughout: **a step that did nothing, and said it worked.**

### 1. One shared patch pass list (#170)

`launch.sh` had grown to 9 `patch_index` passes while `PKGBUILD`'s `build()` still applied 3. `/usr/bin/claude-cowork` execs electron directly against the packaged asar and never calls `launch.sh`, so AUR users never got the other six — nor the `mainView.js` preload-origin patch, which was launcher-only for the same reason.

Following the steer on the issue, the passes move into a new `patch-index.sh` that both consumers source, so the drift is unrepresentable rather than merely tested for. `install.sh`'s private copy of the chunk discovery collapses onto the same file, taking it from three copies to one.

**Feasibility** (the crux the issue flagged): no `source=()` change needed. `PKGBUILD`'s only source is `git+https://github.com/johnzfitch/claude-cowork-linux.git`, so makepkg clones the whole repo to `${srcdir}/claude-cowork-linux`, and `build()` already reaches into it to run `${_repo}/enable-cowork.py`. A repo-root `patch-index.sh` arrives by exactly that mechanism.

**Impact is narrower than the issue implies** — @chefboyrdave21 confirmed this independently on their own install and owns the original mis-attribution:

| Pass | Effect on AUR |
|:--|:--|
| unguarded `resourcesPath`+`app.asar` join | **genuinely broken, now fixed** — the trampoline pins `process.resourcesPath` to `/usr/lib/claude-cowork/resources` while the asar sits at `/usr/lib/claude-cowork/app.asar`, so `shellPathWorker.js` resolved to a nonexistent file and login-shell PATH priming failed |
| `mainView.js` preload origin | **genuinely broken, now fixed** — its absence leaves CoworkSpaces unexposed to the renderer (empty Projects page, spaces don't persist) |
| `resourcesPath` lookups, MCP node-host | inert either way — both are `app.isPackaged`-gated, and both launchers start electron with a *path argument*, so `process.defaultApp` is true and `isPackaged` is false; those seds rewrite a branch that is never taken |
| Handoff ×2, `--effort xhigh` | already covered by `frame-fix-wrapper.js` and `session_orchestrator.js`, both of which `PKGBUILD` does install |

This is **not** the cause of "MCP Filesystem: Node host not found". The issue title still carries that claim; `patch-index.sh`'s header now says so explicitly so nobody re-adds the inert passes expecting a fix.

### 2. `enable-cowork.py` corrupted the bundle and reported SUCCESS

`HOST_PLATFORM_THROW_RE` matched the `Error(...)` argument with `[^)]*`, which stops at the first `)`. On a bundle whose message is built with a call in it —

```js
throw new Error("Unsupported platform: "+getPlatformName())
```

— the match ended *inside* that call, and the substitution left its closing paren behind as `return"darwin-x64")`. That is a syntax error. `patch_host_platform` still returned `True`, so the script printed `SUCCESS`, exited 0, and both callers counted the file as patched.

Reproduced end-to-end. Every existing fixture happens to use a paren-free message, which is why nothing caught it. Now matched paren-aware; deeper nesting **fails closed**. A post-patch `node --check` warns on stderr when the result is unparseable, deliberately **without** changing the exit code — both callers read non-zero as "no platform gate here", so failing that way would *hide* the corruption.

### 3. The `mainView.js` pass repacked the asar on every launch

`sed -i` rewrites its target whether or not the pattern matched, so a miss still bumps mtime — and that pass guarded only on the marker it inserts, which a miss also leaves absent. On any build where the preload's identifier isn't `e`, it re-ran every launch and made `launch.sh`'s "anything newer than the cached asar" check true forever. Tests pin **mtime**, not content — content was already unchanged, which is exactly why this stayed invisible.

### 4. `launch-devtools.sh` debugged the previous build

It synced the stubs and never repacked, so electron got whatever `launch.sh` last packed. For a debugging tool that's the worst shape of failure — indistinguishable from "my change was wrong". Relatedly `launch.sh` ignored `asar pack`'s exit status, falling through to launch against a stale asar with the error already scrolled off.

### 5. `tests/test-install-paths.sh` could not pass, and nothing ran it

Stage 1 `py_compile`d `fetch-dmg.py`, which became `fetch-dmg.js` — stage 2 is even *titled* "fetch-dmg.js output modes". `main()` exits 1 on any failure, so the whole harness exited non-zero regardless. Nothing noticed because the file is in no CI job. Single-arg stage selection also ran N-through-8 rather than "just stage N" as documented, so asking for one static stage tried to download a DMG.

Stage 1 is now wired into CI — pure static analysis, no network or Docker. That's the actual fix; the `fetch-dmg` drift was the symptom.

### 6. Comment corrections

`ipc_overrides.js` said keys match via `channel.includes(key)`; `matchOverride` uses `endsWith`. Not cosmetic — anyone auditing for collisions off the old comment reaches the wrong conclusion. `linux_ipc_stubs.js` named three insertion points in `frame-fix-wrapper.js` that no longer exist; that removal is worth recording, since a generic fallback answering unknown methods from a default table is exactly the shape that would forge an answer to a security question.

### 7. Fixes from the pre-merge review

An adversarial review of the combined `#175 + #176` tree caught four things, three of them regressions this PR itself introduced:

- **`install.sh` stopped syncing `stubs/`.** Refactoring the copy loop for the earlier review comment silently dropped `cp -rf "$stub_src/stubs" "$INSTALL_DIR/"`. Invisible at install time, because the stubs are already in the extracted tree — it bites on the *next* launch, when `launch.sh` re-syncs from the stale `$INSTALL_DIR/stubs` over the fresh ones.
- **Two `die()`s aborted a run master completes.** They land *after* the destructive `asar extract`, skipping `create_launcher`, the sentinel and the doctor. Deterministically reachable: a tag-pinned `CLAUDE_REPO_REF` leaves `$INSTALL_DIR` on a detached HEAD, `git pull --ff-only` then fails permanently, and `$INSTALL_DIR` never receives `patch-index.sh`. Both now warn loudly, name the repair command, and fall back to the same `find(1)` master used — never worse than master, and the doctor still catches an unpatched install.
- **`patch-index.sh` warned on every launch.** The launchers re-patch a *persistent* tree, so from the second launch on every pass legitimately matches nothing. Measured: 0 warnings fresh, **9 on every run after** — noise, and it made a real #166 silent-no-op indistinguishable from the steady state. Off in the launchers; `PKGBUILD` keeps it, since `build()` always starts from a fresh extract where a miss is real signal.
- **`python` was a build dependency listed only in `optdepends`.** `build()` runs it unconditionally, so a clean-chroot build had no python and failed in the patch loop. Moved to `makedepends`; verified the in-array comment leaves the array as exactly `(p7zip asar curl python)`.

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [x] Documentation
- [x] Refactor

## Testing

```
tests/test-cowork-patch.sh    83 passed, 0 failed   (was 58)
tests/test-compat-pins.sh     11 passed, 0 failed
tests/test-install-paths.sh 1  6 passed, 0 failed   (was a guaranteed fail)
node --test .../current-path  559 passed, 0 failed
```

Also verified against the **merged** `master + #176 + #175` tree: clean merge, all suites green, the generated launcher `bash -n`s and keeps a hostile `INSTALL_DIR` literal.

Every fix was reproduced against the pre-fix code first, and each regression test was checked to actually fail without its fix.

- Distro / desktop: not run against a live desktop — these are CI-verifiable changes; the suites exercise the passes against fixtures in both double-quoted and 1.26832.0 backtick shapes
- Tested with `./install.sh --doctor`: not runnable here (no Claude Desktop install in this environment)
- Tested a full Cowork session: no — **an AUR build on a real Arch box remains the check worth doing**, since `build()` is the path that changed most

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning
- [ ] This change does touch security-sensitive code — explanation below:

The patch passes move verbatim — same guard patterns, same sed scripts, same order, including the pass-8-before-pass-9 ordering constraint and the do-not-simplify-the-disclaimer-wrapper note (#132). No pattern was reformatted or re-quoted; the character-for-character `["`]` alternation is what survived #166. The `enable-cowork.py` regex change is strictly *narrowing* in the failure direction.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — not runnable here, see Testing