### PR TITLE
fix(bridge): fall back to ws when Electron has no net.WebSocket

### DIFF
--- a/patch-index.sh
+++ b/patch-index.sh
@@ -257,6 +257,53 @@ patch_index_apply_all() {
     'process\.resourcesPath,["`]app\.asar["`]' \
     's/process\.resourcesPath,["`]app\.asar["`]/require("electron").app.getAppPath()/g'
 
+  # Fix the Claude-in-Chrome / remote-control bridge transport on Electron builds
+  # that have no net.WebSocket.
+  #
+  # The bridge picks between Electron's net.WebSocket and the bundled `ws`
+  # package, behind a remote feature flag. With the flag on it takes the
+  # net.WebSocket path -- but electron.net.WebSocket does not exist in every
+  # Electron (Electron 42.1.0 exposes no WebSocket on the net module at all), and
+  # the constructor call then throws synchronously:
+  #
+  #   [bridge-ws] using net.WebSocket transport for wss://bridge.claudeusercontent.com/chrome/<uuid>
+  #   [claude-in-chrome] Failed to create WebSocket after 21ms: o.net.WebSocket is not a constructor
+  #   [claude-in-chrome] Giving up bridge reconnection after 100 attempts
+  #
+  # The visible symptom is a Chrome extension that never pairs with the desktop
+  # app, which reads as an extension or sign-in problem. It is neither: the
+  # failure is 21ms in, before any network I/O.
+  #
+  # This is a CAPABILITY TEST, not an override. Where net.WebSocket exists the
+  # condition is unchanged and the flag still decides, so builds on a newer or
+  # patched Electron behave exactly as upstream intends; only builds that would
+  # have thrown fall through to the `ws` transport the same code already uses
+  # whenever the flag is off or forceWs is set. That path is also the more
+  # capable one -- it is the only transport implementing protocol ping, and the
+  # bundle already falls back to it at runtime when the peer requires ping.
+  #
+  # Two sites, and both are needed: the factory decides which socket is built,
+  # while wantedTransport() reports which one is wanted and is re-consulted by
+  # the flag-change subscription. Patching only the factory leaves the two
+  # disagreeing, and the subscription re-applies the flag on top.
+  #
+  # Anchored on the forceWs / forceWsTransport property names, never on the flag
+  # id or the minified gate identifier: property names survive minification, and
+  # the flag id is Anthropic's to rotate. require() lazily, per the note on the
+  # unguarded resourcesPath pass -- these are CJS chunks and no minified electron
+  # binding is guaranteed to be in scope here.
+  #
+  # Both guards match the unpatched shape only, so re-runs are no-ops: the
+  # factory guard requires the condition to be immediately followed by `){`,
+  # and the wantedTransport guard requires `<ident>()` directly before the
+  # `&&!this.forceWsTransport`. After patching neither holds.
+  patch_index "Patching bridge transport to fall back to ws when net.WebSocket is absent..." \
+    '\?\.forceWs\|\|![A-Za-z0-9_$]+\(\)\)\{' \
+    's/(\?\.forceWs\|\|![A-Za-z0-9_$]+\(\))\)\{/\1||typeof require("electron").net.WebSocket!="function"){/g'
+  patch_index "Patching bridge wantedTransport() to match the net.WebSocket capability..." \
+    '[A-Za-z0-9_$]+\(\)&&!this\.forceWsTransport' \
+    's/([A-Za-z0-9_$]+\(\))&&!this\.forceWsTransport/\1\&\&typeof require("electron").net.WebSocket=="function"\&\&!this.forceWsTransport/g'
+
   # Fix preload origin validation: the mainView.js preload's h() guard checks
   # if window.location.href origin matches claude.ai/preview.claude.ai etc.
   # On Linux with file:// protocol, origin is "null" and h() returns false,

--- a/tests/test-cowork-patch.sh
+++ b/tests/test-cowork-patch.sh
@@ -75,6 +75,8 @@ function wrapSpawn(t){return process.platform!=="darwin"?t:{cmd:rpt(),args:[t.cm
 const res=kk.app.isPackaged?process.resourcesPath:someFallback;
 const host=kk.app.isPackaged?jn.join(process.resourcesPath,"app.asar","mcp-runtime","nodeHost.js"):jn.join(kk.app.getAppPath(),"nodeHost.js");
 function Ce(e){let t=process.platform==="darwin"?/^\/(net|home)(\/|$)/:/^\/net(\/|$)/;return[e,F(e)].filter(x=>x!==null).some(x=>t.test(S(x)))}
+async function mkSock(u,o){if(o?.forceWs||!fJ9()){return new WsTr(new sw.default(u))}return new NetTr(new q7.net.WebSocket(u))}
+class BridgeConn{wantedTransport(){return fJ9()&&!this.forceWsTransport?"net":"ws"}}
 EOF
 }
 
@@ -107,6 +109,8 @@ const res=T.app.isPackaged?process.resourcesPath:someFallback;
 function c(e,t){let n=i.app.isPackaged?r.default.join(process.resourcesPath,`app.asar`):i.app.getAppPath();return r.default.join(n,`.vite`)}
 function v(){return o.default.join(process.resourcesPath,`app.asar`,`.vite`,`build`,`shell-path-worker`,`shellPathWorker.js`)}
 function Ce(e){let t=process.platform===`darwin`?/^\/(net|home)(\/|$)/:/^\/net(\/|$)/;return[e,F(e)].filter(x=>x!==null).some(x=>t.test(S(x)))}
+async function mkSock(u,o){if(o?.forceWs||!fJ9()){return new WsTr(new sw.default(u))}return new NetTr(new q7.net.WebSocket(u))}
+class BridgeConn{wantedTransport(){return fJ9()&&!this.forceWsTransport?`net`:`ws`}}
 EOF
 }
 
@@ -210,10 +214,10 @@ if [[ ! -f "$SHARED" ]]; then
 else
   pass "patch-index.sh exists at repo root"
   NPASSES="$(grep -c '^  patch_index "' "$SHARED" || true)"
-  if [[ "${NPASSES:-0}" -lt 9 ]]; then
-    fail "patch-index.sh defines all 9 passes (found $NPASSES)"
+  if [[ "${NPASSES:-0}" -lt 11 ]]; then
+    fail "patch-index.sh defines all 11 passes (found $NPASSES)"
   else
-    pass "patch-index.sh defines all 9 passes ($NPASSES)"
+    pass "patch-index.sh defines all 11 passes ($NPASSES)"
   fi
 
   LBUILD="$TMP/shared_build"
@@ -229,6 +233,16 @@ else
   assert_grep "$LCHUNK" '\(mB\.app\.setUserActivity\|\|function\(\)\{\}\)\)\(qq,'          "Handoff setUserActivity no-op fallback"
   refute_grep "$LCHUNK" 'kk\.app\.isPackaged\?process\.resourcesPath:' "resourcesPath fallback forced"
   assert_grep "$LCHUNK" 'kk\.app\.isPackaged\?jn\.join\(kk\.app\.getAppPath\(\),"mcp-runtime"' "MCP node-host uses getAppPath()"
+  # Bridge transport: the net.WebSocket path throws on any Electron without that
+  # constructor, and the guard is a capability test rather than an override --
+  # where it exists the flag still decides. Both sites must agree, or the
+  # flag-change subscription re-applies the flag over the factory's choice.
+  assert_grep "$LCHUNK" '\?\.forceWs\|\|!fJ9\(\)\|\|typeof require\("electron"\)\.net\.WebSocket!="function"\)\{' \
+              "bridge factory falls back to ws when net.WebSocket is absent"
+  assert_grep "$LCHUNK" 'fJ9\(\)&&typeof require\("electron"\)\.net\.WebSocket=="function"&&!this\.forceWsTransport' \
+              "bridge wantedTransport() gated on the same capability"
+  refute_grep "$LCHUNK" '\?\.forceWs\|\|!fJ9\(\)\)\{'          "bridge factory: unguarded net.WebSocket shape gone"
+  refute_grep "$LCHUNK" 'fJ9\(\)&&!this\.forceWsTransport'        "bridge wantedTransport: ungated shape gone"
   # The disclaimer wrap site must survive patching untouched. Neutralising it to
   # the asar's non-darwin (identity) branch is a tempting simplification -- it
   # removes the wrap/unwrap round-trip -- but that wrap is the only chokepoint
@@ -581,6 +595,10 @@ if [[ -f "$SHARED" ]]; then
   assert_grep "$BTL" 'shell-path-worker'                  "backtick: shellPathWorker site still resolves a path"
   assert_grep "$BTL" 'function wrapSpawn\(t\)\{return process\.platform!==`darwin`\?t:\{cmd:rpt\(\)' \
               "backtick: disclaimer wrap site left intact (#132)"
+  assert_grep "$BTL" '\?\.forceWs\|\|!fJ9\(\)\|\|typeof require\("electron"\)\.net\.WebSocket!="function"\)\{' \
+              "backtick: bridge factory falls back to ws when net.WebSocket is absent"
+  assert_grep "$BTL" 'fJ9\(\)&&typeof require\("electron"\)\.net\.WebSocket=="function"&&!this\.forceWsTransport' \
+              "backtick: bridge wantedTransport() gated on the same capability"
   assert_parses "$BTL" "backtick: chunk parses after the shared passes"
 fi
 


### PR DESCRIPTION
## Problem

The Claude-in-Chrome / remote-control bridge never connects on this port. The
Chrome extension is installed and Chrome is running, but the desktop app and the
extension never pair. In `startup.log`:

```
[bridge-ws] using net.WebSocket transport for wss://bridge.claudeusercontent.com/chrome/<uuid>
[claude-in-chrome] Failed to create WebSocket after 21ms: o.net.WebSocket is not a constructor
    at vJt (.../index.chunk-s0W1vGz6.js:729:74171)
    at Object.createWebSocket (.../index.chunk-s0W1vGz6.js:748:3950)
[claude-in-chrome] Bridge reconnecting in 30000ms (attempt 100)
[claude-in-chrome] Giving up bridge reconnection after 100 attempts
```

The bundle chooses between two transports behind a remote feature flag:

```js
async function yJt(e,t){
  if (t?.forceWs || !fJt()) { … return new _Jt(new ws(e, …)) }   // bundled `ws`
  return new gJt(vJt(e, t?.headers));                            // electron net.WebSocket
}
```

The flag is on, so it takes `net.WebSocket` — **which does not exist in the
Electron this port runs against.** Electron 42.1.0 exposes no `WebSocket` on the
`net` module at all (its `electron.d.ts` has a single, unrelated mention). The
constructor call throws synchronously, 21 ms in, before any network I/O.

**This misdiagnoses easily.** With the extension installed and the app signed in,
the in-app assistant reports it as "the extension isn't signed in / its session
with the Claude backend has lapsed" and sends you to re-authenticate in the side
panel. That can never fix it — there is no auth and no network involved in the
failure.

## Fix

A **capability test, not an override** — this is the part that matters for other
distros and other Electron builds:

- Where `net.WebSocket` **exists**, the condition is unchanged and the feature
  flag still decides. Behaviour is byte-identical to today for everyone whose
  Electron has the constructor, including any future Electron that adds it.
- Only builds that *would have thrown* fall through to the `ws` transport — the
  same path this code already takes whenever the flag is off or `forceWs` is set.
  It is not a new or untested code path.

`ws` is also the more capable transport: it is the only one implementing protocol
ping (`supportsProtocolPing: true`, vs the net transport whose `ping()` throws),
and the bundle already falls back to it at runtime when the peer requires ping.

Both decision sites are patched, and both are needed — the factory builds the
socket, while `wantedTransport()` reports which one is *wanted* and is
re-consulted by the `BF(flagId, …)` flag-change subscription. Patching only the
factory leaves the two disagreeing, with the subscription re-applying the flag.

Anchored on the `forceWs` / `forceWsTransport` property names, never the flag id
(`1284392461`) or the minified gate identifier — property names survive
minification, and the flag id is Anthropic's to rotate. `require()` is lazy, per
the existing note on the unguarded `resourcesPath` pass. Both guards match the
unpatched shape only, so re-runs are no-ops.

Added to `patch_index_apply_all` and nowhere else, per the ADDING A PASS contract,
so `launch.sh`, `PKGBUILD`/AUR and `install.sh` all pick it up.

## Verification

Against the **real** 1.30096.5 chunk, not only the fixture:

- Both sites rewrite correctly; `PATCH_INDEX_STRICT_SYNTAX=1` passes.
- Re-running `patch_index_apply_all` leaves the chunk byte-identical (idempotent).
- Patch present in the repacked `app.asar`, extracted back out and `node --check`ed.
- Runtime, current run of `startup.log` after relaunch:

```
[claude-in-chrome] WebSocket connected, sending connect message
[claude-in-chrome] Bridge received: {"type":"paired"}
[claude-in-chrome] Paired with Chrome extension (duration: 1194ms)
[claude-in-chrome] ensureConnected called, connected=true, authenticated=true, wsState=1
[claude-in-chrome] Tool call completed: tabs_context_mcp (f8eaad39) in 769ms
```

`using net.WebSocket transport`, `not a constructor` and `Giving up bridge
reconnection` are all **absent** from that run. End-to-end exercised through the
real browser: navigation, DOM/JS access, console reading and network capture.

`tests/test-cowork-patch.sh`: **99 passed, 0 failed** (6 new assertions — both
sites, on both the double-quoted and backtick fixtures, plus refutations of the
unpatched shapes). The pass-count guard is bumped 9 → 11.

## Environment

| | |
|:--|:--|
| Distro | Ubuntu 24.04.4 LTS, kernel 7.0.0-30-generic x86_64 |
| Electron | **42.1.0** (npm, `~/.local/lib/node_modules/electron`) — the affected variable |
| Claude Desktop asar | 1.30096.5 |
| Node (system) | v18.19.1 (`/usr/bin/node`) |
| Node (nvm, used for install.sh) | v24.11.1 — nvm also has v18.10.0, v20.12.2, v20.15.0 |
| npm | 11.6.2 |
| Google Chrome | 152.0.7977.64, extension `fcoeoabgfenejglbffodgkkbkcdhcgfn` v1.0.90 |
| Install | `install.sh` → `~/.local/share/claude-desktop` |

`install.sh` needs Node ≥ 22 on PATH (nvm v24 here): `asar.mjs` uses
`import … with { type: "json" }`, which the system v18.19.1 rejects.

## Distro / packaging impact

- **No behaviour change** on any Electron that has `net.WebSocket` — the flag
  still decides there.
- **No new dependency**: `ws` is already bundled and already used by this code.
- **AUR/`PKGBUILD`**: picked up automatically via the shared pass list; runs under
  `PATCH_INDEX_STRICT_SYNTAX=1`, which passed on the real chunk.
- **Older/newer asars**: grep-guarded like every other pass, so a build without
  these shapes is a clean no-op (it will emit the usual WARN-on-miss under
  `PKGBUILD`, and is silenced in the launchers as with the other passes).
- Electron 42.1.0 is what this port installs today, so the affected path is the
  default for anyone following the README, not an exotic setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
