### PR TITLE
fix(paths): stop the darwin spoof treating /home as an automount root — every site (adopts #179)

### DIFF
--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -252,6 +252,66 @@ def patch_platform_return_gates(filepath):
     return True
 
 
+# Stop the darwin platform spoof from leaking into a general Linux path-safety
+# check (issue #172).
+#
+# The bundle's automount-root check treats a path as an untrusted "automount
+# root" using one of two regexes, chosen by process.platform:
+#   darwin:        /^\/(net|home)(\/|$)/
+#   everything else: /^\/net(\/|$)/
+# Because this project spoofs process.platform to "darwin" so the Cowork gate
+# returns "supported", this check also sees darwin and applies the macOS
+# rule, which additionally treats anything under /home as an automount root.
+# That's correct on real macOS, where network homes are commonly automounted
+# under /home; on Linux, /home is the normal, non-automounted home hierarchy,
+# so every path under it gets refused as "a protected location" instead.
+#
+# Confirmed on 1.26832.0 to be reachable from Cowork's attach-folder
+# enumeration (every subfolder of $HOME is checked against this and, today,
+# refused) via a { refuseSubstitutedPath: <this function> } option passed to
+# the shared path resolver, and is the most likely mechanism behind #172's
+# report that MCP tool-result files under ~/.claude and local-agent-mode
+# session outputs get rejected the same way.
+#
+# The fix forces the non-darwin regex unconditionally: this compat layer only
+# ever runs on real Linux, so there is no case where the darwin branch should
+# apply here regardless of the spoof. /net stays refused either way -- this
+# doesn't weaken the check or bypass any resolver, it corrects which
+# platform's rule the existing check evaluates.
+AUTOMOUNT_DARWIN_BRANCH = re.escape('?/^\\/(net|home)(\\/|$)/:')
+AUTOMOUNT_LINUX_BRANCH = re.escape('/^\\/net(\\/|$)/')
+AUTOMOUNT_DARWIN_LEAK_RE = re.compile(
+    r'process\.platform===' + Q + r'darwin' + Q +
+    AUTOMOUNT_DARWIN_BRANCH + r'(' + AUTOMOUNT_LINUX_BRANCH + r')'
+)
+AUTOMOUNT_DARWIN_LEAK_MARKER = '/*cowork-automount-patched*/'
+
+
+def patch_automount_darwin_leak(filepath):
+    """Stop the darwin platform spoof from making the automount-root check
+    treat every path under /home as untrusted (issue #172)."""
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    if AUTOMOUNT_DARWIN_LEAK_MARKER in content:
+        print(f"  Automount-root check: already patched")
+        return True
+
+    match = AUTOMOUNT_DARWIN_LEAK_RE.search(content)
+    if not match:
+        print(f"  Automount-root check: no matching site found")
+        return True
+
+    content = content[:match.start()] + match.group(1) + content[match.end():]
+    content += AUTOMOUNT_DARWIN_LEAK_MARKER
+
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+    print(f"  Automount-root check patched: darwin branch no longer treats /home as an automount root")
+    return True
+
+
 def _warn_if_unparseable(filepath):
     """Warn loudly if the patched file is no longer valid JavaScript.
 
@@ -297,6 +357,7 @@ if __name__ == "__main__":
     patch_host_platform(target)
     patch_ipc_origin_guards(target)
     patch_platform_return_gates(target)
+    patch_automount_darwin_leak(target)
 
     # Every pass above is a regex substitution into minified JS, so a pattern
     # that matches slightly more or less than intended produces a file that is

--- a/enable-cowork.py
+++ b/enable-cowork.py
@@ -297,18 +297,23 @@ def patch_automount_darwin_leak(filepath):
         print(f"  Automount-root check: already patched")
         return True
 
-    match = AUTOMOUNT_DARWIN_LEAK_RE.search(content)
-    if not match:
+    # subn, like every other pass in this file, not search + splice. The marker
+    # is written once per FILE, so a first-match-only rewrite leaves any second
+    # occurrence in the same chunk unpatched AND marked as done -- the pass can
+    # never come back for it. Nothing guarantees the bundler emits this check
+    # once: it is a small helper, and minifiers inline small helpers per call
+    # site. Rewriting all of them costs nothing when there is only one.
+    new_content, count = AUTOMOUNT_DARWIN_LEAK_RE.subn(r'\1', content)
+    if count == 0:
         print(f"  Automount-root check: no matching site found")
         return True
 
-    content = content[:match.start()] + match.group(1) + content[match.end():]
-    content += AUTOMOUNT_DARWIN_LEAK_MARKER
+    new_content += AUTOMOUNT_DARWIN_LEAK_MARKER
 
     with open(filepath, 'w') as f:
-        f.write(content)
+        f.write(new_content)
 
-    print(f"  Automount-root check patched: darwin branch no longer treats /home as an automount root")
+    print(f"  Automount-root check patched: {count} site(s) -- darwin branch no longer treats /home as an automount root")
     return True
 
 

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -74,6 +74,7 @@ function handoff(){mB.app.invalidateCurrentActivity();mB.app.setUserActivity(qq,
 function wrapSpawn(t){return process.platform!=="darwin"?t:{cmd:rpt(),args:[t.cmd,...t.args]}}
 const res=kk.app.isPackaged?process.resourcesPath:someFallback;
 const host=kk.app.isPackaged?jn.join(process.resourcesPath,"app.asar","mcp-runtime","nodeHost.js"):jn.join(kk.app.getAppPath(),"nodeHost.js");
+function Ce(e){let t=process.platform==="darwin"?/^\/(net|home)(\/|$)/:/^\/net(\/|$)/;return[e,F(e)].filter(x=>x!==null).some(x=>t.test(S(x)))}
 EOF
 }
 
@@ -105,6 +106,7 @@ function wrapSpawn(t){return process.platform!==`darwin`?t:{cmd:rpt(),args:[t.cm
 const res=T.app.isPackaged?process.resourcesPath:someFallback;
 function c(e,t){let n=i.app.isPackaged?r.default.join(process.resourcesPath,`app.asar`):i.app.getAppPath();return r.default.join(n,`.vite`)}
 function v(){return o.default.join(process.resourcesPath,`app.asar`,`.vite`,`build`,`shell-path-worker`,`shellPathWorker.js`)}
+function Ce(e){let t=process.platform===`darwin`?/^\/(net|home)(\/|$)/:/^\/net(\/|$)/;return[e,F(e)].filter(x=>x!==null).some(x=>t.test(S(x)))}
 EOF
 }
 
@@ -133,6 +135,15 @@ assert_grep  "$CHUNK" 'if\(!\$m\(n\)&&!\(n\.senderFrame&&n\.senderFrame\.url&&n\
              "IPC guard exempts file:// (rotated validator \$m + arg n)"
 assert_grep  "$CHUNK" 'return"darwin-x64"'             "getHostPlatform throw -> darwin-x64"
 refute_grep  "$CHUNK" 'error:`Unsupported platform'    "return-style platform gate neutralized"
+# Automount-root check (#172). The bundle picks its regex off process.platform,
+# which we spoof to darwin, so it evaluates the macOS branch -- and that branch
+# additionally refuses everything under /home. Correct on macOS, where network
+# homes are automounted there; wrong on Linux, where /home is just home. The
+# patch forces the non-darwin branch. /net must STAY refused: this corrects
+# which branch an unmodified check evaluates, it does not weaken the check.
+assert_grep  "$CHUNK" 'cowork-automount-patched'       "automount marker present"
+refute_grep  "$CHUNK" 'net\|home'                      "automount: darwin branch (/home) removed"
+assert_grep  "$CHUNK" 'let t=/\^\\/net'                 "automount: /net branch survives -- still refused"
 assert_parses "$CHUNK" "chunk parses after enable-cowork.py"
 
 # Exit-code contract that install.sh apply_patches relies on to log success
@@ -447,6 +458,8 @@ refute_grep "$BTCHUNK" 'throw Error\(`Unsupported platform'          "backtick: 
 assert_grep "$BTCHUNK" 'did not pass origin validation'              "backtick: IPC guard site still present"
 assert_grep "$BTCHUNK" 'startsWith\("file://"\)'                    "backtick: IPC origin guard exempts file://"
 refute_grep "$BTCHUNK" 'error:`Unsupported platform'                 "backtick: return-style platform gate neutralized"
+refute_grep "$BTCHUNK" 'net\|home'                                   "backtick: automount darwin branch removed"
+assert_grep "$BTCHUNK" 'let t=/\^\\/net'                              "backtick: automount /net branch survives"
 assert_parses "$BTCHUNK" "backtick: chunk parses after enable-cowork.py"
 
 # The fixture above is found via the exact `ke()` entry in KNOWN_PATTERNS, so it
@@ -493,6 +506,36 @@ function hostPlat(){throw new Error("Unsupported platform: "+fmt(name(x)))}
 EOF
 python3 "$REPO_ROOT/enable-cowork.py" "$DEEPGATE" >/dev/null 2>&1
 assert_parses "$DEEPGATE" "deep nesting: fails closed, chunk still parses"
+
+# The marker is written once per FILE, so a first-match-only rewrite leaves any
+# second occurrence unpatched AND marked as done -- the pass can never come back
+# for it. Nothing guarantees the bundler emits this check once: it is a small
+# helper, and minifiers inline small helpers per call site. This fixture fails
+# against a search+splice implementation and passes against subn.
+AUTOMOUNT2="$TMP/automount_two_sites.js"
+cat > "$AUTOMOUNT2" <<'EOF'
+"use strict";
+function ke(){let t=process.platform;if(t!==`darwin`&&t!==`win32`)return{status:`unsupported`,reason:`nope`};return{status:`supported`}}
+function a(e){let t=process.platform===`darwin`?/^\/(net|home)(\/|$)/:/^\/net(\/|$)/;return t.test(e)}
+function b(e){let t=process.platform===`darwin`?/^\/(net|home)(\/|$)/:/^\/net(\/|$)/;return t.test(e)}
+EOF
+python3 "$REPO_ROOT/enable-cowork.py" "$AUTOMOUNT2" >/dev/null 2>&1
+refute_grep "$AUTOMOUNT2" 'net\|home'   "automount: every site rewritten, not just the first"
+if [ "$(grep -c 'let t=/\^\\/net' "$AUTOMOUNT2")" = "2" ]; then
+  pass "automount: both /net branches survive"
+else
+  fail "automount: expected 2 surviving /net branches, got $(grep -c 'let t=/\^\\/net' "$AUTOMOUNT2")"
+fi
+assert_parses "$AUTOMOUNT2" "automount: two-site chunk parses after patching"
+
+# Marker-guarded: a second run must not touch a file it already patched.
+_before="$(cat "$AUTOMOUNT2")"
+python3 "$REPO_ROOT/enable-cowork.py" "$AUTOMOUNT2" >/dev/null 2>&1
+if [ "$_before" = "$(cat "$AUTOMOUNT2")" ]; then
+  pass "automount: re-running is a marker-guarded no-op"
+else
+  fail "automount: re-running changed an already-patched file"
+fi
 
 # The corruption guard must actually fire, on stderr, without changing the
 # exit code — both callers read non-zero as "no platform gate here", so failing


### PR DESCRIPTION
Adopts @chefboyrdave21's #179 with its original commit and authorship intact, plus one follow-up commit correcting the rewrite and adding the fixture coverage the pass had none of.

Addresses #172. Supersedes #179.

## What does this change?

**The analysis and the patch are right, and unchanged.** The bundle picks its automount-root regex off `process.platform`:

```js
let t = process.platform === `darwin` ? /^\/(net|home)(\/|$)/ : /^\/net(\/|$)/;
```

This project spoofs `process.platform` to `"darwin"` so the Cowork gate returns `"supported"`, and that spoof reaches this check too — so it evaluates the macOS branch, which additionally refuses everything under `/home`. Correct on macOS, where network homes are commonly automounted there; wrong on Linux, where `/home` is the ordinary home hierarchy. Forcing the non-darwin branch fixes it.

**`/net` stays refused either way.** This corrects which of two existing branches an unmodified check evaluates. It adds no new path-resolution logic and bypasses no resolver — which is also why it avoids the raw-`realpath` containment gap #172 flagged in the alternative approach.

**The correction: `search` + splice → `subn`,** matching every other pass in this file. The marker is written once per *file*, so a first-match-only rewrite leaves any second occurrence in the same chunk unpatched **and** marked as done — the pass can never come back for it, and the symptom would be indistinguishable from the bug it fixes. Nothing guarantees the bundler emits this check once: it is a small helper, and minifiers inline small helpers per call site. Rewriting all of them costs nothing when there is only one.

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

`tests/test-cowork-patch.sh` had no coverage for this pass at all. Added:

- the automount site in **both** fixture chunks — the double-quote one and the backtick one that #166 exists because of — asserting the `/home` branch is gone, the `/net` branch survives, the marker lands, and the chunk still parses;
- a **two-site chunk**, which is the regression test for the correction;
- an idempotency check that a second run does not touch an already-marked file.

The split is precise about what the follow-up commit actually changes:

| | original #179 | this branch |
|---|---|---|
| marker present | pass | pass |
| darwin `/home` branch removed (double-quote) | pass | pass |
| `/net` branch survives (double-quote) | pass | pass |
| darwin `/home` branch removed (backtick) | pass | pass |
| `/net` branch survives (backtick) | pass | pass |
| re-run is a marker-guarded no-op | pass | pass |
| **every site rewritten, not just the first** | **fail** | pass |
| **both `/net` branches survive** | **fail** (got 1 of 2) | pass |

91 passed / 2 failed against the original; 93 passed here. Everything that passes either way is the original's own correct work.

Full suite: `node --test tests/node/current-path/*.test.cjs` → 559 passed. `test-compat-pins.sh` → 11 passed. `test-launcher-sync.sh` → 20 passed. `test-install-paths.sh 1` → 6 passed. `py_compile` on the patcher: clean.

- Distro / desktop: not applicable — no Claude Desktop install in this environment, so this is fixture-level verification. #179 carries the part I cannot reproduce here: @chefboyrdave21 extracted the real `Ce()`/`F()`/`S()` from a live 1.26832.0 `index2.chunk-u5RDL4mp.js` and ran them under both `process.platform` values, showing `/home/...` paths refused before and allowed after while `/net/fileserver/share` stayed refused throughout.

## One thing this does not settle

#172 was filed against **1.28929.0**, and the reachability evidence is from **1.26832.0** — via Cowork's attach-folder enumeration, which passes this function as `refuseSubstitutedPath` into the shared path resolver. That is the same darwin-spoof-leaking-into-a-path-check mechanism the issue describes, and the fix is version-general rather than shape-specific, so if 1.28929.0's tool-result read path goes through the same shared resolver this covers it too. But nobody has confirmed that call site on an affected build. I would land this on its own merits — it fixes a real, reachable refusal today — and keep #172 open until someone reproduces the MCP Apps symptom on 1.28929.0 and confirms it clears.

## Security impact

- [x] This change does not touch credential handling, token passthrough, or process spawning
- [ ] This change does touch security-sensitive code — explanation below:

It edits a path-safety check in the bundle, so worth being explicit: the patched check refuses strictly the same `/net` paths it refused before, and stops refusing `/home` paths that only the macOS branch ever refused. No new resolver, no bypass, no `realpath` substitution, and the follow-up commit widens the rewrite to *more* call sites of the same check rather than fewer.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [ ] `./install.sh --doctor` passes cleanly on my system — no install available in this environment; see Testing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wCMAXzAedw1kTTxXNs69F)_