### PR TITLE
fix(cowork): handle -- separator in disclaimer wrapper args

### DIFF
--- a/stubs/cowork/exec_capability_registry.js
+++ b/stubs/cowork/exec_capability_registry.js
@@ -246,8 +246,16 @@ function createExecCapabilityRegistry({
   // agrees with resolve() for every class is what keeps that true.
   function resolveDisclaimerCommand(args) {
     if (!Array.isArray(args) || args.length === 0) return null;
-    var cmd = args[0];
-    var rest = args.slice(1);
+    // Some call sites (e.g. HostCLIRunner/Code tab) invoke the wrapper as
+    // `disclaimer -- <cmd> <args...>`, a leading `--` separator with no
+    // command in args[0]. Skip it before reading the command, or cmd becomes
+    // the literal string "--", which matches nothing below and falls through
+    // to the exit-127 stub -- the same failure mode as #132 but for this
+    // callsite's argv shape instead of the path shape.
+    var offset = args[0] === '--' ? 1 : 0;
+    var cmd = args[offset];
+    var rest = args.slice(offset + 1);
+    if (cmd === undefined) return null;
     // The asar invokes the Claude CLI through the disclaimer wrapper using
     // whatever path it chose -- a macOS-style claude.app/.../Claude path, or
     // the SDK path it installed (claude-code-vm/<ver>/claude), or a native

--- a/tests/node/current-path/exec_capability_registry.test.cjs
+++ b/tests/node/current-path/exec_capability_registry.test.cjs
@@ -222,6 +222,32 @@ describe('exec_capability_registry', () => {
         assert.deepStrictEqual(result.rest, ['-p', 'hi']);
       });
 
+      it('resolves a claude path passed with a leading -- separator (Code tab / HostCLIRunner)', () => {
+        // HostCLIRunner (Code tab) invokes the wrapper as
+        // `disclaimer -- <cmd> <args...>` -- a leading `--` with no command
+        // in args[0]. Before this fix, cmd read args[0] unconditionally, saw
+        // the literal string "--", matched neither the claude.app regex nor
+        // the basename check, and fell through to the exit-127 stub on every
+        // Code-tab session -- same failure mode as #132, a different argv
+        // shape at a different call site.
+        const reg = createExecCapabilityRegistry({
+          homedir: os.homedir(),
+          resolveClaudeBinaryPath: () => '/usr/local/bin/claude',
+        });
+        const result = reg.resolveDisclaimerCommand([
+          '--',
+          '/home/u/.config/Claude/claude-code/2.1.246/claude.app/Contents/MacOS/claude',
+        ]);
+        assert.ok(result, 'a leading -- must be skipped, not treated as the command');
+        assert.strictEqual(result.cmd, '/usr/local/bin/claude');
+        assert.deepStrictEqual(result.rest, []);
+      });
+
+      it('rejects a bare -- with no following command', () => {
+        const result = registry.resolveDisclaimerCommand(['--']);
+        assert.strictEqual(result, null);
+      });
+
       // Why the wrap/unwrap round-trip is kept rather than patched out of the
       // bundle. The asar sets pathToClaudeCodeExecutable from Ql({cmd:r}): with
       // the wrap it is the disclaimer binary and r rides in argv, so this unwrap


### PR DESCRIPTION
## Problem
Every Code-tab / local-agent-mode session on Linux fails immediately with
"Claude Code process exited with code 127", surfaced as a "Claude Code
crashed" dialog on every message sent.

## Root cause
`stubs/cowork/exec_capability_registry.js`'s `resolveDisclaimerCommand()`
read `args[0]` as the command unconditionally. HostCLIRunner (Code tab)
invokes the disclaimer wrapper as `disclaimer -- <cmd> <args...>` -- a
leading `--` separator, no command in `args[0]`. `cmd` became the literal
string `"--"`, which matches neither the `claude.app` regex nor the
basename check, so the unwrap returned `null` and the real disclaimer stub
(`exit 127`) ran -- same failure mode as #132, a different argv shape at a
different call site.

## Fix
Skip a leading `--` before reading `cmd`/`rest` in `resolveDisclaimerCommand`.
No change to admission logic -- `resolveClaudeCli()`/`resolve()` still decide
what's actually substituted; this only changes which array index is read as
the command.

## Scope / not touched
- No change to `resolve()`, the allowlist, or any capability class.
- Confirmed this is not a regression carried by an in-flight branch:
  `git diff master -- stubs/cowork/exec_capability_registry.js` is empty
  against this branch's parent history, so the bug predates and is
  independent of any other work in flight.

## Checks
- Added two regression tests in
  `tests/node/current-path/exec_capability_registry.test.cjs`: the `--`
  case, and a bare `--` with no following command.
- Confirmed the new test fails against the pre-fix code and passes after
  the fix.
- `node --test tests/node/current-path/exec_capability_registry.test.cjs`:
  42/42 passing.

## Security note
`exec_capability_registry.js` is the disclaimer/admission chokepoint that's
been through several dedicated security-review passes in this repo's
history (f41417e, 0e1deeb, ea31eda, 04d7b16), and I understand a prior PR
touching this area is still under audit -- flagging explicitly even though
this file isn't on CONTRIBUTING.md's named security-sensitive list. This
change only shifts which argv index is read as `cmd` when the first
element is a bare `--`; the actual admission decision is untouched and
still routes through `resolveClaudeCli()`/`resolve()`. It adds no new
command classes and does not touch the allowlist.