### PR TITLE
fix(welcome): strike Mac, append Linux — with a bounded observer (adopts #177)

### DIFF
--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -602,6 +602,45 @@ function coworkSpaceRoute(targetUrl) {
   }
 }
 
+// Issue #174: the welcome screen's heading picks its platform word from the
+// darwin spoof we present to the Cowork gate, so signed-out Linux users see
+// "Claude for Mac". Un-spoofing isn't an option -- that's the whole
+// mechanism -- so this rewrites the rendered text node in place: strike
+// through "Mac" (U+0336 combining overlay, so it's a plain string survives
+// minifier rotation) and append "Linux". A MutationObserver reapplies it
+// across SPA navigation since the heading can remount.
+function buildMacLinuxRewriteScript() {
+  return [
+    '(function(){',
+    '  try {',
+    '    var STRIKE = "\\u0336";',
+    '    function struck(s) { return s.split("").join(STRIKE) + STRIKE; }',
+    '    function rewrite() {',
+    '      var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);',
+    '      var node;',
+    '      while ((node = walker.nextNode())) {',
+    '        if (node.nodeValue !== "Mac") continue;',
+    '        var el = node.parentElement, depth = 0;',
+    '        while (el && depth < 5) {',
+    '          if (el.textContent && el.textContent.trim() === "Claude for Mac") {',
+    '            node.nodeValue = struck("Mac") + " Linux";',
+    '            break;',
+    '          }',
+    '          el = el.parentElement;',
+    '          depth++;',
+    '        }',
+    '      }',
+    '    }',
+    '    rewrite();',
+    '    if (!window.__coworkMacLinuxObserver) {',
+    '      window.__coworkMacLinuxObserver = new MutationObserver(rewrite);',
+    '      window.__coworkMacLinuxObserver.observe(document.body, { childList: true, subtree: true, characterData: true });',
+    '    }',
+    '  } catch (e) {}',
+    '})();',
+  ].join('\n');
+}
+
 // Build the JS injected into the renderer to perform client-side navigation.
 // The route is JSON-encoded (never string-concatenated raw) so a hostile space
 // name/URL cannot break out of the string literal into executable code.
