### PR TITLE
fix(exec-capability): unwrap the disclaimer `--` separator (#185)

### DIFF
--- a/stubs/cowork/exec_capability_registry.js
+++ b/stubs/cowork/exec_capability_registry.js
@@ -246,8 +246,15 @@ function createExecCapabilityRegistry({
   // agrees with resolve() for every class is what keeps that true.
   function resolveDisclaimerCommand(args) {
     if (!Array.isArray(args) || args.length === 0) return null;
-    var cmd = args[0];
-    var rest = args.slice(1);
+    // Newer bundles (asar >= ~1.40609.0) invoke the wrapper as
+    // `disclaimer -- <cmd> [args...]`; older ones passed `<cmd> [args...]`.
+    // Without this, cmd is "--", realpath fails, and the caller falls through
+    // to the exit-127 disclaimer stub: #132's failure mode, new arg shape.
+    // Parsing only -- admission stays delegated to resolveClaudeCli()/resolve().
+    var argv = (args[0] === '--') ? args.slice(1) : args;
+    if (argv.length === 0) return null;
+    var cmd = argv[0];
+    var rest = argv.slice(1);
     // The asar invokes the Claude CLI through the disclaimer wrapper using
     // whatever path it chose -- a macOS-style claude.app/.../Claude path, or
     // the SDK path it installed (claude-code-vm/<ver>/claude), or a native

--- a/tests/node/current-path/exec_capability_registry.test.cjs
+++ b/tests/node/current-path/exec_capability_registry.test.cjs
@@ -251,6 +251,33 @@ describe('exec_capability_registry', () => {
         }
       });
 
+      // Regression for the asar >= ~1.40609.0 arg shape: the bundle now calls
+      // the wrapper as `disclaimer -- <cmd> [args...]`. Reading args[0] blindly
+      // made cmd "--", which realpath cannot resolve, so the unwrap returned
+      // null and the exit-127 stub ran: #132's failure mode with a new shape.
+      it('unwraps the `--` separator without widening admission', () => {
+        const reg = createExecCapabilityRegistry({
+          homedir: os.homedir(),
+          resolveClaudeBinaryPath: () => '/usr/local/bin/claude',
+        });
+
+        const result = reg.resolveDisclaimerCommand([
+          '--',
+          '/home/u/.config/Claude/claude-code/2.1.247/claude.app/Contents/MacOS/claude',
+          '-p', 'hi',
+        ]);
+        assert.ok(result, 'a separated call must unwrap, not fall through to the stub');
+        assert.strictEqual(result.cmd, '/usr/local/bin/claude');
+        assert.deepStrictEqual(result.rest, ['-p', 'hi'],
+          'the separator is consumed, not forwarded to the binary');
+
+        // Admission is still delegated: the separator changes where the command
+        // is read from, not what is allowed to run.
+        assert.strictEqual(
+          reg.resolveDisclaimerCommand(['--', '/opt/evil/hack', '--rm-rf']), null);
+        assert.strictEqual(reg.resolveDisclaimerCommand(['--']), null);
+      });
+
       it('resolves system binary commands', (t) => {
         const git = ['/usr/bin/git', '/usr/local/bin/git'].find(p => fs.existsSync(p));
         if (!git) return t.skip('no git at any SYSTEM_PATHS location');


### PR DESCRIPTION
Fixes #185.

## What does this change?

asar 1.40609.0 invokes the disclaimer wrapper as `disclaimer -- <cmd> [args...]`. `resolveDisclaimerCommand()` read the command from `args[0]`, so `cmd` was `"--"`, `realpathSafe` could not resolve it, and the unwrap returned null. The caller fell through to the exit-127 disclaimer stub instead of the resolved Claude binary, so every Cowork session died on spawn.

Skip a leading separator before reading cmd/rest. The older `<cmd> [args...]` shape keeps working.

## Type

- [x] Bug fix
- [ ] Distro / DE compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Testing

- Distro / desktop: CachyOS / KDE Plasma (Wayland), Electron v42.1.0, Node v26.7.0, app.asar 1.40609.0
- Tested with `./install.sh --doctor`: 20 passed, 1 warning (asar newer than last tested), 0 failed
- Tested a full Cowork session: yes, sending a message in an existing conversation now spawns the CLI instead of returning the "Claude Code crashed" banner. `BLOCKED (unresolvable): --` and `exited with code 127` are both gone from `startup.log`.
- `tests/node/current-path/exec_capability_registry.test.cjs`: 41 passed, 0 failed. The added case fails on master and passes with the fix.
- `tests/test-cowork-patch.sh`: 93 passed, 0 failed.

## Security impact

- [ ] This change does not touch credential handling, token passthrough, or process spawning
- [x] This change does touch security-sensitive code

It sits in the disclaimer unwrap, which decides what gets spawned. The change is positional only: it selects which element of `args` is read as the command, and does not decide whether that command may run. Admission stays delegated to `resolveClaudeCli()` and `resolve()`, so the unwrap gains no policy of its own, per the comment above the function.

A path refused before is still refused behind the separator. The added test asserts both halves: `['--', <claude path>]` resolves to our binary with the separator consumed rather than forwarded, while `['--', '/opt/evil/hack', '--rm-rf']` and a bare `['--']` still return null.

## Checklist

- [x] No API keys, tokens, `.env` files, or log output with credentials included
- [x] Commit messages follow the project style (no emoji, brief summary + explanation)
- [x] `./install.sh --doctor` passes cleanly on my system
