### PR TITLE
draft(flatpak): starting-point manifest for #85

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,58 @@
+# Flathub draft (#85)
+
+**Status: draft skeleton, never built.** `flatpak-builder` was not available in
+the environment this was written in, so nothing here has been run — not
+`flatpak-builder --user --install`, not a launch, not a Cowork task. Read this
+before trying it, and please report back what breaks.
+
+## What this reproduces
+
+`io.github.johnzfitch.ClaudeCoworkLinux.yml`'s build-commands are a
+near-verbatim port of `nix/package.nix`'s `buildPhase`: extract Claude's
+archive, drop in the stubs, run `enable-cowork.py` once at build time. The
+runtime wrapper (`claude-desktop-wrapper.sh`) mirrors
+`nix/claude-desktop-launcher.sh`'s trick for the same reason: `/app` is
+read-only and `launch.sh` mutates its own directory (sed patches, `asar pack`
+into `.asar-cache/`) on every run, so the prepared tree gets mirrored into a
+writable per-user copy on first run or version bump. No extra permission is
+needed for that mirror because Flatpak already gives every app its own
+private `XDG_DATA_HOME`.
+
+## What's a guess, not a fact
+
+- **`extra-data` sha256/size are placeholders.** Run
+  `node fetch-dmg.js --json` and fill them in before attempting a build — an
+  extra-data source with a wrong hash just fails at install time, so this
+  isn't a silent risk, but it will stop you immediately if skipped.
+- **The runtime/base versions (`24.08`) are unverified against
+  `org.electronjs.Electron2.BaseApp`'s actual compatibility matrix.** Nix
+  pins `electron_41`; whichever BaseApp version actually ships an Electron 41
+  compatible with that should be used instead of the placeholder here.
+- **`--filesystem=home`** is the blunt version of attached-folder access.
+  Portal-based folder access (matching what a native file-open dialog would
+  grant) is the right long-term answer and hasn't been attempted.
+
+## What's a known, unresolved gap — not a guess
+
+**Sandbox-in-sandbox.** Cowork spawns `bwrap` itself to isolate agent task
+execution. Running that nested inside Flatpak's own sandbox is the
+"riskiest unknown" the maintainer flagged on #85, and this draft does not
+solve it. The `--talk-name=org.freedesktop.Flatpak` finish-arg is requested
+so a future fix can use `flatpak-spawn --host` to run the task sandbox on the
+host instead of nesting it — the pattern distrobox and devcontainer-in-flatpak
+setups use — but no code here actually does that. `launch.sh` / the cowork
+sandbox spawner would need to detect `$FLATPAK_ID` and switch how it invokes
+`bwrap` accordingly. That's a real code change to the sandbox spawn path, not
+a manifest change, and it needs testing inside an actual flatpak sandbox to
+know if it even works, neither of which happened here.
+
+## To actually try this
+
+```
+flatpak-builder --user --install --force-clean build-dir \
+  flatpak/io.github.johnzfitch.ClaudeCoworkLinux.yml
+flatpak run io.github.johnzfitch.ClaudeCoworkLinux
+```
+
+Expect the Cowork sandbox step to be where it breaks first. That's the part
+most worth a bug report back on #85.

--- a/flatpak/claude-desktop-wrapper.sh
+++ b/flatpak/claude-desktop-wrapper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# /app is read-only inside the sandbox, and launch.sh mutates its own
+# directory (sed patches + `asar pack` into .asar-cache/). Mirror the
+# prepared tree into XDG_DATA_HOME, refreshing only when the app's version
+# changes. XDG_DATA_HOME already resolves to a private per-app directory
+# under the sandbox (~/.var/app/<id>/data) with no extra --filesystem grant
+# needed — same trick nix/claude-desktop-launcher.sh uses for the Nix store.
+store=/app/share/claude-cowork-linux
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+work_dir="$data_home/claude-cowork-linux"
+marker="$work_dir/.flatpak-store-version"
+
+if [ ! -f "$marker" ] || ! cmp -s "$marker" "$store/.version"; then
+  rm -rf "$work_dir"
+  mkdir -p "$work_dir"
+  cp -r --no-preserve=mode,ownership "$store"/. "$work_dir"/
+  cp "$store/.version" "$marker"
+fi
+
+cd "$work_dir"
+exec bash ./launch.sh "$@"

--- a/flatpak/io.github.johnzfitch.ClaudeCoworkLinux.desktop
+++ b/flatpak/io.github.johnzfitch.ClaudeCoworkLinux.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Claude
+Comment=AI assistant by Anthropic (Cowork mode, unofficial Linux packaging)
+Exec=claude-desktop %U
+Icon=io.github.johnzfitch.ClaudeCoworkLinux
+Terminal=false
+Type=Application
+StartupWMClass=Claude
+Categories=Utility;Development;Chat;
+Keywords=AI;assistant;chat;anthropic;
+MimeType=x-scheme-handler/claude;

