### PR TITLE
fix(welcome): strike Mac, append Linux on the Cowork gate welcome screen

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -602,6 +602,45 @@ function coworkSpaceRoute(targetUrl) {
   }
 }
 
+// Issue #174: the welcome screen's heading picks its platform word from the
+// darwin spoof we present to the Cowork gate, so signed-out Linux users see
+// "Claude for Mac". Un-spoofing isn't an option -- that's the whole
+// mechanism -- so this rewrites the rendered text node in place: strike
+// through "Mac" (U+0336 combining overlay, so it's a plain string survives
+// minifier rotation) and append "Linux". A MutationObserver reapplies it
+// across SPA navigation since the heading can remount.
+function buildMacLinuxRewriteScript() {
+  return [
+    '(function(){',
+    '  try {',
+    '    var STRIKE = "\\u0336";',
+    '    function struck(s) { return s.split("").join(STRIKE) + STRIKE; }',
+    '    function rewrite() {',
+    '      var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);',
+    '      var node;',
+    '      while ((node = walker.nextNode())) {',
+    '        if (node.nodeValue !== "Mac") continue;',
+    '        var el = node.parentElement, depth = 0;',
+    '        while (el && depth < 5) {',
+    '          if (el.textContent && el.textContent.trim() === "Claude for Mac") {',
+    '            node.nodeValue = struck("Mac") + " Linux";',
+    '            break;',
+    '          }',
+    '          el = el.parentElement;',
+    '          depth++;',
+    '        }',
+    '      }',
+    '    }',
+    '    rewrite();',
+    '    if (!window.__coworkMacLinuxObserver) {',
+    '      window.__coworkMacLinuxObserver = new MutationObserver(rewrite);',
+    '      window.__coworkMacLinuxObserver.observe(document.body, { childList: true, subtree: true, characterData: true });',
+    '    }',
+    '  } catch (e) {}',
+    '})();',
+  ].join('\n');
+}
+
 // Build the JS injected into the renderer to perform client-side navigation.
 // The route is JSON-encoded (never string-concatenated raw) so a hostile space
 // name/URL cannot break out of the string literal into executable code.
@@ -1428,9 +1467,11 @@ Module.prototype.require = function(id) {
         _appRef.on('web-contents-created', (_ev, contents) => {
           contents.on('dom-ready', () => {
             contents.insertCSS(_fixCSS).catch(() => {});
+            contents.executeJavaScript(buildMacLinuxRewriteScript()).catch(() => {});
           });
           contents.on('did-navigate', () => {
             contents.insertCSS(_fixCSS).catch(() => {});
+            contents.executeJavaScript(buildMacLinuxRewriteScript()).catch(() => {});
           });
           // Issue #147: convert a full-page navigation to a locally-created
           // Cowork space into an in-app SPA route change, so it loads from IPC


### PR DESCRIPTION
Closes #174.

Signed out, the welcome heading reads "Claude for Mac" on Linux because it picks its platform word from the darwin spoof we present to the Cowork gate. Un-spoofing isn't an option since that's the whole mechanism, so this is a DOM rewrite rather than a bundle patch: the renderer for this screen is served live from `assets-proxy.anthropic.com`, and the bundled `resources/ion-dist` fallback never loads it (confirmed by planting a marker string there and watching it never render).

`buildMacLinuxRewriteScript()` walks text nodes for one that is exactly `Mac` under an ancestor (within 5 levels) whose trimmed text is `Claude for Mac`, and replaces it with `M̶a̶c̶ Linux` using U+0336 combining overlays. Wired into the existing Linux-only `dom-ready`/`did-navigate` handlers in `frame-fix-wrapper.js` (same block that already inserts the drag-region CSS fix), with a `MutationObserver` to reapply across SPA remounts.

Known limitations (also called out in the issue):
- English-only: matches the literal string `Claude for Mac`; other locales no-op.
- Small non-zero per-navigation cost (one DOM walk + an observer).
- Coupled to Anthropic's markup; degrades to a no-op (not a break) if the heading's shape changes.

Verification: `node -c` on the edited file, plus a standalone check that the generated script is valid JS, contains the match string, and that the strike-overlay helper produces `M̶a̶c̶` for `"Mac"`. No existing test in `tests/` covers this file's DOM-injection paths.