### PR TITLE
fix(packaging,launcher): ship the whole native stub; stop repacking app.asar on every launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Cowork patch passes
         run: bash tests/test-cowork-patch.sh
 
+      # Drives launch.sh end to end against a temp tree with fake electron/asar
+      # binaries. Guards the repack cache (a `cp -f` that always stamps mtime
+      # made "Using cached app.asar" unreachable and repacked ~300 files on
+      # every start) and the stub module-set parity that let PKGBUILD ship
+      # @ant/claude-native without the safe_fs.js its index.js require()s.
+      - name: Launcher stub sync
+        run: bash tests/test-launcher-sync.sh
+
       # Stage 1 of the install harness is pure static analysis -- no network, no
       # Docker, no Arch -- so it can run here even though stages 2-8 cannot.
       # Nothing ran this file at all, which is how it came to py_compile

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -126,8 +126,14 @@ build() {
     mkdir -p "${srcdir}/linux-app-extracted/node_modules/@ant/claude-native"
     cp -f "${_repo}/stubs/@ant/claude-swift/js/index.js" \
           "${srcdir}/linux-app-extracted/node_modules/@ant/claude-swift/js/index.js"
-    cp -f "${_repo}/stubs/@ant/claude-native/index.js" \
-          "${srcdir}/linux-app-extracted/node_modules/@ant/claude-native/index.js"
+    # index.js plus every sibling helper it require()s. safe_fs.js landed with
+    # the 1.22209.x safe-fs containment API and is require()d unconditionally at
+    # the top of index.js, but this line still named index.js alone -- so the
+    # package shipped a stub whose first require() throws MODULE_NOT_FOUND, four
+    # months after the helper was added. install.sh and launch.sh both copy the
+    # whole glob; this is the same copy-loop drift as #170, one directory over.
+    cp -f "${_repo}"/stubs/@ant/claude-native/*.js \
+          "${srcdir}/linux-app-extracted/node_modules/@ant/claude-native/"
 
     # Copy frame-fix files
     cp -f "${_repo}/stubs/frame-fix/frame-fix-entry.js" \

--- a/launch-devtools.sh
+++ b/launch-devtools.sh
@@ -32,9 +32,13 @@ if [ -f "stubs/@ant/claude-swift/js/index.js" ]; then
 fi
 if [ -f "stubs/@ant/claude-native/index.js" ]; then
   mkdir -p "linux-app-extracted/node_modules/@ant/claude-native"
-  cp -f "stubs/@ant/claude-native/index.js" "linux-app-extracted/node_modules/@ant/claude-native/index.js"
+  # The whole module set, not just index.js: it require()s ./safe_fs.js at
+  # module load, so a tree with index.js alone throws MODULE_NOT_FOUND. This
+  # said "mirrors launch.sh" while copying one of the two files launch.sh does.
+  cp -f stubs/@ant/claude-native/*.js "linux-app-extracted/node_modules/@ant/claude-native/"
 fi
-for _ff_file in frame-fix-entry.js frame-fix-wrapper.js; do
+# protocol-forwarder.js too -- same list as launch.sh and install_stubs().
+for _ff_file in frame-fix-entry.js frame-fix-wrapper.js protocol-forwarder.js; do
   if [ -f "stubs/frame-fix/$_ff_file" ]; then
     cp -f "stubs/frame-fix/$_ff_file" "linux-app-extracted/$_ff_file"
   fi

--- a/launch.sh
+++ b/launch.sh
@@ -11,6 +11,30 @@ cd "$SCRIPT_DIR"
 # Ensure ~/.local/bin is in PATH (common for user-local electron installs)
 export PATH="$HOME/.local/bin:$PATH"
 
+# Copy src -> dst only when the contents actually differ.
+#
+# Every sync below used a bare `cp -f`, which stamps the destination with the
+# current time whether or not a byte changed. The repack check further down asks
+# "is anything under linux-app-extracted newer than the cached app.asar?", so an
+# unconditional copy of an unchanged file answered yes on every single launch:
+# the cache never hit, "Using cached app.asar (no changes)" was unreachable
+# code, and every start repacked the whole ~300-file tree. Same failure mode the
+# mainView.js sed had (see the note in patch-index.sh) -- a write that always
+# happens, feeding an mtime check that assumes writes mean changes.
+#
+# cmp is in diffutils, present on every distro this supports; if it somehow
+# isn't, the test fails non-zero and we fall through to the copy, i.e. exactly
+# the old behaviour.
+sync_file() {
+  local src="$1" dst="$2"
+  [ -f "$src" ] || return 0
+  if [ -f "$dst" ] && cmp -s "$src" "$dst" 2>/dev/null; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$dst")"
+  cp -f "$src" "$dst"
+}
+
 # Point Cowork at the user's Claude Code CLI binary
 if [ -z "$CLAUDE_CODE_PATH" ]; then
   for _candidate in "$HOME/.local/bin/claude" "$HOME/.npm-global/bin/claude" "/usr/local/bin/claude"; do
@@ -51,31 +75,32 @@ NATIVE_STUB_SRC_FILE="stubs/@ant/claude-native/index.js"
 
 # Ensure the extracted app tree has the latest stubs baked in before packing.
 # This avoids relying on runtime module interception (ESM import() bypasses Module._load).
-if [ -f "$STUB_SRC_FILE" ]; then
-  mkdir -p "$(dirname "$STUB_FILE")"
-  cp -f "$STUB_SRC_FILE" "$STUB_FILE"
-fi
+sync_file "$STUB_SRC_FILE" "$STUB_FILE"
 
 if [ -f "$NATIVE_STUB_SRC_FILE" ]; then
-  mkdir -p "$(dirname "$NATIVE_STUB_FILE")"
   # Copy index.js plus any sibling helper modules it require()s (e.g.
   # safe_fs.js, added for the asar 1.22209.x safe-fs containment API).
   for _nat_src in stubs/@ant/claude-native/*.js; do
-    [ -f "$_nat_src" ] && cp -f "$_nat_src" "$(dirname "$NATIVE_STUB_FILE")/$(basename "$_nat_src")"
+    sync_file "$_nat_src" "$(dirname "$NATIVE_STUB_FILE")/$(basename "$_nat_src")"
   done
 fi
 
-# Sync frame-fix files so wrapper changes take effect without a full reinstall
-for _ff_file in frame-fix-entry.js frame-fix-wrapper.js; do
-  if [ -f "stubs/frame-fix/$_ff_file" ]; then
-    cp -f "stubs/frame-fix/$_ff_file" "linux-app-extracted/$_ff_file"
-  fi
+# Sync frame-fix files so wrapper changes take effect without a full reinstall.
+# protocol-forwarder.js belongs here too: the generated launcher execs
+# linux-app-extracted/protocol-forwarder.js for the claude:// OAuth fast path,
+# and only install.sh ever wrote it -- so an edited forwarder never reached a
+# launch and fixing one needed a full reinstall. install_stubs() already copies
+# all three; this is the same list.
+for _ff_file in frame-fix-entry.js frame-fix-wrapper.js protocol-forwarder.js; do
+  sync_file "stubs/frame-fix/$_ff_file" "linux-app-extracted/$_ff_file"
 done
 
 # Sync cowork orchestration modules into the extracted app tree.
 if [ -d "stubs/cowork" ]; then
   mkdir -p "linux-app-extracted/cowork"
-  cp -f stubs/cowork/*.js "linux-app-extracted/cowork/"
+  for _cw_src in stubs/cowork/*.js; do
+    sync_file "$_cw_src" "linux-app-extracted/cowork/$(basename "$_cw_src")"
+  done
 fi
 
 # Replace macOS pty.node with the Linux ELF build. The DMG ships a Mach-O
@@ -84,7 +109,7 @@ fi
 if [ -f "stubs/node-pty-linux/pty.node" ]; then
   _PTY_DEST="linux-app-extracted/node_modules/node-pty/build/Release"
   if [ -d "$_PTY_DEST" ]; then
-    cp -f stubs/node-pty-linux/pty.node "$_PTY_DEST/pty.node"
+    sync_file stubs/node-pty-linux/pty.node "$_PTY_DEST/pty.node"
   fi
 fi
 
@@ -94,11 +119,13 @@ fi
 # resources dir as a fallback for process.resourcesPath lookups.
 if [ -f "stubs/cowork/cowork-plugin-shim.sh" ]; then
   mkdir -p "linux-app-extracted/resources"
-  cp -f stubs/cowork/cowork-plugin-shim.sh "linux-app-extracted/resources/cowork-plugin-shim.sh"
+  # chmod is unconditional: it moves ctime, not mtime, so it costs no repack,
+  # and sync_file no-ops on an unchanged file that someone stripped +x from.
+  sync_file stubs/cowork/cowork-plugin-shim.sh "linux-app-extracted/resources/cowork-plugin-shim.sh"
   chmod +x "linux-app-extracted/resources/cowork-plugin-shim.sh"
   _RESOURCES_DIR="$(dirname "$ELECTRON_BIN")/resources"
   if [ -d "$_RESOURCES_DIR" ]; then
-    cp -f stubs/cowork/cowork-plugin-shim.sh "$_RESOURCES_DIR/cowork-plugin-shim.sh"
+    sync_file stubs/cowork/cowork-plugin-shim.sh "$_RESOURCES_DIR/cowork-plugin-shim.sh"
     chmod +x "$_RESOURCES_DIR/cowork-plugin-shim.sh"
   fi
 fi
@@ -116,11 +143,26 @@ if [ -d "linux-app-extracted/resources" ] && [ ! -d "linux-app-extracted/resourc
   done
 fi
 
-# Fix entry point: use frame-fix-entry.js so BrowserWindow gets native Linux frames
+# Fix entry point: use frame-fix-entry.js so BrowserWindow gets native Linux frames.
+#
+# Guard on the SUBSTITUTION target, not a looser marker -- PKGBUILD's copy of
+# this patch already does. The guard used to be `"main":.*index\.pre\.js"`
+# while the sed demanded a quote immediately before `.vite`, so a build that
+# spelled its main `"./.vite/build/index.pre.js"` passed the guard, no-oped in
+# the sed, printed "Fixing entry point..." as though it had worked, and left
+# the app running its own entry point. sed -i rewrites the file on a miss too,
+# which bumped mtime and forced a full asar repack on every launch, forever --
+# the same shape as the mainView.js bug noted in patch-index.sh.
 PKG_JSON="linux-app-extracted/package.json"
-if [ -f "$PKG_JSON" ] && grep -q '"main":.*index\.pre\.js"' "$PKG_JSON"; then
-  echo "Fixing entry point to use frame-fix-entry.js..."
-  sed -i 's|"main":.*"\.vite/build/index\.pre\.js"|"main": "frame-fix-entry.js"|' "$PKG_JSON"
+if [ -f "$PKG_JSON" ]; then
+  if grep -q '"main":.*"\.vite/build/index\.pre\.js"' "$PKG_JSON"; then
+    echo "Fixing entry point to use frame-fix-entry.js..."
+    sed -i 's|"main":.*"\.vite/build/index\.pre\.js"|"main": "frame-fix-entry.js"|' "$PKG_JSON"
+  elif grep -q 'index\.pre\.js' "$PKG_JSON"; then
+    echo "WARN: package.json still points at index.pre.js but not in the shape this patch rewrites." >&2
+    echo "      The entry point was NOT repointed at frame-fix-entry.js; expect macOS titlebars" >&2
+    echo "      and a renderer shell that never loads. The bundle layout has changed." >&2
+  fi
 fi
 
 # ── Main-process patches ────────────────────────────────────────────────────

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -138,7 +138,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     mkdir -p "$tree/node_modules/@ant/claude-swift/js" "$tree/node_modules/@ant/claude-native"
     cp stubs/@ant/claude-swift/js/index.js "$tree/node_modules/@ant/claude-swift/js/index.js"
-    cp stubs/@ant/claude-native/index.js "$tree/node_modules/@ant/claude-native/index.js"
+    # index.js plus every sibling it require()s -- ./safe_fs.js is loaded at the
+    # top of index.js, so a tree holding index.js alone throws MODULE_NOT_FOUND.
+    cp stubs/@ant/claude-native/*.js "$tree/node_modules/@ant/claude-native/"
     for f in frame-fix-wrapper.js frame-fix-entry.js protocol-forwarder.js; do
       [ -f "stubs/frame-fix/$f" ] && cp "stubs/frame-fix/$f" "$tree/$f"
     done

--- a/test-local.sh
+++ b/test-local.sh
@@ -5,37 +5,61 @@
 set -e
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-INSTALL_DIR="$HOME/.local/share/claude-desktop"
+INSTALL_DIR="${CLAUDE_INSTALL_DIR:-$HOME/.local/share/claude-desktop}"
 EXTRACTED_DIR="$INSTALL_DIR/linux-app-extracted"
+LAUNCHER="$HOME/.local/bin/claude-desktop"
+
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "ERROR: install dir not found: $INSTALL_DIR" >&2
+    echo "       Run ./install.sh first, or set CLAUDE_INSTALL_DIR." >&2
+    exit 1
+fi
 
 echo "Deploying local stubs from $REPO_DIR"
 
-# Copy frame-fix wrapper
-cp -v "$REPO_DIR/stubs/frame-fix/frame-fix-wrapper.js" "$INSTALL_DIR/frame-fix-wrapper.js"
-cp -v "$REPO_DIR/stubs/frame-fix/frame-fix-wrapper.js" "$EXTRACTED_DIR/frame-fix-wrapper.js" 2>/dev/null || true
-
-# Keep the installed stubs tree and extracted app in sync. Dynamic imports can
-# resolve from either location depending on launch path and packaging state.
-mkdir -p "$INSTALL_DIR/stubs/@ant/claude-swift/js" "$INSTALL_DIR/stubs/@ant/claude-native"
-mkdir -p "$EXTRACTED_DIR/node_modules/@ant/claude-swift/js" "$EXTRACTED_DIR/node_modules/@ant/claude-native"
-
-# Copy swift stub
-cp -v "$REPO_DIR/stubs/@ant/claude-swift/js/index.js" "$INSTALL_DIR/stubs/@ant/claude-swift/js/index.js"
-cp -v "$REPO_DIR/stubs/@ant/claude-swift/js/index.js" "$EXTRACTED_DIR/node_modules/@ant/claude-swift/js/index.js"
-
-# Copy native stub
-cp -v "$REPO_DIR/stubs/@ant/claude-native/index.js" "$INSTALL_DIR/stubs/@ant/claude-native/index.js"
-cp -v "$REPO_DIR/stubs/@ant/claude-native/index.js" "$EXTRACTED_DIR/node_modules/@ant/claude-native/index.js"
-
-# Copy cowork orchestration modules
-if [ -d "$REPO_DIR/stubs/cowork" ]; then
-    mkdir -p "$EXTRACTED_DIR/cowork"
-    cp -v "$REPO_DIR"/stubs/cowork/*.js "$EXTRACTED_DIR/cowork/"
+# $INSTALL_DIR/stubs is the tree launch.sh re-syncs into the extracted app on
+# EVERY start -- swift/native stubs, cowork/*.js, frame-fix/*.js, the plugin
+# shim. Writing only into the extracted app (what this script used to do) is
+# therefore self-defeating: the next launch copies the installed, unmodified
+# stubs straight back over the freshly deployed ones, and you end up testing
+# the code you were trying to replace. Nothing at all read the old
+# $INSTALL_DIR/frame-fix-wrapper.js destination.
+#
+# So deploy to $INSTALL_DIR/stubs first -- that is the source of truth -- and
+# mirror into the extracted tree afterwards so a direct `electron` run (one
+# that bypasses launch.sh) sees the same code.
+# Skip when the repo IS the install dir (running from the installed checkout):
+# `cp -rf x/stubs x/` is "same file" and aborts under set -e.
+if [ "$REPO_DIR" != "$INSTALL_DIR" ]; then
+    echo "Syncing stubs/ -> $INSTALL_DIR/stubs/"
+    cp -rf "$REPO_DIR/stubs" "$INSTALL_DIR/"
 fi
+
+# Mirror into the extracted app. Each destination takes the WHOLE source
+# directory, not a hand-listed file: @ant/claude-native/index.js require()s
+# ./safe_fs.js at module load, and copying index.js alone (what this script
+# used to do) leaves a stub that throws MODULE_NOT_FOUND.
+mkdir -p "$EXTRACTED_DIR/node_modules/@ant/claude-swift/js" \
+         "$EXTRACTED_DIR/node_modules/@ant/claude-native" \
+         "$EXTRACTED_DIR/cowork"
+
+cp -vf "$REPO_DIR"/stubs/@ant/claude-swift/js/*.js \
+       "$EXTRACTED_DIR/node_modules/@ant/claude-swift/js/"
+cp -vf "$REPO_DIR"/stubs/@ant/claude-native/*.js \
+       "$EXTRACTED_DIR/node_modules/@ant/claude-native/"
+cp -vf "$REPO_DIR"/stubs/cowork/*.js "$EXTRACTED_DIR/cowork/"
+
+# frame-fix files land at the root of the extracted app, matching
+# install_stubs() and launch.sh. protocol-forwarder.js is in the list because
+# the generated launcher execs it directly for the claude:// OAuth fast path.
+for _ff in frame-fix-entry.js frame-fix-wrapper.js protocol-forwarder.js; do
+    [ -f "$REPO_DIR/stubs/frame-fix/$_ff" ] || continue
+    cp -vf "$REPO_DIR/stubs/frame-fix/$_ff" "$EXTRACTED_DIR/$_ff"
+done
 
 # Clear asar cache to force rebuild
 if [ -d "$INSTALL_DIR/.asar-cache" ]; then
-    rm -rf "$INSTALL_DIR/.asar-cache"/*
+    rm -rf "${INSTALL_DIR:?}/.asar-cache"/*
     echo "Cleared .asar-cache"
 fi
 
@@ -43,6 +67,13 @@ echo ""
 echo "Local stubs deployed. Run claude-desktop to test."
 
 if [ "$1" = "--launch" ]; then
-    echo "Launching claude-desktop..."
-    exec "$INSTALL_DIR/claude-desktop"
+    # The launcher lives in ~/.local/bin, not in the install dir. This used to
+    # exec "$INSTALL_DIR/claude-desktop", a path install.sh has never written,
+    # so --launch always died with "No such file or directory".
+    if [ -x "$LAUNCHER" ]; then
+        echo "Launching claude-desktop..."
+        exec "$LAUNCHER"
+    fi
+    echo "Launcher not found at $LAUNCHER; falling back to $INSTALL_DIR/launch.sh"
+    exec "$INSTALL_DIR/launch.sh"
 fi

--- a/tests/node/current-path/exec_capability_registry.test.cjs
+++ b/tests/node/current-path/exec_capability_registry.test.cjs
@@ -127,22 +127,26 @@ describe('exec_capability_registry', () => {
         assert.strictEqual(registry.resolve('', []), null);
       });
 
-      it('resolves system binaries', () => {
+      // t.skip(), not a bare `if (found) { ... }`. A silent guard reports a
+      // green test on a machine where the binary is absent -- which is how the
+      // #132 coverage came to assert nothing at all wherever
+      // /usr/local/bin/claude did not exist (see the note further down). An
+      // environment-dependent test that cannot run should say so in the
+      // output, not pass.
+      it('resolves system binaries', (t) => {
         const bash = ['/usr/bin/bash', '/bin/bash'].find(p => fs.existsSync(p));
-        if (bash) {
-          const result = registry.resolve(bash, ['--version']);
-          assert.ok(result);
-          assert.ok(result.capabilityId.startsWith('system-'));
-        }
+        if (!bash) return t.skip('no bash at any SYSTEM_PATHS location');
+        const result = registry.resolve(bash, ['--version']);
+        assert.ok(result);
+        assert.ok(result.capabilityId.startsWith('system-'));
       });
 
-      it('resolves system commands by prefix', () => {
+      it('resolves system commands by prefix', (t) => {
         const git = ['/usr/bin/git', '/usr/local/bin/git'].find(p => fs.existsSync(p));
-        if (git) {
-          const result = registry.resolve(git, ['status']);
-          assert.ok(result);
-          assert.ok(['system-git', 'system-cmd'].includes(result.capabilityId));
-        }
+        if (!git) return t.skip('no git at any SYSTEM_PATHS location');
+        const result = registry.resolve(git, ['status']);
+        assert.ok(result);
+        assert.ok(['system-git', 'system-cmd'].includes(result.capabilityId));
       });
 
       it('rejects paths outside all registries', () => {
@@ -247,14 +251,13 @@ describe('exec_capability_registry', () => {
         }
       });
 
-      it('resolves system binary commands', () => {
+      it('resolves system binary commands', (t) => {
         const git = ['/usr/bin/git', '/usr/local/bin/git'].find(p => fs.existsSync(p));
-        if (git) {
-          const result = registry.resolveDisclaimerCommand([git, 'status']);
-          assert.ok(result);
-          assert.strictEqual(result.cmd, git);
-          assert.deepStrictEqual(result.rest, ['status']);
-        }
+        if (!git) return t.skip('no git at any SYSTEM_PATHS location');
+        const result = registry.resolveDisclaimerCommand([git, 'status']);
+        assert.ok(result);
+        assert.strictEqual(result.cmd, git);
+        assert.deepStrictEqual(result.rest, ['status']);
       });
 
       it('rejects binaries outside registry', () => {

--- a/tests/test-install-paths.sh
+++ b/tests/test-install-paths.sh
@@ -293,14 +293,19 @@ stage_4() {
     mkdir -p "$app_dir/node_modules/@ant/claude-native"
     cp "$REPO_ROOT/stubs/@ant/claude-swift/js/index.js" \
        "$app_dir/node_modules/@ant/claude-swift/js/index.js"
-    cp "$REPO_ROOT/stubs/@ant/claude-native/index.js" \
-       "$app_dir/node_modules/@ant/claude-native/index.js"
+    # The whole module set. Copying index.js alone modelled the deployment
+    # wrongly, which is why this harness could pass against a tree that throws
+    # MODULE_NOT_FOUND the moment the stub is require()d -- exactly what the
+    # AUR and Nix recipes were shipping.
+    cp "$REPO_ROOT"/stubs/@ant/claude-native/*.js \
+       "$app_dir/node_modules/@ant/claude-native/"
 
     assert_file_exists "$app_dir/node_modules/@ant/claude-swift/js/index.js" "Swift stub installed"
     assert_file_exists "$app_dir/node_modules/@ant/claude-native/index.js" "Native stub installed"
+    assert_file_exists "$app_dir/node_modules/@ant/claude-native/safe_fs.js" "Native stub helper installed"
 
     # Copy frame-fix files
-    for f in frame-fix-entry.js frame-fix-wrapper.js; do
+    for f in frame-fix-entry.js frame-fix-wrapper.js protocol-forwarder.js; do
         if [[ -f "$REPO_ROOT/stubs/frame-fix/$f" ]]; then
             cp "$REPO_ROOT/stubs/frame-fix/$f" "$app_dir/$f"
         fi

--- a/tests/test-launcher-sync.sh
+++ b/tests/test-launcher-sync.sh
@@ -186,14 +186,26 @@ NATIVE_DIR="$REPO_ROOT/stubs/@ant/claude-native"
 # Every relative require() in the native stub must resolve in the repo. A
 # require of a file that was never committed fails the same way a deployment
 # path that forgets to copy it does.
+#
+# Both quote styles, and a hard failure when the scan finds NOTHING. A pattern
+# that quietly stops matching is how a check turns into a check-shaped no-op:
+# with a single-quote-only pattern, reformatting the stub to
+# require("./safe_fs.js") would have left this reporting green while inspecting
+# an empty list -- the same vacuous pass this PR removes from
+# exec_capability_registry.test.cjs. index.js has relative requires today, so
+# zero matches means the pattern broke, not that the dependencies went away.
+dep_count=0
 missing_src=""
 while IFS= read -r dep; do
     [ -n "$dep" ] || continue
+    dep_count=$((dep_count + 1))
     [ -f "$NATIVE_DIR/$dep" ] || [ -f "$NATIVE_DIR/$dep.js" ] || missing_src="$missing_src $dep"
-done < <(grep -oE "require\('\./[^']+'\)" "$NATIVE_DIR/index.js" 2>/dev/null \
-         | sed -E "s|require\('\./([^']+)'\)|\1|")
-if [ -z "$missing_src" ]; then
-    pass "every sibling module @ant/claude-native/index.js require()s exists in stubs/"
+done < <(grep -oE "require\(['\"]\./[^'\"]+['\"]\)" "$NATIVE_DIR/index.js" 2>/dev/null \
+         | sed -E "s|require\(['\"]\./([^'\"]+)['\"]\)|\1|")
+if [ "$dep_count" -eq 0 ]; then
+    fail "no relative require() found in the native stub -- this scan's pattern has stopped matching"
+elif [ -z "$missing_src" ]; then
+    pass "all $dep_count sibling modules @ant/claude-native/index.js require()s exist in stubs/"
 else
     fail "native stub require()s files not in stubs/:$missing_src"
 fi

--- a/tests/test-launcher-sync.sh
+++ b/tests/test-launcher-sync.sh
@@ -200,13 +200,35 @@ fi
 
 # Consumers must copy the directory, not hand-list index.js. safe_fs.js landed
 # months after PKGBUILD's copy line was written and never reached the package.
-for consumer in install.sh launch.sh test-local.sh PKGBUILD; do
+for consumer in install.sh launch.sh launch-devtools.sh test-local.sh PKGBUILD nix/package.nix; do
     if grep -qE 'claude-native/\*\.js' "$REPO_ROOT/$consumer"; then
         pass "$consumer copies the whole @ant/claude-native module set"
     else
         fail "$consumer names individual native stub files -- a new sibling module will not ship"
     fi
 done
+
+# Repo-wide, so a deployment path added later cannot reintroduce this without
+# tripping the check -- PR #178's draft flatpak manifest carries the same
+# single-file copy today. Scoped to lines that actually COPY the stub, so a
+# docs mention or validate.sh's reachability curl doesn't match. Plain grep
+# rather than `git grep`: this must work in an exported tree too.
+found_any=0
+while IFS= read -r offender; do
+    [ -n "$offender" ] || continue
+    found_any=1
+    rel="${offender#"$REPO_ROOT"/}"
+    if grep -qE 'claude-native/\*\.js' "$offender"; then
+        pass "$rel names index.js but also copies the whole module set"
+    else
+        fail "$rel copies claude-native/index.js alone -- safe_fs.js will not ship"
+    fi
+done < <(grep -rlE 'cp .*claude-native/index\.js' "$REPO_ROOT" \
+             --exclude-dir=.git --exclude-dir=node_modules \
+             --exclude=index.js 2>/dev/null | sort)
+if [ "$found_any" -eq 0 ]; then
+    pass "no deployment path copies claude-native/index.js by name"
+fi
 
 # ============================================================
 # 4. frame-fix file list parity
@@ -217,7 +239,7 @@ section "frame-fix file list parity"
 # The generated launcher execs linux-app-extracted/protocol-forwarder.js for
 # the claude:// OAuth fast path. install.sh placed it there; launch.sh's sync
 # list omitted it, so an edited forwarder never reached a launch.
-for consumer in install.sh launch.sh test-local.sh; do
+for consumer in install.sh launch.sh launch-devtools.sh test-local.sh nix/package.nix; do
     if grep -q 'protocol-forwarder.js' "$REPO_ROOT/$consumer"; then
         pass "$consumer syncs protocol-forwarder.js"
     else

--- a/tests/test-launcher-sync.sh
+++ b/tests/test-launcher-sync.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+#
+# Launcher stub-sync harness.
+#
+# Two things this file exists to keep true, both of which broke silently and
+# stayed broken for months because nothing looked:
+#
+#   1. The repack cache actually caches. launch.sh re-syncs the stub tree into
+#      linux-app-extracted on every start, then repacks app.asar only "if any
+#      file in the extracted tree is newer than the cached asar". A bare
+#      `cp -f` stamps the destination with the current time whether or not a
+#      byte changed, so that question answered yes on every launch: the cache
+#      never hit, the "Using cached app.asar (no changes)" branch was
+#      unreachable, and every single start repacked the whole ~300-file tree.
+#      The same shape bit the mainView.js sed (see patch-index.sh) and the
+#      package.json entry-point sed below -- a write that always happens,
+#      feeding an mtime check that assumes writes mean changes.
+#
+#   2. Every deployment path delivers a stub's whole module set, not just its
+#      index.js. stubs/@ant/claude-native/index.js require()s ./safe_fs.js at
+#      module load; PKGBUILD copied index.js alone for four months after that
+#      helper landed, so the AUR package shipped a stub whose first require()
+#      throws MODULE_NOT_FOUND. install.sh, launch.sh and test-local.sh copy
+#      the glob; a fourth consumer that hand-lists files will fail here.
+#
+# Hermetic: a temp tree, a temp HOME, and fake `electron`/`asar` binaries. No
+# network, no Docker, no real install touched.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass()    { echo -e "  ${GREEN}PASS${NC} $*"; PASS=$((PASS + 1)); }
+fail()    { echo -e "  ${RED}FAIL${NC} $*"; FAIL=$((FAIL + 1)); }
+skip()    { echo -e "  ${YELLOW}SKIP${NC} $*"; SKIP=$((SKIP + 1)); }
+section() { echo -e "\n${BOLD}=== $* ===${NC}"; }
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# ============================================================
+# Fixture: a minimal tree launch.sh can drive end to end
+# ============================================================
+
+FAKE_BIN="$TMP/bin"
+FAKE_HOME="$TMP/home"
+TREE="$TMP/tree"
+
+build_fixture() {
+    rm -rf "$TREE" "$FAKE_HOME"
+    mkdir -p "$FAKE_BIN" "$FAKE_HOME" \
+             "$TREE/stubs/@ant/claude-swift/js" \
+             "$TREE/stubs/@ant/claude-native" \
+             "$TREE/stubs/cowork" \
+             "$TREE/stubs/frame-fix" \
+             "$TREE/linux-app-extracted/.vite/build" \
+             "$TREE/linux-app-extracted/resources"
+
+    cp "$REPO_ROOT/launch.sh" "$REPO_ROOT/patch-index.sh" "$TREE/"
+
+    echo 'module.exports={};' > "$TREE/stubs/@ant/claude-swift/js/index.js"
+    echo 'module.exports={};' > "$TREE/stubs/@ant/claude-native/index.js"
+    echo 'module.exports={};' > "$TREE/stubs/@ant/claude-native/safe_fs.js"
+    echo 'module.exports={};' > "$TREE/stubs/cowork/dirs.js"
+    for f in frame-fix-entry.js frame-fix-wrapper.js protocol-forwarder.js; do
+        echo 'module.exports={};' > "$TREE/stubs/frame-fix/$f"
+    done
+    printf '#!/bin/sh\nexit 0\n' > "$TREE/stubs/cowork/cowork-plugin-shim.sh"
+
+    echo 'var x=1;' > "$TREE/linux-app-extracted/.vite/build/index.js"
+    # The shape the real bundle ships, and the only one the entry-point sed
+    # rewrites. A different shape is asserted separately below.
+    echo '{"main":".vite/build/index.pre.js"}' > "$TREE/linux-app-extracted/package.json"
+
+    printf '#!/bin/sh\nexit 0\n' > "$FAKE_BIN/electron"
+    # `asar pack <dir> <out>` -- just materialise the output file.
+    printf '#!/bin/sh\nmkdir -p "$(dirname "$3")"; : > "$3"\n' > "$FAKE_BIN/asar"
+    chmod +x "$FAKE_BIN/electron" "$FAKE_BIN/asar"
+}
+
+# Run launch.sh against the fixture with nothing inherited from the caller's
+# environment beyond a minimal PATH, so a developer's real ~/.config/Claude and
+# real electron install can't influence the result.
+run_launch() {
+    env -i HOME="$FAKE_HOME" PATH="$FAKE_BIN:/usr/local/bin:/usr/bin:/bin" \
+        bash "$TREE/launch.sh" 2>&1
+}
+
+# ============================================================
+# 1. The repack cache
+# ============================================================
+
+section "Repack cache (launch.sh)"
+
+if ! command -v cmp >/dev/null 2>&1; then
+    skip "repack cache behaviour (cmp not installed)"
+else
+    build_fixture
+
+    out1="$(run_launch)"
+    if grep -q "Repacking app.asar" <<<"$out1"; then
+        pass "first launch repacks (no cached asar yet)"
+    else
+        fail "first launch should repack; got: $(head -3 <<<"$out1")"
+    fi
+
+    out2="$(run_launch)"
+    if grep -q "Using cached app.asar (no changes)" <<<"$out2"; then
+        pass "second launch reuses the cached asar (sync must not bump mtime)"
+    else
+        fail "second launch repacked with nothing changed -- the stub sync is stamping mtimes again"
+    fi
+
+    # A real edit must still be picked up: a cache that never invalidates is
+    # worse than one that never hits.
+    echo 'module.exports={changed:1};' > "$TREE/stubs/cowork/dirs.js"
+    out3="$(run_launch)"
+    if grep -q "Repacking app.asar" <<<"$out3"; then
+        pass "an edited stub forces a repack"
+    else
+        fail "an edited stub did not force a repack -- the cache never invalidates"
+    fi
+
+    out4="$(run_launch)"
+    if grep -q "Using cached app.asar (no changes)" <<<"$out4"; then
+        pass "cache holds again once the edit has been packed"
+    else
+        fail "cache did not settle after an edit"
+    fi
+fi
+
+# ============================================================
+# 2. The entry-point patch guards on what it substitutes
+# ============================================================
+
+section "Entry-point patch (launch.sh)"
+
+if ! command -v cmp >/dev/null 2>&1; then
+    skip "entry-point patch behaviour (cmp not installed)"
+else
+    build_fixture
+    run_launch >/dev/null
+    if grep -q '"main": "frame-fix-entry.js"' "$TREE/linux-app-extracted/package.json"; then
+        pass "main is repointed at frame-fix-entry.js"
+    else
+        fail "main was not repointed: $(cat "$TREE/linux-app-extracted/package.json")"
+    fi
+
+    # A main the sed cannot rewrite must say so. It used to pass the looser
+    # guard, no-op in the sed, print "Fixing entry point..." anyway, and bump
+    # mtime on every launch forever while the app ran its own entry point.
+    build_fixture
+    echo '{"main":"./.vite/build/index.pre.js"}' > "$TREE/linux-app-extracted/package.json"
+    out="$(run_launch)"
+    if grep -q "WARN: package.json still points at index.pre.js" <<<"$out"; then
+        pass "an unrewritable main warns instead of silently claiming success"
+    else
+        fail "an unrewritable main was patched silently or not reported"
+    fi
+    if grep -q "Fixing entry point" <<<"$out"; then
+        fail "claimed to fix an entry point it did not rewrite"
+    else
+        pass "does not claim to have fixed what it skipped"
+    fi
+fi
+
+# ============================================================
+# 3. Every deployment path ships a stub's whole module set
+# ============================================================
+
+section "Stub module-set parity"
+
+NATIVE_DIR="$REPO_ROOT/stubs/@ant/claude-native"
+
+# Every relative require() in the native stub must resolve in the repo. A
+# require of a file that was never committed fails the same way a deployment
+# path that forgets to copy it does.
+missing_src=""
+while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    [ -f "$NATIVE_DIR/$dep" ] || [ -f "$NATIVE_DIR/$dep.js" ] || missing_src="$missing_src $dep"
+done < <(grep -oE "require\('\./[^']+'\)" "$NATIVE_DIR/index.js" 2>/dev/null \
+         | sed -E "s|require\('\./([^']+)'\)|\1|")
+if [ -z "$missing_src" ]; then
+    pass "every sibling module @ant/claude-native/index.js require()s exists in stubs/"
+else
+    fail "native stub require()s files not in stubs/:$missing_src"
+fi
+
+# Consumers must copy the directory, not hand-list index.js. safe_fs.js landed
+# months after PKGBUILD's copy line was written and never reached the package.
+for consumer in install.sh launch.sh test-local.sh PKGBUILD; do
+    if grep -qE 'claude-native/\*\.js' "$REPO_ROOT/$consumer"; then
+        pass "$consumer copies the whole @ant/claude-native module set"
+    else
+        fail "$consumer names individual native stub files -- a new sibling module will not ship"
+    fi
+done
+
+# ============================================================
+# 4. frame-fix file list parity
+# ============================================================
+
+section "frame-fix file list parity"
+
+# The generated launcher execs linux-app-extracted/protocol-forwarder.js for
+# the claude:// OAuth fast path. install.sh placed it there; launch.sh's sync
+# list omitted it, so an edited forwarder never reached a launch.
+for consumer in install.sh launch.sh test-local.sh; do
+    if grep -q 'protocol-forwarder.js' "$REPO_ROOT/$consumer"; then
+        pass "$consumer syncs protocol-forwarder.js"
+    else
+        fail "$consumer does not sync protocol-forwarder.js"
+    fi
+done
+
+# ============================================================
+
+echo ""
+echo -e "${BOLD}Summary:${NC} ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}, ${YELLOW}${SKIP} skipped${NC}"
+[ "$FAIL" -eq 0 ]

--- a/validate.sh
+++ b/validate.sh
@@ -96,10 +96,22 @@ fi
 step "6. Recent Errors Check"
 
 STARTUP_LOG="$LOG_DIR/startup.log"
+# `grep -c` PRINTS 0 and EXITS 1 when it matches nothing, so `$(grep -c ... ||
+# echo 0)` captured "0\n0" -- and `[[ "0\n0" -gt 0 ]]` is a bash arithmetic
+# syntax error. A clean log, the case this whole section is about, printed three
+# "syntax error in expression" lines and only reached the right answer because
+# the failed comparison happens to be false. Keep grep's own count; drop only
+# its exit status.
+count_in_log() {
+    local n
+    n=$(grep -c "$1" "$STARTUP_LOG" 2>/dev/null) || true
+    printf '%s' "${n:-0}"
+}
+
 if [[ -f "$STARTUP_LOG" ]]; then
-    DISPOSED_COUNT=$(grep -c "webFrameMain.*disposed" "$STARTUP_LOG" 2>/dev/null || echo 0)
-    GPU_ERRORS=$(grep -c "SharedImageManager\|ProduceSkia" "$STARTUP_LOG" 2>/dev/null || echo 0)
-    MCP_DISCONNECTS=$(grep -c "mcp_unexpected_close" "$STARTUP_LOG" 2>/dev/null || echo 0)
+    DISPOSED_COUNT=$(count_in_log "webFrameMain.*disposed")
+    GPU_ERRORS=$(count_in_log "SharedImageManager\|ProduceSkia")
+    MCP_DISCONNECTS=$(count_in_log "mcp_unexpected_close")
 
     if [[ $DISPOSED_COUNT -gt 0 ]]; then
         warn "Found $DISPOSED_COUNT 'webFrameMain disposed' errors in log"
@@ -141,9 +153,16 @@ echo "  - Minimize/restore window"
 echo "  - Run for 5+ minutes"
 echo ""
 
-read -p "Launch now? [y/N] " -n 1 -r
-echo
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    info "Launching Claude Desktop..."
-    exec ./launch.sh
+# Only prompt on a terminal. Under `set -e` a `read` with no stdin returns
+# non-zero and aborts the script, so piping this file or running it from CI
+# ended a fully passing validation run with a non-zero exit and no explanation.
+if [[ -t 0 ]]; then
+    read -p "Launch now? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        info "Launching Claude Desktop..."
+        exec ./launch.sh
+    fi
+else
+    info "Not a terminal; skipping the launch prompt. Run ./launch.sh when ready."
 fi


### PR DESCRIPTION
## What does this change?

Six defects found by tracing every deployment path — install.sh, launch.sh, launch-devtools.sh, test-local.sh, PKGBUILD, nix/package.nix — from `stubs/` to what actually lands in the app tree. Every one of them was silent: nothing failed loudly, so nothing looked.

**1. The AUR and Nix packages ship a stub that cannot load.** `stubs/@ant/claude-native/index.js` require()s `./safe_fs.js` unconditionally at module load (line 27). PKGBUILD and `nix/package.nix` copied `index.js` alone, so `require('@ant/claude-native')` throws `MODULE_NOT_FOUND` in both packages. `safe_fs.js` landed in 5702bf4 (2026-07-23); the PKGBUILD copy line had not been touched since 8e129f6 (2026-03-21) — four months of drift, the same shape as #170, one directory over. `launch-devtools.sh` and `test-local.sh` carried it too; `tests/test-install-paths.sh` stage 4 modelled the deployment the same wrong way, which is why the harness could bake, pack and assert success against a tree that cannot load the stub.

**2. `launch.sh` repacked the whole app.asar on every launch.** It re-syncs the stub tree with `cp -f`, which stamps the destination with the current time whether or not a byte changed, and then decides whether to repack by asking whether anything under `linux-app-extracted` is newer than the cached asar. That answered yes every time: the cache never hit and `"Using cached app.asar (no changes)"` was unreachable code. `sync_file()` now compares before copying, so the cache works and a real edit still invalidates it.

**3. `launch.sh`'s entry-point patch guarded on a looser pattern than it substituted.** The guard `"main":.*index\.pre\.js"` passes for a main spelled `"./.vite/build/index.pre.js"`, which the sed then cannot rewrite — so it printed `"Fixing entry point..."` over a file it left alone, ran the app on its own entry point (macOS titlebars, renderer shell never loads), and bumped mtime every launch forever. Now guards on the substitution target, as PKGBUILD's copy of this patch already did, and warns when an `index.pre.js` main appears in a shape the sed does not handle.

**4. `launch.sh` and `launch-devtools.sh` never synced `protocol-forwarder.js`,** though the generated launcher execs `linux-app-extracted/protocol-forwarder.js` for the `claude://` OAuth fast path. Only install.sh ever wrote it, so an edited forwarder never reached a launch.

**5. `test-local.sh` deployed to paths nothing reads.** Its whole job is putting local stubs in front of a real install. It wrote `frame-fix-wrapper.js` to `$INSTALL_DIR/frame-fix-wrapper.js` — a path nothing reads — and the cowork modules only into the extracted app. `launch.sh` re-syncs both from `$INSTALL_DIR/stubs` on the next start, so the deployed code was overwritten with the installed code before it ever ran. `--launch` exec'd `$INSTALL_DIR/claude-desktop`, a path install.sh has never written (the launcher is `~/.local/bin/claude-desktop`).

**6. `validate.sh` printed three bash errors on every healthy run.** `$(grep -c … || echo 0)` captures `"0\n0"` when grep matches nothing — grep -c prints 0 *and* exits 1 — and `[[ "0\n0" -gt 0 ]]` is an arithmetic syntax error. The clean-log case, which is what that whole section is for, emitted three `syntax error in expression` lines and reached the right answer only because a failed comparison happens to be false. Its closing `read` also aborted the script under `set -e` with no tty, ending a fully passing run non-zero.

Also: three tests in `exec_capability_registry.test.cjs` wrapped their assertions in `if (binaryFound) { … }`, so they reported green while asserting nothing where the binary was absent — the shape the #132 coverage was already burned by. They now `t.skip()` visibly.

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor

## Testing

`tests/test-launcher-sync.sh` is new and wired into CI. It drives `launch.sh` end to end against a temp tree with fake `electron`/`asar` binaries and a temp `HOME`, so it is hermetic — no network, no Docker, no real install touched. It asserts the repack cache hits on an unchanged tree, still invalidates on a real edit, that an unrewritable `main` warns instead of claiming success, and that every deployment path ships the whole native module set and all three frame-fix files.

The module-set check is not a hardcoded consumer list: it greps the tree for any file that copies `claude-native/index.js` by name and requires that same file to copy the glob too, so a deployment path added later trips it on arrival. PR #178's draft flatpak manifest has exactly this shape today and would be caught.

- Against `master` (b0c3d2b): **16 failures**, covering every defect above.
- On this branch: **20 passes**.
- `node --test tests/node/current-path/*.test.cjs`: 559 passed, 0 failed.
- `tests/test-compat-pins.sh`: 11 passed. `tests/test-cowork-patch.sh`: 84 passed. `tests/test-install-paths.sh 1`: 6 passed. `python -m py_compile enable-cowork.py`: clean. `bash -n` on every shell file and PKGBUILD: clean.
- Distro / desktop: not applicable — every check here is hermetic and runs in CI. No Claude Desktop install was available in this environment, so the packaging fixes are verified structurally (the require graph, the copy lists, and the mtime/repack behaviour driven for real) rather than by launching the app. A `--doctor` run and a Cowork session on an AUR or Nix install would be worth doing before release.

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning
- [ ] This change does touch security-sensitive code — explanation below:

No change to `filterEnv`, spawn admission, `resolveDisclaimerCommand`, `AuthRequest`, or any path-safety predicate. The `exec_capability_registry.test.cjs` edit changes only how three tests report when their binary is absent; no assertion was removed or weakened. Restoring `safe_fs.js` to the AUR and Nix trees makes the safe-fs containment layer present where it previously failed to load at all, which is a strengthening, not a relaxation.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — no install available in this environment; see Testing.

---

## Companion triage of the open PRs and issues

Traced but deliberately **not** implemented here, so as not to duplicate or pre-empt contributors' open work.

| # | Verdict |
|---|---|
| [#177](https://github.com/johnzfitch/claude-cowork-linux/pull/177) welcome screen Mac→Linux | Approach is sound; one real problem. The `MutationObserver` watches `document.body` with `subtree` + `characterData` and its callback walks **every text node in the document**. In a streaming chat UI that is a full-document traversal per token, and the observer is never disconnected, so it keeps running long after sign-in when the heading is gone. Worth disconnecting after the first successful rewrite (or a short timeout) before landing. |
| [#179](https://github.com/johnzfitch/claude-cowork-linux/pull/179) darwin automount leak | Correct and well-scoped. `enable-cowork.py` already runs across `index.js` plus every `index*.chunk-*.js`, so the pass reaches the index2 chunk it targets. Two notes: it uses `re.search` + splice where the neighbouring passes use `subn`, so a second occurrence in the same file is left unpatched behind the marker; and the marker is appended to the last line, which will be swallowed into a trailing `//# sourceMappingURL=` comment where one exists (harmless for idempotency, breaks that map URL). Recommend landing with `subn`. |
| [#180](https://github.com/johnzfitch/claude-cowork-linux/pull/180) sync install.sh/COMPAT.md/enable-cowork.py | Premise verified. All three are read from `$INSTALL_DIR` after install: the launcher execs `$INSTALL_DIR/install.sh` for `--doctor`/`--update`, `compat_read_last_tested "$INSTALL_DIR/COMPAT.md"` at install.sh:1415, and the patch-script fallback at install.sh:825. The fix is the right one and reuses the loop's existing missing-file check. Ready to merge. |
| [#181](https://github.com/johnzfitch/claude-cowork-linux/pull/181) `--` separator in disclaimer args | Change is cheap and harmless, but the stated root cause does not reproduce against the bundle in this tree. `Ql(t)` is the only disclaimer wrapper and always builds `args:[t.cmd, ...t.args]`, so `args[0]` is the command. HostCLIRunner reaches it via `yi(n, t, …)` → `Ql({cmd:n, args:t})`, same shape. The SDK spawn is `J = mvt(c) ? [...a, ...z] : [...a, c, ...z]`, and `mvt` is true for the disclaimer path (no `.js`/`.ts` suffix), so no `--` is inserted there either. The only `"--"` array element anywhere in the bundle is inside `git diff` argv, where `args[0]` is still the git path. The second added test (`['--']` → null) also passes unchanged against master, so it is not a regression test. The reporter's exit-127 on the Code tab is real; worth asking for the actual failing argv (`CLAUDE_COWORK_IPC_TAP=1`) before attributing it here. |
| [#178](https://github.com/johnzfitch/claude-cowork-linux/pull/178) flatpak draft | Honest about what is untested. Note its build-commands copy `stubs/@ant/claude-native/index.js` alone — the same bug fixed here in four other paths. The new parity check will flag it when the manifest lands. |
| [#161](https://github.com/johnzfitch/claude-cowork-linux/issues/161) DeviceRegistry / BuddyBleTransport | Already resolved as far as it can be. `BuddyBleTransport_$_reportState` is stubbed as a no-op and registered proactively under `claude.buddy`; `DeviceRegistry` is deliberately not overridden (stubbing `signCreateSessionBind` would forge a device-identity assertion), with a test asserting no override exists and COMPAT.md recording it. The issue is a documented won't-fix, not open work. |
| [#172](https://github.com/johnzfitch/claude-cowork-linux/issues/172) MCP Apps tool-result reads | #179 is the right shape of fix, and avoids the raw-`realpath` containment gap the issue flags in the alternative. It is confirmed on 1.26832.0 via attach-folder enumeration, not on 1.28929.0's tool-result path, so it still needs a reproduce on an affected build to close the issue rather than just land the patch. |
| [#174](https://github.com/johnzfitch/claude-cowork-linux/issues/174) welcome screen | Addressed by #177; see the observer note above. |
| [#85](https://github.com/johnzfitch/claude-cowork-linux/issues/85) flathub | #178 is a starting skeleton; the sandbox-in-sandbox question it names is the real blocker and needs a code change to the bwrap spawn path, not a manifest change. |

One process note: #180 and #181 sit at `mergeable_state: unstable` with **zero check runs** — fork PRs awaiting workflow approval, not failures. They need a maintainer to approve the runs before their CI means anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wCMAXzAedw1kTTxXNs69F)_