--- a/flatpak/io.github.johnzfitch.ClaudeCoworkLinux.metainfo.xml
+++ b/flatpak/io.github.johnzfitch.ClaudeCoworkLinux.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.johnzfitch.ClaudeCoworkLinux</id>
+  <name>Claude</name>
+  <summary>Run Claude Desktop's Cowork mode natively on Linux</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>
+      Runs Claude Desktop's Cowork (Local Agent Mode) natively on Linux, no
+      macOS or VM required. This is an unofficial compatibility layer: it
+      downloads Anthropic's official macOS build and stubs the macOS-native
+      modules it depends on, it does not modify or redistribute Anthropic's
+      code.
+    </p>
+  </description>
+  <launchable type="desktop-id">io.github.johnzfitch.ClaudeCoworkLinux.desktop</launchable>
+  <url type="homepage">https://github.com/johnzfitch/claude-cowork-linux</url>
+  <url type="bugtracker">https://github.com/johnzfitch/claude-cowork-linux/issues</url>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="5.2.0" date="2026-07-02">
+      <description>
+        <p>See COMPAT.md and the GitHub releases page for details.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/flatpak/io.github.johnzfitch.ClaudeCoworkLinux.yml
+++ b/flatpak/io.github.johnzfitch.ClaudeCoworkLinux.yml
@@ -1,0 +1,119 @@
+# DRAFT manifest for #85 — not submitted to Flathub, not verified end to end.
+# flatpak-builder was not available where this was written, so build/install
+# have not been run even once. Treat this as a starting skeleton, not a
+# working release. See flatpak/README.md for what's untested and why.
+#
+# Architecture mirrors nix/package.nix: extract Claude's archive, stub the
+# macOS-native modules, run enable-cowork.py once at build time, then ship a
+# launcher that mirrors the read-only /app tree into a writable per-user copy
+# before handing off to launch.sh, which does its own per-run sed/asar-repack
+# pass. That mirror step needs no extra permission here — Flatpak already
+# gives every app a private, writable XDG_DATA_HOME under
+# ~/.var/app/<id>/data, so $XDG_DATA_HOME inside the sandbox just works.
+app-id: io.github.johnzfitch.ClaudeCoworkLinux
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: claude-desktop
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --device=dri
+  # Attached-folder access for Cowork tasks. --filesystem=home is broad;
+  # narrowing this to specific accepted folders (portal-based, like the
+  # normal file-open dialog) instead of a blanket home grant is open work.
+  - --filesystem=home
+  # NOT yet used by any code change here. This only grants the permission a
+  # flatpak-spawn --host approach would need if the Cowork task sandbox is
+  # rewritten to delegate its bwrap invocation to the host instead of
+  # nesting it inside this sandbox (see flatpak/README.md, "sandbox in
+  # sandbox"). Requesting it now so that fix doesn't also need a manifest
+  # change. Safe to drop if a different approach is taken instead.
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  - name: claude-cowork-linux
+    buildsystem: simple
+
+    sources:
+      # Pinned to the same release nix/package.nix tracks. To bump: run
+      # `node fetch-dmg.js --json` for the current version/url/sha256.
+      # Flathub builds are network-isolated; extra-data is fetched by the
+      # flatpak installer before build-commands run, so it's already on
+      # disk (as dest-filename, in the module's build directory) by the
+      # time this module's build-commands execute — same offline-build
+      # constraint Chrome's and 1Password's Flathub manifests solve the
+      # same way.
+      - type: extra-data
+        filename: claude-desktop.zip
+        url: https://downloads.claude.ai/releases/darwin/universal/1.11187.4/Claude-58400536f3ccde1cff9a129de6c3112dc8cb489a.zip
+        sha256: PLACEHOLDER_SHA256_FROM_fetch-dmg.js
+        size: 0 # PLACEHOLDER — fill from `node fetch-dmg.js --json`
+        only-arches: [x86_64]
+      - type: dir
+        path: ..
+
+    build-commands:
+      # Mirrors nix/package.nix's buildPhase almost verbatim — see that file
+      # for the extract/stub/patch pipeline this reproduces. Kept identical
+      # on purpose so the two packaging paths don't drift into two different
+      # sources of truth for what the tree looks like.
+      - mkdir -p claude-app && unzip -q claude-desktop.zip -d claude-app
+      - |
+        set -e
+        appDir=$(find claude-app -maxdepth 2 -name "*.app" -type d | head -1)
+        [ -n "$appDir" ] || { echo "Claude.app not found in archive" >&2; exit 1; }
+        res="$appDir/Contents/Resources"
+        [ -f "$res/app.asar" ] || { echo "app.asar not found at $res" >&2; exit 1; }
+        tree=tree/linux-app-extracted
+        mkdir -p tree
+        asar extract "$res/app.asar" "$tree"
+        if [ -d "$res/app.asar.unpacked" ]; then
+          cp -r "$res/app.asar.unpacked"/* "$tree/" || true
+        fi
+        mkdir -p "$tree/resources"
+        for item in "$res"/*; do
+          case "$(basename "$item")" in
+            app.asar | app.asar.unpacked) continue ;;
+          esac
+          cp -r "$item" "$tree/resources/" || true
+        done
+        mkdir -p "$tree/resources/i18n"
+        if ls "$tree/resources"/*.json >/dev/null 2>&1; then
+          mv "$tree/resources"/*.json "$tree/resources/i18n/"
+        fi
+        mkdir -p "$tree/node_modules/@ant/claude-swift/js" "$tree/node_modules/@ant/claude-native"
+        cp stubs/@ant/claude-swift/js/index.js "$tree/node_modules/@ant/claude-swift/js/index.js"
+        cp stubs/@ant/claude-native/index.js "$tree/node_modules/@ant/claude-native/index.js"
+        for f in frame-fix-wrapper.js frame-fix-entry.js protocol-forwarder.js; do
+          [ -f "stubs/frame-fix/$f" ] && cp "stubs/frame-fix/$f" "$tree/$f"
+        done
+        mkdir -p "$tree/cowork"
+        cp -f stubs/cowork/*.js "$tree/cowork/"
+        python3 enable-cowork.py "$tree/.vite/build/index.js"
+      - |
+        set -e
+        share=/app/share/claude-cowork-linux
+        mkdir -p "$share"
+        cp -r tree/linux-app-extracted "$share/"
+        cp launch.sh launch-devtools.sh patch-index.sh enable-cowork.py COMPAT.md "$share/"
+        cp -r stubs "$share/"
+        echo "1.11187.4" > "$share/.version"
+        install -Dm755 flatpak/claude-desktop-wrapper.sh /app/bin/claude-desktop
+        install -Dm644 flatpak/io.github.johnzfitch.ClaudeCoworkLinux.desktop \
+          /app/share/applications/io.github.johnzfitch.ClaudeCoworkLinux.desktop
+        install -Dm644 flatpak/io.github.johnzfitch.ClaudeCoworkLinux.metainfo.xml \
+          /app/share/metainfo/io.github.johnzfitch.ClaudeCoworkLinux.metainfo.xml
+        icns="$share/linux-app-extracted/resources/electron.icns"
+        if [ -f "$icns" ]; then
+          python3 nix/extract-icns.py "$icns" /app/share/icons/hicolor && \
+            for f in /app/share/icons/hicolor/*/apps/claude.png; do
+              mv "$f" "$(dirname "$f")/io.github.johnzfitch.ClaudeCoworkLinux.png"
+            done || echo "icon extraction failed (non-fatal)" >&2
+        fi