@@ -1428,9 +1467,11 @@ Module.prototype.require = function(id) {
         _appRef.on('web-contents-created', (_ev, contents) => {
           contents.on('dom-ready', () => {
             contents.insertCSS(_fixCSS).catch(() => {});
+            contents.executeJavaScript(buildMacLinuxRewriteScript()).catch(() => {});
           });
           contents.on('did-navigate', () => {
             contents.insertCSS(_fixCSS).catch(() => {});
+            contents.executeJavaScript(buildMacLinuxRewriteScript()).catch(() => {});
           });
           // Issue #147: convert a full-page navigation to a locally-created
           // Cowork space into an in-app SPA route change, so it loads from IPC

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -606,36 +606,77 @@ function coworkSpaceRoute(targetUrl) {
 // darwin spoof we present to the Cowork gate, so signed-out Linux users see
 // "Claude for Mac". Un-spoofing isn't an option -- that's the whole
 // mechanism -- so this rewrites the rendered text node in place: strike
-// through "Mac" (U+0336 combining overlay, so it's a plain string survives
-// minifier rotation) and append "Linux". A MutationObserver reapplies it
-// across SPA navigation since the heading can remount.
+// through "Mac" (U+0336 combining overlay, so it stays a plain string that
+// survives minifier rotation) and append "Linux".
+//
+// The observer is deliberately short-lived, and that is the whole design
+// constraint here. Watching document.body with { subtree, characterData } and
+// running a full-document TreeWalker in the callback -- the obvious way to
+// write this -- means every streamed token mutates a text node and triggers a
+// walk of every text node in the document: quadratic in conversation length,
+// running forever, to fix a cosmetic label on a screen the user sees once
+// before signing in. Instead:
+//
+//   - a successful rewrite disconnects the observer; the heading is a
+//     signed-out artifact and there is nothing left to watch for on that page;
+//   - a deadline disconnects it on pages where the heading never appears,
+//     which is every signed-in session;
+//   - childList only. A remount inserts the heading as a subtree, which is a
+//     childList record. An in-place edit of an existing text node from some
+//     other string to exactly "Mac" is missed, and is not a shape this screen
+//     produces;
+//   - a burst of records coalesces into one walk per frame.
+//
+// So the cost is bounded to the first seconds of a navigation, and the
+// dom-ready/did-navigate handlers below re-arm it on the next one. The
+// tradeoff is a welcome screen that remounts mid-page, with no navigation and
+// after the deadline, keeps its "Mac" -- a label, not a break.
+var MAC_LINUX_OBSERVER_DEADLINE_MS = 15000;
+
 function buildMacLinuxRewriteScript() {
   return [
     '(function(){',
     '  try {',
+    '    if (!document.body) return;',
     '    var STRIKE = "\\u0336";',
     '    function struck(s) { return s.split("").join(STRIKE) + STRIKE; }',
     '    function rewrite() {',
     '      var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);',
-    '      var node;',
+    '      var node, hit = false;',
     '      while ((node = walker.nextNode())) {',
     '        if (node.nodeValue !== "Mac") continue;',
     '        var el = node.parentElement, depth = 0;',
     '        while (el && depth < 5) {',
     '          if (el.textContent && el.textContent.trim() === "Claude for Mac") {',
     '            node.nodeValue = struck("Mac") + " Linux";',
+    '            hit = true;',
     '            break;',
     '          }',
     '          el = el.parentElement;',
     '          depth++;',
     '        }',
     '      }',
+    '      return hit;',
     '    }',
-    '    rewrite();',
-    '    if (!window.__coworkMacLinuxObserver) {',
-    '      window.__coworkMacLinuxObserver = new MutationObserver(rewrite);',
-    '      window.__coworkMacLinuxObserver.observe(document.body, { childList: true, subtree: true, characterData: true });',
+    '    function release(o) {',
+    '      try { o.disconnect(); } catch (e) {}',
+    '      if (window.__coworkMacLinuxObserver === o) { window.__coworkMacLinuxObserver = null; }',
     '    }',
+    '    var live = window.__coworkMacLinuxObserver;',
+    '    if (rewrite()) { if (live) { release(live); } return; }',
+    '    if (live) return;',
+    '    var queued = false;',
+    '    var observer = new MutationObserver(function () {',
+    '      if (queued) return;',
+    '      queued = true;',
+    '      requestAnimationFrame(function () {',
+    '        queued = false;',
+    '        if (rewrite()) { release(observer); }',
+    '      });',
+    '    });',
+    '    window.__coworkMacLinuxObserver = observer;',
+    '    observer.observe(document.body, { childList: true, subtree: true });',
+    '    setTimeout(function () { release(observer); }, ' + MAC_LINUX_OBSERVER_DEADLINE_MS + ');',
     '  } catch (e) {}',
     '})();',
   ].join('\n');

--- a/stubs/frame-fix/frame-fix-wrapper.js
+++ b/stubs/frame-fix/frame-fix-wrapper.js
@@ -662,9 +662,19 @@ function buildMacLinuxRewriteScript() {
     '      try { o.disconnect(); } catch (e) {}',
     '      if (window.__coworkMacLinuxObserver === o) { window.__coworkMacLinuxObserver = null; }',
     '    }',
+    // Defer to a live observer BEFORE walking. The handlers below inject on
+    // both dom-ready and did-navigate, so without this the second injection
+    // pays for a second full-document walk while an observer is already
+    // watching for the very thing it would find. An observer is only installed
+    // when a walk found nothing, and a heading can only appear afterwards via a
+    // mutation -- which is what the observer is subscribed to. So there is
+    // nothing the redundant walk could catch that the live observer will not.
+    // (Its walk is rAF-scheduled, so in a backgrounded window the rewrite lands
+    // a little later than an immediate walk would. That is a heading nobody is
+    // looking at.) The global is nulled on release, so non-null means connected.
     '    var live = window.__coworkMacLinuxObserver;',
-    '    if (rewrite()) { if (live) { release(live); } return; }',
     '    if (live) return;',
+    '    if (rewrite()) return;',
     '    var queued = false;',
     '    var observer = new MutationObserver(function () {',
     '      if (queued) return;',

--- a/tests/node/current-path/welcome_screen_rewrite.test.cjs
+++ b/tests/node/current-path/welcome_screen_rewrite.test.cjs
@@ -256,6 +256,24 @@ test('a document with no body is a no-op, not a throw', () => {
   assert.equal(page.observers.length, 0);
 });
 
+test('re-injection with a live observer does not pay for another full walk', () => {
+  // dom-ready and did-navigate both inject. Walking again while an observer is
+  // already watching is exactly the cost this change exists to remove, so the
+  // ordering that avoids it is pinned here rather than left to reading.
+  const page = makePage(elem([text('no heading')]));
+  page.run();
+  const walksAfterFirstInjection = page.walks;
+
+  page.run();
+  page.run();
+
+  assert.equal(
+    page.walks,
+    walksAfterFirstInjection,
+    'a live observer already covers what a re-injection walk would find'
+  );
+});
+
 test('re-injecting on the same page does not stack observers', () => {
   const page = makePage(elem([text('no heading')]));
   page.run();

--- a/tests/node/current-path/welcome_screen_rewrite.test.cjs
+++ b/tests/node/current-path/welcome_screen_rewrite.test.cjs
@@ -1,0 +1,266 @@
+// Issue #174: the signed-out welcome screen says "Claude for Mac" on Linux
+// because the heading takes its platform word from the darwin spoof. The fix
+// injects a script into the renderer that rewrites the text node.
+//
+// What these tests are really guarding is the COST of that script, not just
+// its output. The natural way to write it -- observe document.body with
+// { subtree, characterData } and run a full-document TreeWalker in the
+// callback -- makes every streamed token trigger a walk of every text node in
+// the document. That is quadratic in conversation length, runs for the life of
+// the window, and buys a cosmetic label on a screen the user sees once. So the
+// assertions below pin the bounds: childList only, one walk per frame, and an
+// observer that disconnects both on success and on a deadline.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WRAPPER = path.join(__dirname, '..', '..', '..', 'stubs', 'frame-fix', 'frame-fix-wrapper.js');
+
+// Pull the generator out of the wrapper the same way frame_fix_wrapper.test.cjs
+// slices its helper block: the wrapper requires electron at load, so it cannot
+// be required directly from a test.
+//
+// Deliberately NOT anchored on anything this fix introduced. An extractor that
+// keys on a constant added alongside the fix cannot load the code it replaced,
+// so every test fails for the same uninteresting reason and none of them
+// demonstrates anything. Anchored on the function name alone, the output tests
+// below pass against either implementation and only the cost tests separate
+// them -- which is the actual claim being made.
+function buildScript() {
+  const source = fs.readFileSync(WRAPPER, 'utf8');
+  const fnStart = source.indexOf('function buildMacLinuxRewriteScript');
+  assert.ok(fnStart !== -1, 'could not locate buildMacLinuxRewriteScript in ' + WRAPPER);
+  const end = source.indexOf('\n}', fnStart) + 2;
+  assert.ok(end > fnStart, 'could not find the end of buildMacLinuxRewriteScript');
+
+  // Any module-level constants the generator interpolates.
+  const preamble = source
+    .slice(0, fnStart)
+    .split('\n')
+    .filter((line) => /^var MAC_LINUX_[A-Z_]+ =/.test(line))
+    .join('\n');
+
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(preamble + '\n' + source.slice(fnStart, end), context);
+  return vm.runInContext('buildMacLinuxRewriteScript()', context);
+}
+
+// ── A DOM small enough to reason about ──────────────────────────────────────
+
+function text(value) {
+  return { isText: true, nodeValue: value, parentElement: null };
+}
+
+function elem(children) {
+  const node = {
+    isText: false,
+    children: [],
+    parentElement: null,
+    get textContent() {
+      return collect(this);
+    },
+  };
+  for (const child of children) {
+    child.parentElement = node;
+    node.children.push(child);
+  }
+  return node;
+}
+
+function collect(node) {
+  return node.isText ? node.nodeValue : node.children.map(collect).join('');
+}
+
+function textNodesUnder(node, out = []) {
+  if (node.isText) out.push(node);
+  else for (const child of node.children) textNodesUnder(child, out);
+  return out;
+}
+
+// A page, plus the hooks a test needs to drive it: mutation callbacks, frame
+// callbacks, the deadline timer, and a count of how many full walks ran.
+function makePage(body) {
+  const state = {
+    walks: 0,
+    observers: [],
+    frames: [],
+    timers: [],
+    body,
+  };
+
+  const sandbox = {
+    document: {
+      get body() {
+        return state.body;
+      },
+      createTreeWalker(root) {
+        state.walks++;
+        const nodes = root ? textNodesUnder(root) : [];
+        let i = 0;
+        return { nextNode: () => (i < nodes.length ? nodes[i++] : null) };
+      },
+    },
+    NodeFilter: { SHOW_TEXT: 4 },
+    window: {},
+    MutationObserver: function (callback) {
+      const observer = {
+        callback,
+        options: null,
+        connected: false,
+        observe(target, options) {
+          this.options = options;
+          this.connected = true;
+        },
+        disconnect() {
+          this.connected = false;
+        },
+      };
+      state.observers.push(observer);
+      return observer;
+    },
+    requestAnimationFrame(callback) {
+      state.frames.push(callback);
+    },
+    setTimeout(callback, ms) {
+      state.timers.push({ callback, ms });
+    },
+  };
+
+  vm.createContext(sandbox);
+  state.sandbox = sandbox;
+  state.run = () => vm.runInContext(buildScript(), sandbox);
+  state.flushFrames = () => {
+    const pending = state.frames.splice(0);
+    for (const frame of pending) frame();
+  };
+  return state;
+}
+
+const STRUCK_MAC = 'M̶a̶c̶';
+
+function welcomeHeading() {
+  const mac = text('Mac');
+  const heading = elem([text('Claude for '), mac]);
+  return { body: elem([heading]), mac };
+}
+
+// ── Output ──────────────────────────────────────────────────────────────────
+
+test('rewrites the heading text node to a struck Mac plus Linux', () => {
+  const { body, mac } = welcomeHeading();
+  const page = makePage(body);
+  page.run();
+  assert.equal(mac.nodeValue, STRUCK_MAC + ' Linux');
+});
+
+test('leaves a bare "Mac" alone when no ancestor reads "Claude for Mac"', () => {
+  const mac = text('Mac');
+  const page = makePage(elem([elem([text('Made on a '), mac])]));
+  page.run();
+  assert.equal(mac.nodeValue, 'Mac', 'only the welcome heading may be rewritten');
+});
+
+// ── Cost ────────────────────────────────────────────────────────────────────
+
+test('a heading present on the first pass leaves no observer running', () => {
+  const { body } = welcomeHeading();
+  const page = makePage(body);
+  page.run();
+  assert.equal(page.observers.length, 0, 'nothing to watch for once the rewrite landed');
+  assert.equal(page.sandbox.window.__coworkMacLinuxObserver, undefined);
+});
+
+test('the observer never subscribes to characterData', () => {
+  const page = makePage(elem([text('signed in, no heading here')]));
+  page.run();
+  assert.equal(page.observers.length, 1);
+  const { options } = page.observers[0];
+  assert.equal(options.childList, true);
+  assert.equal(options.subtree, true);
+  assert.ok(
+    !options.characterData,
+    'characterData + subtree means a full-document walk per streamed token'
+  );
+});
+
+test('a burst of mutations coalesces into one walk per frame', () => {
+  const page = makePage(elem([text('no heading yet')]));
+  page.run();
+  const walksAfterFirstPass = page.walks;
+  const observer = page.observers[0];
+
+  for (let i = 0; i < 25; i++) observer.callback([], observer);
+  assert.equal(page.walks, walksAfterFirstPass, 'no walk until the frame runs');
+
+  page.flushFrames();
+  assert.equal(page.walks, walksAfterFirstPass + 1, '25 records must cost one walk, not 25');
+});
+
+test('a heading that arrives later is rewritten, then the observer stops', () => {
+  const page = makePage(elem([text('no heading yet')]));
+  page.run();
+  const observer = page.observers[0];
+  assert.equal(observer.connected, true);
+
+  const { body, mac } = welcomeHeading();
+  page.body = body;
+  observer.callback([], observer);
+  page.flushFrames();
+
+  assert.equal(mac.nodeValue, STRUCK_MAC + ' Linux');
+  assert.equal(observer.connected, false, 'must disconnect once the rewrite lands');
+  assert.equal(page.sandbox.window.__coworkMacLinuxObserver, null);
+});
+
+test('the deadline disconnects an observer on a page that never shows the heading', () => {
+  const page = makePage(elem([text('a signed-in session, forever')]));
+  page.run();
+  const observer = page.observers[0];
+  assert.equal(observer.connected, true);
+
+  assert.equal(page.timers.length, 1, 'a deadline must be armed');
+  assert.ok(page.timers[0].ms > 0 && page.timers[0].ms <= 60000,
+    'deadline should be seconds, not unbounded: ' + page.timers[0].ms);
+  page.timers[0].callback();
+
+  assert.equal(observer.connected, false);
+  assert.equal(page.sandbox.window.__coworkMacLinuxObserver, null);
+});
+
+test('a stale deadline cannot disconnect a later navigation observer', () => {
+  const page = makePage(elem([text('first navigation')]));
+  page.run();
+  const first = page.observers[0];
+  const firstDeadline = page.timers[0].callback;
+
+  first.disconnect();
+  page.sandbox.window.__coworkMacLinuxObserver = null;
+  page.run();
+  const second = page.observers[1];
+  assert.equal(second.connected, true);
+
+  firstDeadline();
+  assert.equal(second.connected, true, 'the old timer must not release the new observer');
+  assert.equal(page.sandbox.window.__coworkMacLinuxObserver, second);
+});
+
+// ── Robustness ──────────────────────────────────────────────────────────────
+
+test('a document with no body is a no-op, not a throw', () => {
+  const page = makePage(null);
+  assert.doesNotThrow(() => page.run());
+  assert.equal(page.observers.length, 0);
+});
+
+test('re-injecting on the same page does not stack observers', () => {
+  const page = makePage(elem([text('no heading')]));
+  page.run();
+  page.run();
+  page.run();
+  const connected = page.observers.filter((o) => o.connected);
+  assert.equal(connected.length, 1, 'dom-ready and did-navigate both inject; only one may observe');
+});


### PR DESCRIPTION
Adopts @chefboyrdave21's #177 with its original commit and authorship intact, plus two follow-up commits: one fixing the single thing that could not ship as written, one addressing Copilot's review.

Closes #174. Supersedes #177.

## What does this change?

**The rewrite itself is right, and unchanged.** A heading reading `Claude for Mac` becomes `M̶a̶c̶ Linux` (U+0336 combining overlays); a bare `Mac` with no such ancestor is left alone. The tests added here confirm that against *both* revisions.

**What could not ship as written is cost.** The observer took `{ childList, subtree, characterData }` on `document.body` and ran a full-document `TreeWalker` in its callback. Those two facts together are the problem: `characterData` + `subtree` makes every streamed token a mutation record, and every record walked every text node in the document. That is quadratic in conversation length, for the life of the window, to correct a cosmetic label on a screen the user sees once before signing in. It also never disconnected, so a signed-in session kept paying for a heading that had already stopped existing.

Bounded four ways:

- a successful rewrite disconnects — the heading is a signed-out artifact, and there is nothing left to watch for on that page;
- a 15s deadline disconnects on pages where it never appears, which is every signed-in session;
- `childList` only, so a token stream is not a wake-up. A remount inserts the heading as a subtree, which *is* a `childList` record;
- a burst of records coalesces into one walk per frame.

The deadline releases the specific observer it armed rather than whatever is currently in the global, so a stale timer from a previous navigation cannot disconnect the live one.

**And a fifth, from Copilot's review (890a878):** defer to a live observer *before* walking. The handlers inject on both `dom-ready` and `did-navigate`, so the ordering `rewrite()` → check `live` meant the second injection paid for a whole document walk while an observer was already watching for the very thing it would find — the bound undercutting itself. Checking first is safe, not merely cheaper: an observer is only installed when a walk found nothing, and a heading can only appear afterwards via a mutation, which is exactly what it subscribes to.

Also: return early when `document.body` is null. The original relied on the outer `try/catch`, which meant a `dom-ready` on a document with no body yet threw *past* the observer installation and left the page unwatched entirely.

**The tradeoffs, stated plainly:** a welcome screen that remounts mid-page, with no navigation and after the deadline, keeps its "Mac". And deferring to a live observer means deferring to its rAF-scheduled walk, so in a backgrounded window the rewrite lands slightly later. Both are a label nobody is looking at, and both self-correct. The original had the opposite trade — always correct, unbounded cost.

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

`tests/node/current-path/welcome_screen_rewrite.test.cjs` is new. It extracts the generated script and runs it against a minimal DOM shim (tree walker, mutation observer, animation frames, deadline timer), so it exercises the real injected source rather than a paraphrase of it.

The extractor is deliberately anchored on the function name alone and not on anything this fix introduced — an extractor keyed to a new constant cannot load the code it replaces, so every test would fail for the same uninteresting reason and none would demonstrate anything. Anchored properly, the split is the actual claim:

| | original #177 | this branch |
|---|---|---|
| rewrites the heading correctly | pass | pass |
| leaves an unrelated "Mac" alone | pass | pass |
| does not stack observers on re-injection | pass | pass |
| no observer left running after a successful rewrite | **fail** | pass |
| never subscribes to characterData | **fail** | pass |
| a burst coalesces to one walk per frame | **fail** | pass |
| disconnects once a late heading is rewritten | **fail** | pass |
| deadline disconnects on a page without the heading | **fail** | pass |
| a stale deadline cannot release a later observer | **fail** | pass |
| no body is a no-op, not a throw | **fail** | pass |
| re-injection with a live observer costs no extra walk | **fail** | pass |

**3 passed / 8 failed against the original; 11 passed here.** The three that pass either way are the output tests — which is the point: this changes cost, not correctness. The last row also fails against this PR's own first follow-up commit, which is what Copilot caught.

Full suite: `node --test tests/node/current-path/*.test.cjs` → **570 passed, 0 failed**. `tests/test-launcher-sync.sh` → 20 passed. `node --check` on the wrapper: clean.

- Distro / desktop: not applicable — no Claude Desktop install in this environment. The DOM-level behaviour is covered by the shim above; what is *not* verified here is @chefboyrdave21's original finding that this screen is served live from `assets-proxy.anthropic.com` and that the bundled `ion-dist` fallback never loads it. That was established in #177 by planting a marker string, and is worth one look on a real signed-out launch before release.

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning
- [ ] This change does touch security-sensitive code — explanation below:

The injected script only reads and writes text-node values in the renderer. It runs strictly less often and strictly less broadly than the revision it adopts. No new IPC, no new file access, no change to `filterEnv`, spawn admission, or any path predicate.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — no install available in this environment; see Testing.