### PR TITLE
fix(paths): stop the darwin spoof from treating /home as an automount root

### DIFF
--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -252,6 +252,66 @@ def patch_platform_return_gates(filepath):
     return True
 
 
+# Stop the darwin platform spoof from leaking into a general Linux path-safety
+# check (issue #172).
+#
+# The bundle's automount-root check treats a path as an untrusted "automount
+# root" using one of two regexes, chosen by process.platform:
+#   darwin:        /^\/(net|home)(\/|$)/
+#   everything else: /^\/net(\/|$)/
+# Because this project spoofs process.platform to "darwin" so the Cowork gate
+# returns "supported", this check also sees darwin and applies the macOS
+# rule, which additionally treats anything under /home as an automount root.
+# That's correct on real macOS, where network homes are commonly automounted
+# under /home; on Linux, /home is the normal, non-automounted home hierarchy,
+# so every path under it gets refused as "a protected location" instead.
+#
+# Confirmed on 1.26832.0 to be reachable from Cowork's attach-folder
+# enumeration (every subfolder of $HOME is checked against this and, today,
+# refused) via a { refuseSubstitutedPath: <this function> } option passed to
+# the shared path resolver, and is the most likely mechanism behind #172's
+# report that MCP tool-result files under ~/.claude and local-agent-mode
+# session outputs get rejected the same way.
+#
+# The fix forces the non-darwin regex unconditionally: this compat layer only
+# ever runs on real Linux, so there is no case where the darwin branch should
+# apply here regardless of the spoof. /net stays refused either way -- this
+# doesn't weaken the check or bypass any resolver, it corrects which
+# platform's rule the existing check evaluates.
+AUTOMOUNT_DARWIN_BRANCH = re.escape('?/^\\/(net|home)(\\/|$)/:')
+AUTOMOUNT_LINUX_BRANCH = re.escape('/^\\/net(\\/|$)/')
+AUTOMOUNT_DARWIN_LEAK_RE = re.compile(
+    r'process\.platform===' + Q + r'darwin' + Q +
+    AUTOMOUNT_DARWIN_BRANCH + r'(' + AUTOMOUNT_LINUX_BRANCH + r')'
+)
+AUTOMOUNT_DARWIN_LEAK_MARKER = '/*cowork-automount-patched*/'
+
+
+def patch_automount_darwin_leak(filepath):
+    """Stop the darwin platform spoof from making the automount-root check
+    treat every path under /home as untrusted (issue #172)."""
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    if AUTOMOUNT_DARWIN_LEAK_MARKER in content:
+        print(f"  Automount-root check: already patched")
+        return True
+
+    match = AUTOMOUNT_DARWIN_LEAK_RE.search(content)
+    if not match:
+        print(f"  Automount-root check: no matching site found")
+        return True
+
+    content = content[:match.start()] + match.group(1) + content[match.end():]
+    content += AUTOMOUNT_DARWIN_LEAK_MARKER
+
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+    print(f"  Automount-root check patched: darwin branch no longer treats /home as an automount root")
+    return True
+
+
 def _warn_if_unparseable(filepath):
     """Warn loudly if the patched file is no longer valid JavaScript.
 
@@ -297,6 +357,7 @@ if __name__ == "__main__":
     patch_host_platform(target)
     patch_ipc_origin_guards(target)
     patch_platform_return_gates(target)
+    patch_automount_darwin_leak(target)
 
     # Every pass above is a regex substitution into minified JS, so a pattern
     # that matches slightly more or less than intended produces a file that is


### PR DESCRIPTION
Addresses #172, with real verification this time (I don't have a working Linux install for #172 myself, but I do have access to a machine with a real 1.26832.0 install for this session, and used it directly against the actual bundle).

**Root cause, found in the real code:** the automount-root check picks its regex by `process.platform`:
```js
function Ce(e){let t=process.platform===`darwin`?/^\/(net|home)(\/|$)/:/^\/net(\/|$)/;return[e,F(e)].filter(e=>e!==null).some(e=>t.test(S(e)))}
```
This project spoofs `process.platform` to `"darwin"` so the Cowork gate returns `"supported"`. That spoof also reaches this check, so it evaluates the darwin branch, which additionally refuses anything under `/home`. Correct on real macOS (network homes are commonly automounted under `/home` there); wrong on Linux, where `/home` is the ordinary, non-automounted home hierarchy.

**Confirmed reachable, not just theorized:** `index2.chunk-D0mW2oMM.js` passes this function as `refuseSubstitutedPath` into the shared path resolver when enumerating attach-folder candidates under `$HOME` (Cowork's "attach a folder" flow). On the real install I checked, every subfolder of `$HOME` gets checked against this and is refused today.

**Verified end to end**, not just read: extracted the actual `Ce()`/`F()`/`S()` from a real 1.26832.0 `index2.chunk-u5RDL4mp.js`, ran them standalone under both `process.platform` values:

| path | spoofed darwin (today) | patched |
|---|---|---|
| `/home/x/.claude/projects/.../tool-results/y.json` | refused | allowed |
| `/home/x/.../local_.../outputs/z` | refused | allowed |
| `/home/x/Documents/whatever.txt` | refused | allowed |
| `/net/fileserver/share/x` (real automount) | refused | **still refused** |

`/net` stays refused in every case — this doesn't bypass or weaken the check, it corrects which platform's branch an unmodified check evaluates.

**On #172 specifically:** the issue was filed against 1.28929.0, which I don't have access to, so I can't independently confirm this exact function is the one gating the MCP tool-result read path on that build. What I can say: it's the same darwin-spoof-leaking-into-a-path-check mechanism the issue describes, it's real and reachable today on 1.26832.0 (just via attach-folder enumeration rather than tool-results specifically), and the fix is version-general rather than shape-specific, so if 1.28929.0's tool-result read path goes through this same shared resolver (plausible, `refuseSubstitutedPath` is the general mechanism, not a per-feature one), this fixes that too. Worth a doctor/reproduce check on an affected build to confirm.

I'd also flagged a path-traversal gap in the alternative fix proposed on #172 (raw `realpath` with no post-resolution containment check). This patch doesn't have that problem since it doesn't add any new path-resolution logic or bypass — it only fixes which of the *existing* two regex branches an unmodified function picks.

**Verification:**
- `tests/test-cowork-patch.sh`: 84/84 still passing, no regressions.
- The new pass run against every `index*.chunk-*.js` in a real extracted+patched install tree: matches exactly one file (`index2.chunk-u5RDL4mp.js`), zero false positives elsewhere, every chunk still parses (`node -c`) after patching.
- Idempotency: re-running against an already-patched file is a marker-guarded no-op, confirmed.

Happy to dig further if someone can run this against an actual 1.28929.0 install and confirm/deny the tool-results call site.