### PR DESCRIPTION
Draft for #85, opened as a draft on purpose: this has never been run through `flatpak-builder`, that wasn't available in the environment this was written in. Opening it because the triage on #85 explicitly invited a draft manifest for review, not because it's close to mergeable.

**What it does:** ports `nix/package.nix`'s build phase (extract → stub → `enable-cowork.py`) and `nix/claude-desktop-launcher.sh`'s writable-tree mirror almost verbatim, since `/app` is read-only the same way the Nix store is. Kept close to the Nix version on purpose so the two packaging paths don't drift into separately-maintained pipelines.

**What it doesn't do, and isn't pretending to:** solve the sandbox-in-sandbox problem you flagged as the riskiest unknown. Cowork spawns its own `bwrap`; nesting that inside Flatpak's sandbox is unresolved here. `--talk-name=org.freedesktop.Flatpak` is requested so a future `flatpak-spawn --host` fix to the sandbox spawner (the pattern distrobox/devcontainers-in-flatpak use) doesn't also need a manifest change, but no code change to `launch.sh` or the cowork sandbox spawner is attempted in this PR.

Also unverified/placeholder, listed in full in `flatpak/README.md`:
- `extra-data` sha256/size are placeholders, need `node fetch-dmg.js --json`.
- `org.electronjs.Electron2.BaseApp` runtime version (`24.08`) isn't checked against Electron 41 compatibility.
- `--filesystem=home` for attached folders is the blunt version; portal-based access is the right long-term answer.

Verification: YAML, the metainfo XML, the wrapper script, and each embedded `build-commands` shell block all pass a syntax check. No actual `flatpak-builder --user --install` run, no launch, no Cowork task attempted, no GPG/hardware here to do that with.

If anyone can run `flatpak-builder` against this, the sandbox step is almost certainly where it breaks first and is the most useful thing to report back on #85.