### PR TITLE
fix(install): sync install.sh, COMPAT.md, and enable-cowork.py to the install dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -762,10 +762,18 @@ install_stubs() {
         # launcher's protocol-forwarder search looks under it, so leaving it
         # behind means an update installs fresh stubs and then has the old ones
         # copied back over them on the next launch.
+        # install.sh, COMPAT.md, and enable-cowork.py ride along for the same
+        # reason: the generated launcher execs $INSTALL_DIR/install.sh for
+        # --doctor and --update, the launcher and doctor grep
+        # $INSTALL_DIR/COMPAT.md for the last-tested pin, and an --update run
+        # patches with $INSTALL_DIR/enable-cowork.py. Leaving them behind means
+        # every later --doctor/--update runs whatever version the install dir
+        # happened to hold — stale checks reporting false warnings against a
+        # current install.
         [[ -d "$stub_src/stubs" ]] || die "stubs/ missing from $stub_src. Re-run from a complete checkout."
         cp -rf "$stub_src/stubs" "$INSTALL_DIR/"
         local _f
-        for _f in launch.sh launch-devtools.sh patch-index.sh; do
+        for _f in launch.sh launch-devtools.sh patch-index.sh install.sh COMPAT.md enable-cowork.py; do
             [[ -f "$stub_src/$_f" ]] || die "$_f missing from $stub_src. Re-run from a complete checkout."
             cp -f "$stub_src/$_f" "$INSTALL_DIR/$_f"
         done


### PR DESCRIPTION
## Problem

`install_stubs()` syncs `launch.sh`, `launch-devtools.sh`, `patch-index.sh`, and `stubs/` into `$INSTALL_DIR` so future launches use current code — but not `install.sh`, `COMPAT.md`, or `enable-cowork.py`. All three are exec'd/read from the install dir after install:

- the generated launcher runs `$INSTALL_DIR/install.sh` for `--doctor` and `--update`
- the launcher and doctor grep `$INSTALL_DIR/COMPAT.md` for the last-tested asar pin
- an `--update` run patches with `$INSTALL_DIR/enable-cowork.py`

On an install whose install dir predates the current checkout, `claude-desktop --doctor` runs months-old checks against a current install. Observed on a real install whose install dir was at the PR #69 era: the doctor grepped only `index.js` for the cowork marker (fixed for the repo copy in 9d24d9a, but the fix never reached the install dir), so it reported **"Cowork patch: not applied"** on a correctly patched app — the exact false warning 9d24d9a fixed — and the launcher warned the asar was newer than last tested **1.6259.1** when COMPAT.md upstream had long pinned 1.26832.0.

## Fix

Add the three files to the existing sync loop in `install_stubs()`, with a comment explaining why they have to ride along. The loop's existing missing-file check applies to them unchanged.

## Testing

- `bash -n install.sh`
- Reproduced the stale-doctor state locally (install dir at v5.1.0-era `install.sh`); after syncing the three files, `claude-desktop --doctor` reports "Cowork patch: applied" and compares against the current COMPAT.md pin — 20 passed, 1 warning (the genuine newer-than-tested notice), 0 failed.
